### PR TITLE
feat: タスク操作 UI を実装

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "@tascal/web",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
         "@tanstack/react-router": "^1.167.3",
         "better-auth": "^1.5.5",
         "react": "^19.1.0",
@@ -512,6 +513,45 @@
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.1.21.tgz",
       "integrity": "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.12",
@@ -4733,7 +4773,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tsx": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,7 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
     "@tanstack/react-router": "^1.167.3",
     "better-auth": "^1.5.5",
     "react": "^19.1.0",

--- a/apps/web/src/api/tasks.ts
+++ b/apps/web/src/api/tasks.ts
@@ -11,3 +11,49 @@ export async function fetchTasks(
   }
   return res.json() as Promise<Task[]>;
 }
+
+export async function createTask(data: {
+  title: string;
+  description?: string | null;
+  date: string;
+  status?: "todo" | "done";
+}): Promise<Task> {
+  const res = await fetch("/api/tasks", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) {
+    throw new Error("タスクの作成に失敗しました");
+  }
+  return res.json() as Promise<Task>;
+}
+
+export async function updateTask(
+  id: string,
+  data: {
+    title?: string;
+    description?: string | null;
+    date?: string;
+    status?: "todo" | "done";
+  },
+): Promise<Task> {
+  const res = await fetch(`/api/tasks/${id}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) {
+    throw new Error("タスクの更新に失敗しました");
+  }
+  return res.json() as Promise<Task>;
+}
+
+export async function deleteTask(id: string): Promise<void> {
+  const res = await fetch(`/api/tasks/${id}`, {
+    method: "DELETE",
+  });
+  if (!res.ok) {
+    throw new Error("タスクの削除に失敗しました");
+  }
+}

--- a/apps/web/src/components/Calendar.tsx
+++ b/apps/web/src/components/Calendar.tsx
@@ -1,8 +1,11 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { DndContext, type DragEndEvent } from "@dnd-kit/core";
 import type { Task } from "../types/task";
-import { fetchTasks } from "../api/tasks";
+import { fetchTasks, updateTask } from "../api/tasks";
 import { getCalendarDays, formatDateKey } from "../utils/calendar";
 import { CalendarDayCell } from "./CalendarDayCell";
+import { TaskFormModal } from "./TaskFormModal";
+import { TaskDetailModal } from "./TaskDetailModal";
 
 const WEEKDAY_LABELS = ["日", "月", "火", "水", "木", "金", "土"];
 
@@ -13,6 +16,15 @@ export function Calendar() {
   const [tasks, setTasks] = useState<Task[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  // モーダル状態
+  const [addDate, setAddDate] = useState<string | null>(null);
+  const [selectedTask, setSelectedTask] = useState<Task | null>(null);
+
+  const refreshTasks = useCallback(() => {
+    setRefreshKey((k) => k + 1);
+  }, []);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -35,7 +47,7 @@ export function Calendar() {
       });
 
     return () => controller.abort();
-  }, [year, month]);
+  }, [year, month, refreshKey]);
 
   const days = useMemo(() => getCalendarDays(year, month), [year, month]);
 
@@ -72,6 +84,28 @@ export function Calendar() {
     const today = new Date();
     setYear(today.getFullYear());
     setMonth(today.getMonth() + 1);
+  };
+
+  const handleToggleStatus = (task: Task) => {
+    const newStatus = task.status === "done" ? "todo" : "done";
+    void updateTask(task.id, { status: newStatus })
+      .then(() => refreshTasks())
+      .catch(() => setError("ステータスの更新に失敗しました"));
+  };
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over) return;
+
+    const task = active.data.current?.task as Task | undefined;
+    if (!task) return;
+
+    const newDate = over.id as string;
+    if (task.date === newDate) return;
+
+    void updateTask(task.id, { date: newDate })
+      .then(() => refreshTasks())
+      .catch(() => setError("タスクの移動に失敗しました"));
   };
 
   return (
@@ -111,40 +145,67 @@ export function Calendar() {
         </div>
       )}
 
-      <div
-        className={`overflow-hidden rounded-lg border border-gray-200 ${loading ? "opacity-50" : ""}`}
-      >
-        <div className="grid grid-cols-7">
-          {WEEKDAY_LABELS.map((label, i) => (
-            <div
-              key={label}
-              className={`border-b border-gray-200 py-2 text-center text-sm font-medium ${
-                i === 0
-                  ? "text-red-500"
-                  : i === 6
-                    ? "text-blue-500"
-                    : "text-gray-600"
-              }`}
-            >
-              {label}
-            </div>
-          ))}
-        </div>
+      <DndContext onDragEnd={handleDragEnd}>
+        <div
+          className={`overflow-hidden rounded-lg border border-gray-200 ${loading ? "opacity-50" : ""}`}
+        >
+          <div className="grid grid-cols-7">
+            {WEEKDAY_LABELS.map((label, i) => (
+              <div
+                key={label}
+                className={`border-b border-gray-200 py-2 text-center text-sm font-medium ${
+                  i === 0
+                    ? "text-red-500"
+                    : i === 6
+                      ? "text-blue-500"
+                      : "text-gray-600"
+                }`}
+              >
+                {label}
+              </div>
+            ))}
+          </div>
 
-        <div className="grid grid-cols-7">
-          {days.map((day) => {
-            const key = formatDateKey(day.date);
-            return (
-              <CalendarDayCell
-                key={key}
-                date={day.date}
-                isCurrentMonth={day.isCurrentMonth}
-                tasks={tasksByDate.get(key) ?? []}
-              />
-            );
-          })}
+          <div className="grid grid-cols-7">
+            {days.map((day) => {
+              const key = formatDateKey(day.date);
+              return (
+                <CalendarDayCell
+                  key={key}
+                  date={day.date}
+                  isCurrentMonth={day.isCurrentMonth}
+                  tasks={tasksByDate.get(key) ?? []}
+                  onAddClick={setAddDate}
+                  onTaskClick={setSelectedTask}
+                  onToggleStatus={handleToggleStatus}
+                />
+              );
+            })}
+          </div>
         </div>
-      </div>
+      </DndContext>
+
+      {addDate && (
+        <TaskFormModal
+          date={addDate}
+          onClose={() => setAddDate(null)}
+          onCreated={() => {
+            setAddDate(null);
+            refreshTasks();
+          }}
+        />
+      )}
+
+      {selectedTask && (
+        <TaskDetailModal
+          task={selectedTask}
+          onClose={() => setSelectedTask(null)}
+          onUpdated={() => {
+            setSelectedTask(null);
+            refreshTasks();
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/CalendarDayCell.tsx
+++ b/apps/web/src/components/CalendarDayCell.tsx
@@ -1,5 +1,7 @@
+import { useDroppable } from "@dnd-kit/core";
 import type { Task } from "../types/task";
-import { isToday } from "../utils/calendar";
+import { isToday, formatDateKey } from "../utils/calendar";
+import { DraggableTask } from "./DraggableTask";
 
 const MAX_VISIBLE_TASKS = 3;
 
@@ -7,22 +9,32 @@ type CalendarDayCellProps = {
   date: Date;
   isCurrentMonth: boolean;
   tasks: Task[];
+  onAddClick: (dateKey: string) => void;
+  onTaskClick: (task: Task) => void;
+  onToggleStatus: (task: Task) => void;
 };
 
 export function CalendarDayCell({
   date,
   isCurrentMonth,
   tasks,
+  onAddClick,
+  onTaskClick,
+  onToggleStatus,
 }: CalendarDayCellProps) {
   const today = isToday(date);
+  const dateKey = formatDateKey(date);
   const visibleTasks = tasks.slice(0, MAX_VISIBLE_TASKS);
   const remainingCount = tasks.length - MAX_VISIBLE_TASKS;
 
+  const { setNodeRef, isOver } = useDroppable({ id: dateKey });
+
   return (
     <div
-      className={`min-h-24 border border-gray-200 p-1 ${
+      ref={setNodeRef}
+      className={`group relative min-h-24 border border-gray-200 p-1 ${
         !isCurrentMonth ? "bg-gray-50" : "bg-white"
-      }`}
+      } ${isOver ? "bg-blue-50" : ""}`}
     >
       <div className="mb-1 flex items-center justify-center">
         <span
@@ -37,18 +49,22 @@ export function CalendarDayCell({
           {date.getDate()}
         </span>
       </div>
+      <button
+        type="button"
+        onClick={() => onAddClick(dateKey)}
+        className="absolute right-1 top-1 hidden h-5 w-5 items-center justify-center rounded text-gray-400 hover:bg-gray-200 hover:text-gray-600 focus:flex group-hover:flex group-focus-within:flex"
+        aria-label={`${dateKey}にタスクを追加`}
+      >
+        +
+      </button>
       <div className="space-y-0.5">
         {visibleTasks.map((task) => (
-          <div
+          <DraggableTask
             key={task.id}
-            className={`truncate rounded px-1 text-xs ${
-              task.status === "done"
-                ? "text-gray-400 line-through"
-                : "bg-blue-100 text-blue-800"
-            }`}
-          >
-            {task.title}
-          </div>
+            task={task}
+            onTaskClick={onTaskClick}
+            onToggleStatus={onToggleStatus}
+          />
         ))}
         {remainingCount > 0 && (
           <div className="px-1 text-xs text-gray-500">+{remainingCount} 件</div>

--- a/apps/web/src/components/DraggableTask.tsx
+++ b/apps/web/src/components/DraggableTask.tsx
@@ -1,0 +1,52 @@
+import { useDraggable } from "@dnd-kit/core";
+import type { Task } from "../types/task";
+
+type DraggableTaskProps = {
+  task: Task;
+  onTaskClick: (task: Task) => void;
+  onToggleStatus: (task: Task) => void;
+};
+
+export function DraggableTask({
+  task,
+  onTaskClick,
+  onToggleStatus,
+}: DraggableTaskProps) {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: task.id,
+    data: { task },
+  });
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={`flex items-center gap-1 rounded px-1 text-xs ${
+        task.status === "done"
+          ? "text-gray-400 line-through"
+          : "bg-blue-100 text-blue-800"
+      } ${isDragging ? "opacity-50" : ""}`}
+    >
+      <input
+        type="checkbox"
+        checked={task.status === "done"}
+        onChange={() => onToggleStatus(task)}
+        onClick={(e) => e.stopPropagation()}
+        className="h-3 w-3 shrink-0 cursor-pointer"
+      />
+      <span
+        className="cursor-pointer truncate"
+        onClick={() => onTaskClick(task)}
+      >
+        {task.title}
+      </span>
+      <span
+        className="ml-auto shrink-0 cursor-grab touch-none text-gray-400"
+        {...listeners}
+        {...attributes}
+        aria-label="ドラッグして移動"
+      >
+        ⠿
+      </span>
+    </div>
+  );
+}

--- a/apps/web/src/components/TaskDetailModal.tsx
+++ b/apps/web/src/components/TaskDetailModal.tsx
@@ -1,0 +1,151 @@
+import { useState } from "react";
+import type { Task } from "../types/task";
+import { updateTask, deleteTask } from "../api/tasks";
+
+type TaskDetailModalProps = {
+  task: Task;
+  onClose: () => void;
+  onUpdated: () => void;
+};
+
+export function TaskDetailModal({
+  task,
+  onClose,
+  onUpdated,
+}: TaskDetailModalProps) {
+  const [title, setTitle] = useState(task.title);
+  const [description, setDescription] = useState(task.description ?? "");
+  const [date, setDate] = useState(task.date);
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSave = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!title.trim()) return;
+
+    setSaving(true);
+    setError(null);
+    try {
+      await updateTask(task.id, {
+        title: title.trim(),
+        description: description.trim() || null,
+        date,
+      });
+      onUpdated();
+    } catch {
+      setError("タスクの更新に失敗しました");
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!window.confirm("このタスクを削除しますか？")) return;
+
+    setDeleting(true);
+    setError(null);
+    try {
+      await deleteTask(task.id);
+      onUpdated();
+    } catch {
+      setError("タスクの削除に失敗しました");
+      setDeleting(false);
+    }
+  };
+
+  const busy = saving || deleting;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-md rounded-lg bg-white p-6 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3 className="mb-4 text-lg font-bold text-gray-900">タスクの詳細</h3>
+        {error && (
+          <div className="mb-3 rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">
+            {error}
+          </div>
+        )}
+        <form onSubmit={(e) => void handleSave(e)} className="space-y-4">
+          <div>
+            <label
+              htmlFor="detail-title"
+              className="mb-1 block text-sm font-medium text-gray-700"
+            >
+              タイトル <span className="text-red-500">*</span>
+            </label>
+            <input
+              id="detail-title"
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              required
+            />
+          </div>
+          <div>
+            <label
+              htmlFor="detail-description"
+              className="mb-1 block text-sm font-medium text-gray-700"
+            >
+              説明
+            </label>
+            <textarea
+              id="detail-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              rows={3}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            />
+          </div>
+          <div>
+            <label
+              htmlFor="detail-date"
+              className="mb-1 block text-sm font-medium text-gray-700"
+            >
+              日付
+            </label>
+            <input
+              id="detail-date"
+              type="date"
+              value={date}
+              onChange={(e) => setDate(e.target.value)}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              required
+            />
+          </div>
+          <div className="flex justify-between">
+            <button
+              type="button"
+              onClick={() => void handleDelete()}
+              disabled={busy}
+              className="rounded-md bg-red-600 px-4 py-2 text-sm text-white hover:bg-red-700 disabled:opacity-50"
+            >
+              {deleting ? "削除中..." : "削除"}
+            </button>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={onClose}
+                className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm text-gray-700 hover:bg-gray-50"
+              >
+                キャンセル
+              </button>
+              <button
+                type="submit"
+                disabled={busy || !title.trim()}
+                className="rounded-md bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
+              >
+                {saving ? "保存中..." : "保存"}
+              </button>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/TaskFormModal.tsx
+++ b/apps/web/src/components/TaskFormModal.tsx
@@ -1,0 +1,109 @@
+import { useState } from "react";
+import { createTask } from "../api/tasks";
+
+type TaskFormModalProps = {
+  date: string;
+  onClose: () => void;
+  onCreated: () => void;
+};
+
+export function TaskFormModal({
+  date,
+  onClose,
+  onCreated,
+}: TaskFormModalProps) {
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!title.trim()) return;
+
+    setSaving(true);
+    setError(null);
+    try {
+      await createTask({
+        title: title.trim(),
+        description: description.trim() || null,
+        date,
+      });
+      onCreated();
+    } catch {
+      setError("タスクの作成に失敗しました");
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-md rounded-lg bg-white p-6 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3 className="mb-4 text-lg font-bold text-gray-900">
+          タスクを追加（{date}）
+        </h3>
+        {error && (
+          <div className="mb-3 rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">
+            {error}
+          </div>
+        )}
+        <form onSubmit={(e) => void handleSubmit(e)} className="space-y-4">
+          <div>
+            <label
+              htmlFor="task-title"
+              className="mb-1 block text-sm font-medium text-gray-700"
+            >
+              タイトル <span className="text-red-500">*</span>
+            </label>
+            <input
+              id="task-title"
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              autoFocus
+              required
+            />
+          </div>
+          <div>
+            <label
+              htmlFor="task-description"
+              className="mb-1 block text-sm font-medium text-gray-700"
+            >
+              説明
+            </label>
+            <textarea
+              id="task-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              rows={3}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            />
+          </div>
+          <div className="flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm text-gray-700 hover:bg-gray-50"
+            >
+              キャンセル
+            </button>
+            <button
+              type="submit"
+              disabled={saving || !title.trim()}
+              className="rounded-md bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
+            >
+              {saving ? "保存中..." : "追加"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
close #7

## Summary
- カレンダー上の日付セルの「+」ボタンからタスクを追加できるモーダルを実装
- タスクをクリックして詳細モーダルで編集・削除が可能（削除は確認ダイアログ付き）
- チェックボックスでタスクの完了/未完了を切り替え可能
- `@dnd-kit/core` を使ったドラッグ&ドロップでタスクを別の日付に移動可能
- API クライアントに `createTask` / `updateTask` / `deleteTask` を追加

## 変更ファイル
- `apps/web/package.json` — `@dnd-kit/core` 依存追加
- `apps/web/src/api/tasks.ts` — CRUD API クライアント関数追加
- `apps/web/src/components/Calendar.tsx` — DndContext、モーダル状態管理、エラーハンドリング
- `apps/web/src/components/CalendarDayCell.tsx` — 「+」ボタン、ドロップターゲット対応
- `apps/web/src/components/DraggableTask.tsx` — 新規: ドラッグ可能なタスク要素（ハンドル分離）
- `apps/web/src/components/TaskFormModal.tsx` — 新規: タスク追加モーダル
- `apps/web/src/components/TaskDetailModal.tsx` — 新規: タスク詳細/編集モーダル

## Test plan
- [ ] 日付セルの「+」ボタンからタスクを追加できること
- [ ] タスククリックで詳細モーダルが開き、タイトル・説明・日付を編集して保存できること
- [ ] チェックボックスで完了/未完了を切り替えられること
- [ ] 削除ボタンで確認ダイアログ後にタスクが削除されること
- [ ] タスクをドラッグ&ドロップで別の日付に移動できること
- [ ] API エラー時にエラーメッセージが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)