### PR TITLE
style: ログイン・サインアップ画面にスタイルを適用

### DIFF
--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -31,44 +31,70 @@ function LoginPage() {
   };
 
   return (
-    <div>
-      <h1>ログイン</h1>
-      <form onSubmit={handleSubmit}>
-        <div>
-          <label htmlFor="email">メールアドレス</label>
-          <input
-            id="email"
-            type="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            required
-          />
-        </div>
-        <div>
-          <label htmlFor="password">パスワード</label>
-          <input
-            id="password"
-            type="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            required
-          />
-        </div>
-        {error && <p>{error}</p>}
-        <button type="submit">ログイン</button>
-      </form>
-      <p>
-        アカウントをお持ちでない方は
-        <a
-          href="/signup"
-          onClick={(e) => {
-            e.preventDefault();
-            void navigate({ to: "/signup" });
-          }}
-        >
-          サインアップ
-        </a>
-      </p>
+    <div className="flex min-h-screen items-center justify-center bg-gray-100 px-4">
+      <div className="w-full max-w-sm rounded-lg bg-white p-6 shadow-xl">
+        <h1 className="mb-6 text-center text-lg font-bold text-gray-900">
+          ログイン
+        </h1>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label
+              htmlFor="email"
+              className="mb-1 block text-sm font-medium text-gray-700"
+            >
+              メールアドレス
+            </label>
+            <input
+              id="email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            />
+          </div>
+          <div>
+            <label
+              htmlFor="password"
+              className="mb-1 block text-sm font-medium text-gray-700"
+            >
+              パスワード
+            </label>
+            <input
+              id="password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            />
+          </div>
+          {error && (
+            <p className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">
+              {error}
+            </p>
+          )}
+          <button
+            type="submit"
+            className="w-full rounded-md bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700"
+          >
+            ログイン
+          </button>
+        </form>
+        <p className="mt-4 text-center text-sm text-gray-600">
+          アカウントをお持ちでない方は
+          <a
+            href="/signup"
+            onClick={(e) => {
+              e.preventDefault();
+              void navigate({ to: "/signup" });
+            }}
+            className="ml-1 text-blue-600 hover:text-blue-700 hover:underline"
+          >
+            サインアップ
+          </a>
+        </p>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/routes/signup.tsx
+++ b/apps/web/src/routes/signup.tsx
@@ -33,54 +33,86 @@ function SignupPage() {
   };
 
   return (
-    <div>
-      <h1>サインアップ</h1>
-      <form onSubmit={handleSubmit}>
-        <div>
-          <label htmlFor="name">名前</label>
-          <input
-            id="name"
-            type="text"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            required
-          />
-        </div>
-        <div>
-          <label htmlFor="email">メールアドレス</label>
-          <input
-            id="email"
-            type="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            required
-          />
-        </div>
-        <div>
-          <label htmlFor="password">パスワード</label>
-          <input
-            id="password"
-            type="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            required
-          />
-        </div>
-        {error && <p>{error}</p>}
-        <button type="submit">サインアップ</button>
-      </form>
-      <p>
-        すでにアカウントをお持ちの方は
-        <a
-          href="/login"
-          onClick={(e) => {
-            e.preventDefault();
-            void navigate({ to: "/login" });
-          }}
-        >
-          ログイン
-        </a>
-      </p>
+    <div className="flex min-h-screen items-center justify-center bg-gray-100 px-4">
+      <div className="w-full max-w-sm rounded-lg bg-white p-6 shadow-xl">
+        <h1 className="mb-6 text-center text-lg font-bold text-gray-900">
+          サインアップ
+        </h1>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label
+              htmlFor="name"
+              className="mb-1 block text-sm font-medium text-gray-700"
+            >
+              名前
+            </label>
+            <input
+              id="name"
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            />
+          </div>
+          <div>
+            <label
+              htmlFor="email"
+              className="mb-1 block text-sm font-medium text-gray-700"
+            >
+              メールアドレス
+            </label>
+            <input
+              id="email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            />
+          </div>
+          <div>
+            <label
+              htmlFor="password"
+              className="mb-1 block text-sm font-medium text-gray-700"
+            >
+              パスワード
+            </label>
+            <input
+              id="password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            />
+          </div>
+          {error && (
+            <p className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">
+              {error}
+            </p>
+          )}
+          <button
+            type="submit"
+            className="w-full rounded-md bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700"
+          >
+            サインアップ
+          </button>
+        </form>
+        <p className="mt-4 text-center text-sm text-gray-600">
+          すでにアカウントをお持ちの方は
+          <a
+            href="/login"
+            onClick={(e) => {
+              e.preventDefault();
+              void navigate({ to: "/login" });
+            }}
+            className="ml-1 text-blue-600 hover:text-blue-700 hover:underline"
+          >
+            ログイン
+          </a>
+        </p>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
close #33

## Summary
- ログイン画面（`/login`）とサインアップ画面（`/signup`）に Tailwind CSS クラスを適用
- フォームを画面中央に配置し、カード型のレイアウトに変更
- 入力欄・ボタン・エラーメッセージ・リンクにスタイルを追加
- 既存のカレンダー画面やモーダルと統一感のあるデザイン（gray + blue カラースキーム、rounded-md、shadow-xl 等）

## Test plan
- [x] `make lint` パス
- [x] `make format-check` パス
- [x] `make typecheck` パス
- [ ] ログイン画面の表示確認（中央配置、入力欄・ボタンのスタイル）
- [ ] サインアップ画面の表示確認
- [ ] エラーメッセージの表示確認（赤背景のスタイル）
- [ ] 画面間のリンク遷移確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)