### PR TITLE
feat: Cloud Run デプロイ環境を構築

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+.env
+.env.local
+.git
+*.md

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,54 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+
+env:
+  PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+  REGION: asia-northeast1
+  SERVICE_NAME: tascal
+  REPOSITORY: tascal
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --quiet
+
+      - name: Build and push Docker image
+        run: |
+          IMAGE=${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.SERVICE_NAME }}:${{ github.sha }}
+          docker build -t $IMAGE .
+          docker push $IMAGE
+
+      # Cloud Run の環境変数（DATABASE_URL, BETTER_AUTH_SECRET, BETTER_AUTH_URL, TRUSTED_ORIGINS）は
+      # Google Cloud コンソールまたは gcloud CLI で事前に設定してください
+      - name: Deploy to Cloud Run
+        run: |
+          IMAGE=${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.SERVICE_NAME }}:${{ github.sha }}
+          gcloud run deploy ${{ env.SERVICE_NAME }} \
+            --image $IMAGE \
+            --region ${{ env.REGION }} \
+            --platform managed \
+            --allow-unauthenticated \
+            --memory 256Mi \
+            --cpu 1 \
+            --min-instances 0 \
+            --max-instances 2 \
+            --port 8080

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy
 
 on:
   push:
-    branches: [main]
+    branches: [feature/setup-deployment]
 
 env:
   PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy
 
 on:
   push:
-    branches: [feature/setup-deployment]
+    branches: [main]
 
 env:
   PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /app/apps/web
 COPY apps/web/package.json apps/web/package-lock.json ./
 RUN npm ci
 COPY tsconfig.json /app/tsconfig.json
+COPY apps/api/tsconfig.json /app/apps/api/tsconfig.json
 COPY apps/web/ ./
 RUN npx vite build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ FROM base AS web-build
 WORKDIR /app/apps/web
 COPY apps/web/package.json apps/web/package-lock.json ./
 RUN npm ci
+COPY tsconfig.json /app/tsconfig.json
+COPY apps/api/tsconfig.json /app/apps/api/tsconfig.json
 COPY apps/web/ ./
 RUN npm run build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ FROM base AS web-build
 WORKDIR /app/apps/web
 COPY apps/web/package.json apps/web/package-lock.json ./
 RUN npm ci
+COPY tsconfig.json /app/tsconfig.json
 COPY apps/web/ ./
 RUN npx vite build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,4 +34,4 @@ EXPOSE 8080
 ENV PORT=8080
 ENV NODE_ENV=production
 
-CMD ["node", "dist/index.js"]
+CMD ["node", "dist/src/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+FROM node:24-slim AS base
+
+# --- Web build ---
+FROM base AS web-build
+WORKDIR /app/apps/web
+COPY apps/web/package.json apps/web/package-lock.json ./
+RUN npm ci
+COPY apps/web/ ./
+RUN npm run build
+
+# --- API build ---
+FROM base AS api-build
+WORKDIR /app/apps/api
+COPY apps/api/package.json apps/api/package-lock.json ./
+COPY tsconfig.json /app/tsconfig.json
+RUN npm ci
+COPY apps/api/ ./
+RUN npm run build
+
+# --- Production ---
+FROM base AS production
+WORKDIR /app
+
+COPY apps/api/package.json apps/api/package-lock.json ./
+RUN npm ci --omit=dev
+
+COPY --from=api-build /app/apps/api/dist ./dist
+COPY --from=web-build /app/apps/web/dist ./public
+COPY --from=api-build /app/apps/api/drizzle ./drizzle
+
+EXPOSE 8080
+ENV PORT=8080
+ENV NODE_ENV=production
+
+CMD ["node", "dist/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,8 @@ FROM base AS web-build
 WORKDIR /app/apps/web
 COPY apps/web/package.json apps/web/package-lock.json ./
 RUN npm ci
-COPY tsconfig.json /app/tsconfig.json
-COPY apps/api/tsconfig.json /app/apps/api/tsconfig.json
 COPY apps/web/ ./
-RUN npm run build
+RUN npx vite build
 
 # --- API build ---
 FROM base AS api-build

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,3 +1,4 @@
 DATABASE_URL=postgresql://tascal:tascal@localhost:5432/tascal
 BETTER_AUTH_SECRET=your-secret-key-here
 BETTER_AUTH_URL=http://localhost:3000
+CORS_ORIGIN=http://localhost:5173

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "tsx watch --env-file=.env src/index.ts",
     "build": "tsc",
+    "start": "node dist/index.js",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",
     "format": "prettier --write .",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "tsx watch --env-file=.env src/index.ts",
     "build": "tsc",
-    "start": "node dist/index.js",
+    "start": "node dist/src/index.js",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",
     "format": "prettier --write .",

--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -13,7 +13,11 @@ function createAuth() {
     emailAndPassword: {
       enabled: true,
     },
-    trustedOrigins: ["http://localhost:5173"],
+    trustedOrigins: process.env.TRUSTED_ORIGINS
+      ? process.env.TRUSTED_ORIGINS.split(",")
+          .map((s) => s.trim())
+          .filter(Boolean)
+      : ["http://localhost:5173"],
   });
 }
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,4 +1,5 @@
 import { serve } from "@hono/node-server";
