### PR TITLE
fix: dev スクリプトで .env を自動読み込み

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@
 make install
 ```
 
-`.env.example` を参考に `apps/api/.env.local` を作成します。
+`apps/api/.env.example` を参考に `apps/api/.env` を作成します。
 
 ```bash
-cp .env.example apps/api/.env.local
+cp apps/api/.env.example apps/api/.env
 # 必要に応じて値を編集
 ```
 

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,2 +1,3 @@
 DATABASE_URL=postgresql://tascal:tascal@localhost:5432/tascal
-BETTER_AUTH_SECRET=secret
+BETTER_AUTH_SECRET=your-secret-key-here
+BETTER_AUTH_URL=http://localhost:3000

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx watch src/index.ts",
+    "dev": "tsx watch --env-file=.env src/index.ts",
     "build": "tsc",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",

--- a/apps/api/src/db/index.ts
+++ b/apps/api/src/db/index.ts
@@ -9,7 +9,7 @@ export function getDb(): NodePgDatabase<typeof schema> {
     const databaseUrl = process.env.DATABASE_URL;
     if (!databaseUrl) {
       throw new Error(
-        "DATABASE_URL environment variable is not set. Please set it in .env or .env.local file.",
+        "DATABASE_URL environment variable is not set. Please set it in apps/api/.env file.",
       );
     }
     const pool = new Pool({ connectionString: databaseUrl });


### PR DESCRIPTION
close #31

## Summary
- `tsx watch` に `--env-file=.env` オプションを追加し、`make dev` 起動時に環境変数が自動読み込みされるように修正
- README のセットアップ手順を `.env.local` から `.env` に統一
- `apps/api/.env.example` に `BETTER_AUTH_URL` を追加
- エラーメッセージを `.env` に統一

## Test plan
- [x] `make lint` パス
- [x] `make format-check` パス
- [x] `make typecheck` パス
- [x] `make test` パス（API 17件、Web 27件）
- [ ] `make dev` で API サーバーが環境変数を読み込んで正常起動することを確認
- [ ] サインアップ・ログインが 500 エラーにならないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)