### PR TITLE
fix: DATABASE_URL未設定時もローカルサーバーが起動できるように修正

### DIFF
--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -1,16 +1,29 @@
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
-import { db } from "./db/index.js";
+import { getDb } from "./db/index.js";
 import * as schema from "./db/schema.js";
 
-export const auth = betterAuth({
-  database: drizzleAdapter(db, {
-    provider: "pg",
-    schema,
-    usePlural: true,
-  }),
-  emailAndPassword: {
-    enabled: true,
-  },
-  trustedOrigins: ["http://localhost:5173"],
-});
+function createAuth() {
+  return betterAuth({
+    database: drizzleAdapter(getDb(), {
+      provider: "pg",
+      schema,
+      usePlural: true,
+    }),
+    emailAndPassword: {
+      enabled: true,
+    },
+    trustedOrigins: ["http://localhost:5173"],
+  });
+}
+
+export type Auth = ReturnType<typeof createAuth>;
+
+let _auth: Auth | null = null;
+
+export function getAuth(): Auth {
+  if (!_auth) {
+    _auth = createAuth();
+  }
+  return _auth;
+}

--- a/apps/api/src/db/index.ts
+++ b/apps/api/src/db/index.ts
@@ -1,7 +1,19 @@
 import { neon } from "@neondatabase/serverless";
-import { drizzle } from "drizzle-orm/neon-http";
+import { drizzle, type NeonHttpDatabase } from "drizzle-orm/neon-http";
 import * as schema from "./schema.js";
 
-const sql = neon(process.env.DATABASE_URL!);
+let _db: NeonHttpDatabase<typeof schema> | null = null;
 
-export const db = drizzle({ client: sql, schema });
+export function getDb(): NeonHttpDatabase<typeof schema> {
+  if (!_db) {
+    const databaseUrl = process.env.DATABASE_URL;
+    if (!databaseUrl) {
+      throw new Error(
+        "DATABASE_URL environment variable is not set. Please set it in .env or .env.local file.",
+      );
+    }
+    const sql = neon(databaseUrl);
+    _db = drizzle({ client: sql, schema });
+  }
+  return _db;
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,12 +1,13 @@
 import { serve } from "@hono/node-server";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
-import { auth } from "./auth.js";
+import { getAuth } from "./auth.js";
+import type { Auth } from "./auth.js";
 import tasksApp from "./routes/tasks.js";
 
 type AuthVariables = {
-  user: typeof auth.$Infer.Session.user | null;
-  session: typeof auth.$Infer.Session.session | null;
+  user: Auth["$Infer"]["Session"]["user"] | null;
+  session: Auth["$Infer"]["Session"]["session"] | null;
 };
 
 const app = new Hono<{ Variables: AuthVariables }>();
@@ -21,7 +22,7 @@ app.use(
 
 // セッション取得ミドルウェア
 app.use("/api/*", async (c, next) => {
-  const session = await auth.api.getSession({
+  const session = await getAuth().api.getSession({
     headers: c.req.raw.headers,
   });
 
@@ -37,7 +38,7 @@ app.use("/api/*", async (c, next) => {
 });
 
 app.on(["POST", "GET"], "/api/auth/**", (c) => {
-  return auth.handler(c.req.raw);
+  return getAuth().handler(c.req.raw);
 });
 
 app.route("/api/tasks", tasksApp);

--- a/apps/api/src/routes/__tests__/tasks.test.ts
+++ b/apps/api/src/routes/__tests__/tasks.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Hono } from "hono";
-import type { auth } from "../../auth.js";
+import type { Auth } from "../../auth.js";
 
 type AuthVariables = {
-  user: typeof auth.$Infer.Session.user | null;
-  session: typeof auth.$Infer.Session.session | null;
+  user: Auth["$Infer"]["Session"]["user"] | null;
+  session: Auth["$Infer"]["Session"]["session"] | null;
 };
 
 const mockUser = {
@@ -35,7 +35,7 @@ const mockUpdate = vi.fn();
 const mockDelete = vi.fn();
 
 vi.mock("../../db/index.js", () => ({
-  db: {
+  getDb: () => ({
     select: () => ({
       from: () => ({
         where: mockSelect,
@@ -58,7 +58,7 @@ vi.mock("../../db/index.js", () => ({
         returning: mockDelete,
       }),
     }),
-  },
+  }),
 }));
 
 vi.mock("../../db/schema.js", async () => {

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -1,13 +1,13 @@
 import { Hono } from "hono";
 import { z } from "zod";
 import { eq, and, gte, lt } from "drizzle-orm";
-import { db } from "../db/index.js";
+import { getDb } from "../db/index.js";
 import { tasks } from "../db/schema.js";
-import type { auth } from "../auth.js";
+import type { Auth } from "../auth.js";
 
 type AuthVariables = {
-  user: typeof auth.$Infer.Session.user | null;
-  session: typeof auth.$Infer.Session.session | null;
+  user: Auth["$Infer"]["Session"]["user"] | null;
+  session: Auth["$Infer"]["Session"]["session"] | null;
 };
 
 const createTaskSchema = z.object({
@@ -68,7 +68,7 @@ app.get("/", async (c) => {
   const nextYear = month === 12 ? year + 1 : year;
   const endDate = `${nextYear}-${String(nextMonth).padStart(2, "0")}-01`;
 
-  const result = await db
+  const result = await getDb()
     .select()
     .from(tasks)
     .where(
@@ -99,7 +99,7 @@ app.post("/", async (c) => {
     );
   }
 
-  const [task] = await db
+  const [task] = await getDb()
     .insert(tasks)
     .values({
       title: parsed.data.title,
@@ -136,7 +136,7 @@ app.patch("/:id", async (c) => {
     );
   }
 
-  const [updated] = await db
+  const [updated] = await getDb()
     .update(tasks)
     .set({
       ...parsed.data,
@@ -162,7 +162,7 @@ app.delete("/:id", async (c) => {
     return c.json({ error: "不正なタスクIDです" }, 400);
   }
 
-  const [deleted] = await db
+  const [deleted] = await getDb()
     .delete(tasks)
     .where(and(eq(tasks.id, id), eq(tasks.userId, user.id)))
     .returning();


### PR DESCRIPTION
## Summary
- DB接続（`getDb()`）と認証（`getAuth()`）を遅延初期化に変更し、`DATABASE_URL` が未設定でもサーバーが起動できるようにした
- モジュール読み込み時に `neon()` や `betterAuth()` が即座に実行され、環境変数未設定時にクラッシュしていた問題を修正
- Proxy パターンではなく、利用箇所を直接 `getDb()` / `getAuth()` 呼び出しに統一

## 変更ファイル
- `apps/api/src/db/index.ts` — `db` エクスポートを `getDb()` 関数に変更
- `apps/api/src/auth.ts` — `auth` エクスポートを `getAuth()` 関数に変更
- `apps/api/src/index.ts` — `getAuth()` 呼び出しに変更
- `apps/api/src/routes/tasks.ts` — `getDb()` 呼び出しに変更
- `apps/api/src/routes/__tests__/tasks.test.ts` — モック対象を `getDb` に変更

## Test plan
- [x] `npm run typecheck` パス（API / Web 両方）
- [x] `npm run lint` パス
- [x] `npm run format:check` パス
- [x] `npm test` パス（API 17件 / Web 27件）
- [x] `DATABASE_URL` 未設定でサーバー起動し `GET /` が正常応答することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)