### PR TITLE
feat: tseslint の型チェック付きルールセットに変更

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,7 +7,15 @@ import globals from "globals";
 export default tseslint.config(
   { ignores: ["**/dist"] },
   js.configs.recommended,
-  ...tseslint.configs.recommended,
+  ...tseslint.configs.recommendedTypeChecked,
+  {
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
   {
     files: ["apps/web/**/*.{ts,tsx}"],
     plugins: {
@@ -27,5 +35,9 @@ export default tseslint.config(
     languageOptions: {
       globals: globals.node,
     },
+  },
+  {
+    files: ["**/*.js"],
+    ...tseslint.configs.disableTypeChecked,
   },
 );


### PR DESCRIPTION
## Summary
- ESLint の tseslint 設定を `recommended` から `recommendedTypeChecked` に変更し、型情報を使ったルールを有効化
- `projectService: true` と `tsconfigRootDir` を設定して型チェックに必要なパーサーオプションを追加
- JS ファイル（`eslint.config.js` など）には `disableTypeChecked` を適用し、型チェックルールの誤検知を防止

## Test plan
- [x] `npm run lint` がエラーなく通ることを確認
- [x] `prettier --check` でフォーマットが崩れていないことを確認
- [ ] CI が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)