+import { serveStatic } from "@hono/node-server/serve-static";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { getAuth } from "./auth.js";
@@ -12,13 +13,16 @@ type AuthVariables = {
 
 const app = new Hono<{ Variables: AuthVariables }>();
 
-app.use(
-  "/api/*",
-  cors({
-    origin: "http://localhost:5173",
-    credentials: true,
-  }),
-);
+const corsOrigin = process.env.CORS_ORIGIN;
+if (corsOrigin) {
+  app.use(
+    "/api/*",
+    cors({
+      origin: corsOrigin,
+      credentials: true,
+    }),
+  );
+}
 
 // セッション取得ミドルウェア
 app.use("/api/*", async (c, next) => {
@@ -43,10 +47,19 @@ app.on(["POST", "GET"], "/api/auth/**", (c) => {
 
 app.route("/api/tasks", tasksApp);
 
-app.get("/", (c) => {
-  return c.json({ message: "tascal API" });
+// SPA 静的ファイル配信（本番用）
+app.use("*", serveStatic({ root: "./public" }));
+
+// SPA fallback: API 以外のルートで index.html を返す
+app.get("*", (c, next) => {
+  if (c.req.path.startsWith("/api/")) {
+    return next();
+  }
+  return serveStatic({ root: "./public", path: "index.html" })(c, next);
 });
 
-serve({ fetch: app.fetch, port: 3000 }, (info) => {
+const port = Number(process.env.PORT) || 3000;
+
+serve({ fetch: app.fetch, port }, (info) => {
   console.log(`Server is running on http://localhost:${info.port}`);
 });

--- a/apps/web/src/auth-client.ts
+++ b/apps/web/src/auth-client.ts
@@ -1,5 +1,3 @@
 import { createAuthClient } from "better-auth/react";
 
-export const authClient = createAuthClient({
-  baseURL: "http://localhost:3000",
-});
+export const authClient = createAuthClient();


### PR DESCRIPTION
close #8

## Summary
- Dockerfile（マルチステージビルド）を作成し、Web の vite build + API を1コンテナにまとめる構成を実現
- Hono に serve-static を追加し、SPA 静的ファイル配信 + クライアントサイドルーティング fallback を実装
- CORS origin、trustedOrigins、PORT、auth baseURL を環境変数で制御可能にし、本番/開発を切り替え
- GitHub Actions デプロイワークフロー（main push → Artifact Registry → Cloud Run）を作成

## 変更ファイル
| ファイル | 変更内容 |
|---------|---------|
| `Dockerfile` | マルチステージビルド（web-build → api-build → production） |
| `.dockerignore` | ビルド除外設定 |
| `.github/workflows/deploy.yml` | CD ワークフロー（Workload Identity Federation） |
| `apps/api/src/index.ts` | serve-static + SPA fallback + CORS/PORT 環境変数化 |
| `apps/api/src/auth.ts` | trustedOrigins 環境変数化 |
| `apps/api/package.json` | start スクリプト追加 |
| `apps/web/src/auth-client.ts` | baseURL 削除（同一オリジン対応） |
| `apps/api/.env.example` | CORS_ORIGIN 追加 |

## GCP 側の事前準備
以下は Cloud Run デプロイ前に手動で設定が必要です：
1. GCP プロジェクト作成
2. Artifact Registry リポジトリ作成（`asia-northeast1-docker.pkg.dev/<PROJECT_ID>/tascal`）
3. Workload Identity Federation の設定
4. GitHub Secrets の設定（`GCP_PROJECT_ID`, `GCP_WORKLOAD_IDENTITY_PROVIDER`, `GCP_SERVICE_ACCOUNT`）
5. Cloud Run 環境変数の設定（`DATABASE_URL`, `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL`, `TRUSTED_ORIGINS`）

## Test plan
- [x] `make lint` 成功
- [x] `make format-check` 成功
- [x] `make typecheck` 成功
- [x] `make test` 成功（API 17/17, Web 27/27）
- [ ] Docker ビルド成功確認（`docker build -t tascal .`）
- [ ] GCP 環境セットアップ後、本番デプロイ動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)