### PR TITLE
PrismaClientのimportを@/app/_lib/prisma経由に強制する

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,25 @@
 {
-  "extends": ["next/core-web-vitals", "plugin:prettier/recommended"]
+  "extends": ["next/core-web-vitals", "plugin:prettier/recommended"],
+  "rules": {
+    "no-restricted-imports": [
+      "error",
+      {
+        "paths": [
+          {
+            "name": "@prisma/client",
+            "importNames": ["PrismaClient"],
+            "message": "Please import PrismaClient from ./app/_lib/prisma.ts instead."
+          }
+        ]
+      }
+    ]
+  },
+  "overrides": [
+    {
+      "files": ["./app/_lib/prisma.ts"],
+      "rules": {
+        "no-restricted-imports": "off"
+      }
+    }
+  ]
 }

--- a/app/(main)/calendar/_lib/fetchTask.ts
+++ b/app/(main)/calendar/_lib/fetchTask.ts
@@ -1,6 +1,6 @@
 import { getUserId } from "@/app/_lib/auth";
+import { getPrismaClient } from "@/app/_lib/prisma";
 import { Ymd } from "@/app/_model/ymd";
-import { PrismaClient } from "@prisma/client";
 import { unstable_cache } from "next/cache";
 
 function convertDateToYmd(date: Date) {
@@ -13,7 +13,7 @@ function convertDateToYmd(date: Date) {
 }
 
 async function _fetchTasks() {
-  const prisma = new PrismaClient();
+  const prisma = getPrismaClient();
   const userId = await getUserId();
 
   const tasks = await prisma.task.findMany({

--- a/app/(main)/list/_lib/fetchTask.ts
+++ b/app/(main)/list/_lib/fetchTask.ts
@@ -1,6 +1,6 @@
 import { getUserId } from "@/app/_lib/auth";
+import { getPrismaClient } from "@/app/_lib/prisma";
 import { Ymd } from "@/app/_model/ymd";
-import { PrismaClient } from "@prisma/client";
 import { unstable_cache } from "next/cache";
 
 function convertDateToYmd(date: Date) {
@@ -17,7 +17,7 @@ async function _fetchTasks({
 }: {
   includeCompleted?: boolean;
 }) {
-  const prisma = new PrismaClient();
+  const prisma = getPrismaClient();
   const userId = await getUserId();
 
   const tasks = await prisma.task.findMany({


### PR DESCRIPTION
参考

- [eslint (no-restricted-imports) で特定のimportを特定のディレクトリから禁止する](https://zenn.dev/suzukenz/articles/d5321f31134e2b)