### PR TITLE
不要になったdependabotの設定を削除

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "weekly"


### PR DESCRIPTION
Dependabotの代わりにrenovateを導入したので、dependabotの設定ファイルは不要になった