### PR TITLE
feat: OGP・メタタグの設定（素材不要分）

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,1 @@
+VITE_APP_URL=https://example.com

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -4,6 +4,27 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>tascal</title>
+    <meta
+      name="description"
+      content="tascal はシンプルなタスク管理アプリです。カレンダー上でタスクをドラッグ&ドロップして直感的にスケジュール管理できます。"
+    />
+    <meta name="theme-color" content="#2563eb" />
+    <!-- OGP -->
+    <meta property="og:title" content="tascal" />
+    <meta
+      property="og:description"
+      content="tascal はシンプルなタスク管理アプリです。カレンダー上でタスクをドラッグ&ドロップして直感的にスケジュール管理できます。"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="%VITE_APP_URL%" />
+    <meta property="og:site_name" content="tascal" />
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="tascal" />
+    <meta
+      name="twitter:description"
+      content="tascal はシンプルなタスク管理アプリです。カレンダー上でタスクをドラッグ&ドロップして直感的にスケジュール管理できます。"
+    />
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
close #39

## 概要

- `apps/web/index.html` に OGP メタタグ・基本メタタグを追加
- `description`、`og:title` / `og:description` / `og:type` / `og:url` / `og:site_name`、`twitter:card` / `twitter:title` / `twitter:description`、`theme-color` を設定
- `og:url` は環境ごとに URL が異なるため、Vite の環境変数 `VITE_APP_URL` で注入する形式にした
- `og:image` / `twitter:image` は素材準備後に別 issue で対応予定

## 補足

- `theme-color` は既存 UI で使用している Tailwind `blue-600`（`#2563eb`）を採用
- デプロイ環境では `VITE_APP_URL` 環境変数の設定が必要（`.env.example` 参照）

## テスト計画

- [x] `make lint` パス
- [x] `make format-check` パス
- [x] `make typecheck` パス
- [x] `make test` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)