### PR TITLE
テストでサインイン後のページ遷移を待機する

### DIFF
--- a/tests/auth.setup.ts
+++ b/tests/auth.setup.ts
@@ -29,6 +29,8 @@ setup("authenticate", async ({ page }) => {
   await page.getByRole("button", { name: "Next" }).click();
   await page.getByRole("button", { name: "Continue" }).click();
 
+  await page.waitForURL("http://localhost:3000/list");
+
   await expect(page.getByText("Hiroki")).toBeVisible();
 
   await page.context().storageState({ path: authFile });


### PR DESCRIPTION
`await expect(page.getByText("Hiroki")).toBeVisible();` だけだと、サインイン時のGoogle認証の画面でもexpectが成功してしまっていた