### PR TITLE
feat: make devでDB・API・Webをまとめて起動

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,11 @@ install:
 	cd apps/web && npm install
 
 dev:
-	cd apps/api && npm run dev & cd apps/web && npm run dev & wait
+	trap 'docker compose down' EXIT; \
+	docker compose up -d db && \
+	cd apps/api && npm run dev & \
+	cd apps/web && npm run dev & \
+	wait
 
 build:
 	cd apps/api && npm run build

--- a/README.md
+++ b/README.md
@@ -1,3 +1,52 @@
 # tascal
 
 [![CI](https://github.com/hirokisakabe/tascal/actions/workflows/ci.yml/badge.svg)](https://github.com/hirokisakabe/tascal/actions/workflows/ci.yml)
+
+## ローカル開発
+
+### 前提条件
+
+- Node.js
+- Docker
+
+### セットアップ
+
+```bash
+make install
+```
+
+`.env.example` を参考に `apps/api/.env.local` を作成します。
+
+```bash
+cp .env.example apps/api/.env.local
+# 必要に応じて値を編集
+```
+
+初回のみ DB マイグレーションを実行します。
+
+```bash
+make db-up
+make db-migrate
+make db-down
+```
+
+### 開発サーバーの起動
+
+DB（PostgreSQL）・API・Web をまとめて起動します。`Ctrl+C` で全て停止します。
+
+```bash
+make dev
+```
+
+### その他のコマンド
+
+| コマンド | 説明 |
+|---|---|
+| `make db-up` | DB のみ起動（デタッチモード） |
+| `make db-down` | DB を停止 |
+| `make db-migrate` | DB マイグレーション実行 |
+| `make lint` | リンター実行 |
+| `make format` | フォーマッター実行 |
+| `make typecheck` | 型チェック |
+| `make test` | テスト実行 |
+| `make build` | ビルド |


### PR DESCRIPTION
## Summary
- `make dev` で DB（PostgreSQL）・API・Web をまとめて起動できるようにした
- `trap` により `Ctrl+C` で DB コンテナも確実に停止するようにした
- README にローカル開発の初期セットアップ手順（環境変数設定・マイグレーション）を追記

## Test plan
- [ ] `make dev` で DB・API・Web が起動することを確認
- [ ] `Ctrl+C` で全プロセスが停止し、DB コンテナも停止することを確認
- [ ] フレッシュクローンから README の手順通りにセットアップできることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)