### PR TITLE
feat: TanStack Query による楽観的UI更新を導入

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -7,6 +7,7 @@
       "name": "@tascal/web",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
+        "@tanstack/react-query": "^5.97.0",
         "@tanstack/react-router": "^1.167.3",
         "better-auth": "^1.5.5",
         "react": "^19.1.0",
@@ -2188,6 +2189,32 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.97.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.97.0.tgz",
+      "integrity": "sha512-QdpLP5VzVMgo4VtaPppRA2W04UFjIqX+bxke/ZJhE5cfd5UPkRzqIAJQt9uXkQJjqE8LBOMbKv7f8HCsZltXlg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.97.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.97.0.tgz",
+      "integrity": "sha512-y4So4eGcQoK2WVMAcDNZE9ofB/p5v1OlKvtc1F3uqHwrtifobT7q+ZnXk2mRkc8E84HKYSlAE9z6HXl2V0+ySQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.97.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@tanstack/react-router": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
+    "@tanstack/react-query": "^5.97.0",
     "@tanstack/react-router": "^1.167.3",
     "better-auth": "^1.5.5",
     "react": "^19.1.0",

--- a/apps/web/src/components/Calendar.tsx
+++ b/apps/web/src/components/Calendar.tsx
@@ -1,7 +1,7 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { DndContext, type DragEndEvent } from "@dnd-kit/core";
 import type { Task } from "../types/task";
-import { fetchTasks, updateTask } from "../api/tasks";
+import { useTasks, useUpdateTask } from "../hooks/useTasks";
 import { getCalendarDays, formatDateKey } from "../utils/calendar";
 import { CalendarDayCell } from "./CalendarDayCell";
 import { TaskFormModal } from "./TaskFormModal";
@@ -13,41 +13,20 @@ export function Calendar() {
   const now = new Date();
   const [year, setYear] = useState(now.getFullYear());
   const [month, setMonth] = useState(now.getMonth() + 1);
-  const [tasks, setTasks] = useState<Task[]>([]);
-  const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [refreshKey, setRefreshKey] = useState(0);
 
   // モーダル状態
   const [addDate, setAddDate] = useState<string | null>(null);
   const [selectedTask, setSelectedTask] = useState<Task | null>(null);
 
-  const refreshTasks = useCallback(() => {
-    setRefreshKey((k) => k + 1);
-  }, []);
+  const {
+    data: tasks = [],
+    isLoading,
+    error: queryError,
+  } = useTasks(year, month);
 
-  useEffect(() => {
-    const controller = new AbortController();
-    setLoading(true);
-    setError(null);
+  const updateTaskMutation = useUpdateTask(year, month);
 
-    fetchTasks(year, month, controller.signal)
-      .then((data) => {
-        setTasks(data);
-      })
-      .catch((e: unknown) => {
-        if (e instanceof DOMException && e.name === "AbortError") return;
-        setTasks([]);
-        setError("タスクの取得に失敗しました");
-      })
-      .finally(() => {
-        if (!controller.signal.aborted) {
-          setLoading(false);
-        }
-      });
-
-    return () => controller.abort();
-  }, [year, month, refreshKey]);
+  const [mutationError, setMutationError] = useState<string | null>(null);
 
   const days = useMemo(() => getCalendarDays(year, month), [year, month]);
 
@@ -88,9 +67,13 @@ export function Calendar() {
 
   const handleToggleStatus = (task: Task) => {
     const newStatus = task.status === "done" ? "todo" : "done";
-    void updateTask(task.id, { status: newStatus })
-      .then(() => refreshTasks())
-      .catch(() => setError("ステータスの更新に失敗しました"));
+    setMutationError(null);
+    updateTaskMutation.mutate(
+      { id: task.id, data: { status: newStatus } },
+      {
+        onError: () => setMutationError("ステータスの更新に失敗しました"),
+      },
+    );
   };
 
   const handleDragEnd = (event: DragEndEvent) => {
@@ -103,10 +86,16 @@ export function Calendar() {
     const newDate = over.id as string;
     if (task.date === newDate) return;
 
-    void updateTask(task.id, { date: newDate })
-      .then(() => refreshTasks())
-      .catch(() => setError("タスクの移動に失敗しました"));
+    setMutationError(null);
+    updateTaskMutation.mutate(
+      { id: task.id, data: { date: newDate } },
+      {
+        onError: () => setMutationError("タスクの移動に失敗しました"),
+      },
+    );
   };
+
+  const error = queryError ? "タスクの取得に失敗しました" : mutationError;
 
   return (
     <div className="mx-auto max-w-5xl">
@@ -147,7 +136,7 @@ export function Calendar() {
 
       <DndContext onDragEnd={handleDragEnd}>
         <div
-          className={`overflow-hidden rounded-lg border border-gray-200 ${loading ? "opacity-50" : ""}`}
+          className={`overflow-hidden rounded-lg border border-gray-200 ${isLoading ? "opacity-50" : ""}`}
         >
           <div className="grid grid-cols-7">
             {WEEKDAY_LABELS.map((label, i) => (
@@ -188,10 +177,11 @@ export function Calendar() {
       {addDate && (
         <TaskFormModal
           date={addDate}
+          year={year}
+          month={month}
           onClose={() => setAddDate(null)}
           onCreated={() => {
             setAddDate(null);
-            refreshTasks();
           }}
         />
       )}
@@ -199,10 +189,11 @@ export function Calendar() {
       {selectedTask && (
         <TaskDetailModal
           task={selectedTask}
+          year={year}
+          month={month}
           onClose={() => setSelectedTask(null)}
           onUpdated={() => {
             setSelectedTask(null);
-            refreshTasks();
           }}
         />
       )}

--- a/apps/web/src/components/TaskDetailModal.tsx
+++ b/apps/web/src/components/TaskDetailModal.tsx
@@ -1,59 +1,64 @@
 import { useState } from "react";
 import type { Task } from "../types/task";
-import { updateTask, deleteTask } from "../api/tasks";
+import { useUpdateTask, useDeleteTask } from "../hooks/useTasks";
 
 type TaskDetailModalProps = {
   task: Task;
+  year: number;
+  month: number;
   onClose: () => void;
   onUpdated: () => void;
 };
 
 export function TaskDetailModal({
   task,
+  year,
+  month,
   onClose,
   onUpdated,
 }: TaskDetailModalProps) {
   const [title, setTitle] = useState(task.title);
   const [description, setDescription] = useState(task.description ?? "");
   const [date, setDate] = useState(task.date);
-  const [saving, setSaving] = useState(false);
-  const [deleting, setDeleting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const handleSave = async (e: React.FormEvent) => {
+  const updateTaskMutation = useUpdateTask(year, month);
+  const deleteTaskMutation = useDeleteTask(year, month);
+
+  const saving = updateTaskMutation.isPending;
+  const deleting = deleteTaskMutation.isPending;
+  const busy = saving || deleting;
+
+  const handleSave = (e: React.FormEvent) => {
     e.preventDefault();
     if (!title.trim()) return;
 
-    setSaving(true);
     setError(null);
-    try {
-      await updateTask(task.id, {
-        title: title.trim(),
-        description: description.trim() || null,
-        date,
-      });
-      onUpdated();
-    } catch {
-      setError("タスクの更新に失敗しました");
-      setSaving(false);
-    }
+    updateTaskMutation.mutate(
+      {
+        id: task.id,
+        data: {
+          title: title.trim(),
+          description: description.trim() || null,
+          date,
+        },
+      },
+      {
+        onSuccess: () => onUpdated(),
+        onError: () => setError("タスクの更新に失敗しました"),
+      },
+    );
   };
 
-  const handleDelete = async () => {
+  const handleDelete = () => {
     if (!window.confirm("このタスクを削除しますか？")) return;
 
-    setDeleting(true);
     setError(null);
-    try {
-      await deleteTask(task.id);
-      onUpdated();
-    } catch {
-      setError("タスクの削除に失敗しました");
-      setDeleting(false);
-    }
+    deleteTaskMutation.mutate(task.id, {
+      onSuccess: () => onUpdated(),
+      onError: () => setError("タスクの削除に失敗しました"),
+    });
   };
-
-  const busy = saving || deleting;
 
   return (
     <div
@@ -70,7 +75,7 @@ export function TaskDetailModal({
             {error}
           </div>
         )}
-        <form onSubmit={(e) => void handleSave(e)} className="space-y-4">
+        <form onSubmit={handleSave} className="space-y-4">
           <div>
             <label
               htmlFor="detail-title"
@@ -121,7 +126,7 @@ export function TaskDetailModal({
           <div className="flex justify-between">
             <button
               type="button"
-              onClick={() => void handleDelete()}
+              onClick={handleDelete}
               disabled={busy}
               className="rounded-md bg-red-600 px-4 py-2 text-sm text-white hover:bg-red-700 disabled:opacity-50"
             >

--- a/apps/web/src/components/TaskFormModal.tsx
+++ b/apps/web/src/components/TaskFormModal.tsx
@@ -1,39 +1,42 @@
 import { useState } from "react";
-import { createTask } from "../api/tasks";
+import { useCreateTask } from "../hooks/useTasks";
 
 type TaskFormModalProps = {
   date: string;
+  year: number;
+  month: number;
   onClose: () => void;
   onCreated: () => void;
 };
 
 export function TaskFormModal({
   date,
+  year,
+  month,
   onClose,
   onCreated,
 }: TaskFormModalProps) {
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
-  const [saving, setSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const createTaskMutation = useCreateTask(year, month);
+  const saving = createTaskMutation.isPending;
+  const error = createTaskMutation.error ? "タスクの作成に失敗しました" : null;
+
+  const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!title.trim()) return;
 
-    setSaving(true);
-    setError(null);
-    try {
-      await createTask({
+    createTaskMutation.mutate(
+      {
         title: title.trim(),
         description: description.trim() || null,
         date,
-      });
-      onCreated();
-    } catch {
-      setError("タスクの作成に失敗しました");
-      setSaving(false);
-    }
+      },
+      {
+        onSuccess: () => onCreated(),
+      },
+    );
   };
 
   return (
@@ -53,7 +56,7 @@ export function TaskFormModal({
             {error}
           </div>
         )}
-        <form onSubmit={(e) => void handleSubmit(e)} className="space-y-4">
+        <form onSubmit={handleSubmit} className="space-y-4">
           <div>
             <label
               htmlFor="task-title"

--- a/apps/web/src/components/__tests__/Calendar.test.tsx
+++ b/apps/web/src/components/__tests__/Calendar.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Calendar } from "../Calendar";
+import { renderWithQueryClient } from "../../test/helpers";
 
 // API モック
 const mockFetchTasks = vi.fn();
@@ -60,7 +61,7 @@ describe("Calendar", () => {
   });
 
   it("年月ヘッダーと曜日ラベルが表示される", async () => {
-    render(<Calendar />);
+    renderWithQueryClient(<Calendar />);
 
     const now = new Date();
     await waitFor(() => {
@@ -76,7 +77,7 @@ describe("Calendar", () => {
 
   it("マウント時にタスクを取得して表示する", async () => {
     mockFetchTasks.mockResolvedValue([mockTask]);
-    render(<Calendar />);
+    renderWithQueryClient(<Calendar />);
 
     await waitFor(() => {
       expect(screen.getByText("テストタスク")).toBeInTheDocument();
@@ -91,7 +92,7 @@ describe("Calendar", () => {
 
   it("前月・次月ボタンで月を切り替えられる", async () => {
     const user = userEvent.setup();
-    render(<Calendar />);
+    renderWithQueryClient(<Calendar />);
 
     const now = new Date();
     const currentMonth = now.getMonth() + 1;
@@ -125,7 +126,7 @@ describe("Calendar", () => {
 
   it("「今日」ボタンで今月に戻れる", async () => {
     const user = userEvent.setup();
-    render(<Calendar />);
+    renderWithQueryClient(<Calendar />);
 
     const now = new Date();
     const currentYear = now.getFullYear();
@@ -152,7 +153,7 @@ describe("Calendar", () => {
 
   it("タスク取得失敗時にエラーメッセージを表示する", async () => {
     mockFetchTasks.mockRejectedValue(new Error("API error"));
-    render(<Calendar />);
+    renderWithQueryClient(<Calendar />);
 
     await waitFor(() => {
       expect(
@@ -166,7 +167,7 @@ describe("Calendar", () => {
     mockCreateTask.mockResolvedValue(mockTask);
 
     const user = userEvent.setup();
-    render(<Calendar />);
+    renderWithQueryClient(<Calendar />);
 
     await waitFor(() => {
       expect(mockFetchTasks).toHaveBeenCalled();
@@ -200,7 +201,7 @@ describe("Calendar", () => {
     mockUpdateTask.mockResolvedValue({ ...mockTask, title: "更新後タスク" });
 
     const user = userEvent.setup();
-    render(<Calendar />);
+    renderWithQueryClient(<Calendar />);
 
     // タスクが表示されるのを待つ
     await waitFor(() => {
@@ -235,7 +236,7 @@ describe("Calendar", () => {
     vi.spyOn(window, "confirm").mockReturnValue(true);
 
     const user = userEvent.setup();
-    render(<Calendar />);
+    renderWithQueryClient(<Calendar />);
 
     await waitFor(() => {
       expect(screen.getByText("テストタスク")).toBeInTheDocument();
@@ -255,7 +256,7 @@ describe("Calendar", () => {
     mockFetchTasks.mockResolvedValue([]);
 
     const user = userEvent.setup();
-    render(<Calendar />);
+    renderWithQueryClient(<Calendar />);
 
     await waitFor(() => {
       expect(mockFetchTasks).toHaveBeenCalled();
@@ -278,7 +279,7 @@ describe("Calendar", () => {
     mockFetchTasks.mockResolvedValue([mockTask]);
     mockUpdateTask.mockResolvedValue({ ...mockTask, date: "2026-03-20" });
 
-    render(<Calendar />);
+    renderWithQueryClient(<Calendar />);
 
     await waitFor(() => {
       expect(screen.getByText("テストタスク")).toBeInTheDocument();
@@ -301,7 +302,7 @@ describe("Calendar", () => {
   it("同じ日付へのドロップでは更新しない", async () => {
     mockFetchTasks.mockResolvedValue([mockTask]);
 
-    render(<Calendar />);
+    renderWithQueryClient(<Calendar />);
 
     await waitFor(() => {
       expect(screen.getByText("テストタスク")).toBeInTheDocument();
@@ -318,7 +319,7 @@ describe("Calendar", () => {
   it("ドロップ先がない場合は更新しない", async () => {
     mockFetchTasks.mockResolvedValue([mockTask]);
 
-    render(<Calendar />);
+    renderWithQueryClient(<Calendar />);
 
     await waitFor(() => {
       expect(screen.getByText("テストタスク")).toBeInTheDocument();
@@ -337,7 +338,7 @@ describe("Calendar", () => {
     mockUpdateTask.mockResolvedValue({ ...mockTask, status: "done" });
 
     const user = userEvent.setup();
-    render(<Calendar />);
+    renderWithQueryClient(<Calendar />);
 
     await waitFor(() => {
       expect(screen.getByText("テストタスク")).toBeInTheDocument();

--- a/apps/web/src/components/__tests__/TaskDetailModal.test.tsx
+++ b/apps/web/src/components/__tests__/TaskDetailModal.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { TaskDetailModal } from "../TaskDetailModal";
+import { renderWithQueryClient } from "../../test/helpers";
 
 const mockUpdateTask = vi.fn();
 const mockDeleteTask = vi.fn();
@@ -25,6 +26,8 @@ const mockTask = {
 describe("TaskDetailModal", () => {
   const defaultProps = {
     task: mockTask,
+    year: 2026,
+    month: 3,
     onClose: vi.fn(),
     onUpdated: vi.fn(),
   };
@@ -38,7 +41,7 @@ describe("TaskDetailModal", () => {
   });
 
   it("タスクの情報がフォームに表示される", () => {
-    render(<TaskDetailModal {...defaultProps} />);
+    renderWithQueryClient(<TaskDetailModal {...defaultProps} />);
 
     expect(screen.getByText("タスクの詳細")).toBeInTheDocument();
     expect(screen.getByDisplayValue("既存タスク")).toBeInTheDocument();
@@ -49,7 +52,7 @@ describe("TaskDetailModal", () => {
   it("タイトルを変更して保存できる", async () => {
     mockUpdateTask.mockResolvedValue({ ...mockTask, title: "変更後" });
     const user = userEvent.setup();
-    render(<TaskDetailModal {...defaultProps} />);
+    renderWithQueryClient(<TaskDetailModal {...defaultProps} />);
 
     const titleInput = screen.getByLabelText(/タイトル/);
     await user.clear(titleInput);
@@ -62,7 +65,9 @@ describe("TaskDetailModal", () => {
         expect.objectContaining({ title: "変更後" }),
       );
     });
-    expect(defaultProps.onUpdated).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(defaultProps.onUpdated).toHaveBeenCalled();
+    });
   });
 
   it("削除ボタンで確認後に削除できる", async () => {
@@ -70,21 +75,23 @@ describe("TaskDetailModal", () => {
     vi.spyOn(window, "confirm").mockReturnValue(true);
 
     const user = userEvent.setup();
-    render(<TaskDetailModal {...defaultProps} />);
+    renderWithQueryClient(<TaskDetailModal {...defaultProps} />);
 
     await user.click(screen.getByText("削除"));
 
     await waitFor(() => {
       expect(mockDeleteTask).toHaveBeenCalledWith("task-1");
     });
-    expect(defaultProps.onUpdated).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(defaultProps.onUpdated).toHaveBeenCalled();
+    });
   });
 
   it("削除確認でキャンセルすると削除されない", async () => {
     vi.spyOn(window, "confirm").mockReturnValue(false);
 
     const user = userEvent.setup();
-    render(<TaskDetailModal {...defaultProps} />);
+    renderWithQueryClient(<TaskDetailModal {...defaultProps} />);
 
     await user.click(screen.getByText("削除"));
 
@@ -93,7 +100,7 @@ describe("TaskDetailModal", () => {
 
   it("キャンセルで onClose が呼ばれる", async () => {
     const user = userEvent.setup();
-    render(<TaskDetailModal {...defaultProps} />);
+    renderWithQueryClient(<TaskDetailModal {...defaultProps} />);
 
     await user.click(screen.getByText("キャンセル"));
     expect(defaultProps.onClose).toHaveBeenCalled();
@@ -102,7 +109,7 @@ describe("TaskDetailModal", () => {
   it("更新失敗時にエラーメッセージを表示する", async () => {
     mockUpdateTask.mockRejectedValue(new Error("更新失敗"));
     const user = userEvent.setup();
-    render(<TaskDetailModal {...defaultProps} />);
+    renderWithQueryClient(<TaskDetailModal {...defaultProps} />);
 
     await user.click(screen.getByText("保存"));
 
@@ -119,7 +126,7 @@ describe("TaskDetailModal", () => {
     vi.spyOn(window, "confirm").mockReturnValue(true);
 
     const user = userEvent.setup();
-    render(<TaskDetailModal {...defaultProps} />);
+    renderWithQueryClient(<TaskDetailModal {...defaultProps} />);
 
     await user.click(screen.getByText("削除"));
 
@@ -132,7 +139,7 @@ describe("TaskDetailModal", () => {
   });
 
   it("description が null のタスクでも正しく表示される", () => {
-    render(
+    renderWithQueryClient(
       <TaskDetailModal
         {...defaultProps}
         task={{ ...mockTask, description: null }}

--- a/apps/web/src/components/__tests__/TaskFormModal.test.tsx
+++ b/apps/web/src/components/__tests__/TaskFormModal.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { TaskFormModal } from "../TaskFormModal";
+import { renderWithQueryClient } from "../../test/helpers";
 
 const mockCreateTask = vi.fn();
 
@@ -12,6 +13,8 @@ vi.mock("../../api/tasks", () => ({
 describe("TaskFormModal", () => {
   const defaultProps = {
     date: "2026-03-15",
+    year: 2026,
+    month: 3,
     onClose: vi.fn(),
     onCreated: vi.fn(),
   };
@@ -21,14 +24,14 @@ describe("TaskFormModal", () => {
   });
 
   it("日付付きのタイトルが表示される", () => {
-    render(<TaskFormModal {...defaultProps} />);
+    renderWithQueryClient(<TaskFormModal {...defaultProps} />);
     expect(screen.getByText("タスクを追加（2026-03-15）")).toBeInTheDocument();
   });
 
   it("タイトルと説明を入力してタスクを作成できる", async () => {
     mockCreateTask.mockResolvedValue({});
     const user = userEvent.setup();
-    render(<TaskFormModal {...defaultProps} />);
+    renderWithQueryClient(<TaskFormModal {...defaultProps} />);
 
     await user.type(screen.getByLabelText(/タイトル/), "新規タスク");
     await user.type(screen.getByLabelText(/説明/), "タスクの説明文");
@@ -41,18 +44,20 @@ describe("TaskFormModal", () => {
         date: "2026-03-15",
       });
     });
-    expect(defaultProps.onCreated).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(defaultProps.onCreated).toHaveBeenCalled();
+    });
   });
 
   it("タイトル未入力では追加ボタンが無効化される", () => {
-    render(<TaskFormModal {...defaultProps} />);
+    renderWithQueryClient(<TaskFormModal {...defaultProps} />);
     expect(screen.getByText("追加")).toBeDisabled();
   });
 
   it("説明が空の場合 null が送信される", async () => {
     mockCreateTask.mockResolvedValue({});
     const user = userEvent.setup();
-    render(<TaskFormModal {...defaultProps} />);
+    renderWithQueryClient(<TaskFormModal {...defaultProps} />);
 
     await user.type(screen.getByLabelText(/タイトル/), "タスク");
     await user.click(screen.getByText("追加"));
@@ -68,7 +73,7 @@ describe("TaskFormModal", () => {
 
   it("キャンセルで onClose が呼ばれる", async () => {
     const user = userEvent.setup();
-    render(<TaskFormModal {...defaultProps} />);
+    renderWithQueryClient(<TaskFormModal {...defaultProps} />);
 
     await user.click(screen.getByText("キャンセル"));
     expect(defaultProps.onClose).toHaveBeenCalled();
@@ -77,7 +82,7 @@ describe("TaskFormModal", () => {
   it("作成失敗時にエラーメッセージを表示する", async () => {
     mockCreateTask.mockRejectedValue(new Error("作成失敗"));
     const user = userEvent.setup();
-    render(<TaskFormModal {...defaultProps} />);
+    renderWithQueryClient(<TaskFormModal {...defaultProps} />);
 
     await user.type(screen.getByLabelText(/タイトル/), "タスク");
     await user.click(screen.getByText("追加"));

--- a/apps/web/src/hooks/useTasks.ts
+++ b/apps/web/src/hooks/useTasks.ts
@@ -1,0 +1,123 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import type { Task } from "../types/task";
+import { fetchTasks, createTask, updateTask, deleteTask } from "../api/tasks";
+
+function tasksQueryKey(year: number, month: number) {
+  return ["tasks", year, month] as const;
+}
+
+export function useTasks(year: number, month: number) {
+  return useQuery({
+    queryKey: tasksQueryKey(year, month),
+    queryFn: ({ signal }) => fetchTasks(year, month, signal),
+  });
+}
+
+export function useCreateTask(year: number, month: number) {
+  const queryClient = useQueryClient();
+  const key = tasksQueryKey(year, month);
+
+  return useMutation({
+    mutationFn: (data: {
+      title: string;
+      description?: string | null;
+      date: string;
+      status?: "todo" | "done";
+    }) => createTask(data),
+    onMutate: async (newTask) => {
+      await queryClient.cancelQueries({ queryKey: key });
+      const previous = queryClient.getQueryData<Task[]>(key);
+
+      queryClient.setQueryData<Task[]>(key, (old) => [
+        ...(old ?? []),
+        {
+          id: `temp-${Date.now()}`,
+          title: newTask.title,
+          description: newTask.description ?? null,
+          date: newTask.date,
+          status: newTask.status ?? "todo",
+          userId: "",
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+      ]);
+
+      return { previous };
+    },
+    onError: (_err, _variables, context) => {
+      if (context) {
+        queryClient.setQueryData(key, context.previous);
+      }
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: key });
+    },
+  });
+}
+
+export function useUpdateTask(year: number, month: number) {
+  const queryClient = useQueryClient();
+  const key = tasksQueryKey(year, month);
+
+  return useMutation({
+    mutationFn: ({
+      id,
+      data,
+    }: {
+      id: string;
+      data: {
+        title?: string;
+        description?: string | null;
+        date?: string;
+        status?: "todo" | "done";
+      };
+    }) => updateTask(id, data),
+    onMutate: async ({ id, data }) => {
+      await queryClient.cancelQueries({ queryKey: key });
+      const previous = queryClient.getQueryData<Task[]>(key);
+
+      queryClient.setQueryData<Task[]>(key, (old) =>
+        (old ?? []).map((task) =>
+          task.id === id ? { ...task, ...data } : task,
+        ),
+      );
+
+      return { previous };
+    },
+    onError: (_err, _variables, context) => {
+      if (context) {
+        queryClient.setQueryData(key, context.previous);
+      }
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: key });
+    },
+  });
+}
+
+export function useDeleteTask(year: number, month: number) {
+  const queryClient = useQueryClient();
+  const key = tasksQueryKey(year, month);
+
+  return useMutation({
+    mutationFn: (id: string) => deleteTask(id),
+    onMutate: async (id) => {
+      await queryClient.cancelQueries({ queryKey: key });
+      const previous = queryClient.getQueryData<Task[]>(key);
+
+      queryClient.setQueryData<Task[]>(key, (old) =>
+        (old ?? []).filter((task) => task.id !== id),
+      );
+
+      return { previous };
+    },
+    onError: (_err, _variables, context) => {
+      if (context) {
+        queryClient.setQueryData(key, context.previous);
+      }
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: key });
+    },
+  });
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,10 +1,12 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { RouterProvider, createRouter } from "@tanstack/react-router";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { routeTree } from "./routeTree.gen";
 import "./index.css";
 
 const router = createRouter({ routeTree });
+const queryClient = new QueryClient();
 
 declare module "@tanstack/react-router" {
   interface Register {
@@ -14,6 +16,8 @@ declare module "@tanstack/react-router" {
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <RouterProvider router={router} />
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>
   </StrictMode>,
 );

--- a/apps/web/src/test/helpers.tsx
+++ b/apps/web/src/test/helpers.tsx
@@ -1,0 +1,23 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, type RenderOptions } from "@testing-library/react";
+import type { ReactElement } from "react";
+
+export function renderWithQueryClient(
+  ui: ReactElement,
+  options?: Omit<RenderOptions, "wrapper">,
+) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  }
+
+  return render(ui, { wrapper: Wrapper, ...options });
+}


### PR DESCRIPTION
close #37

## 概要

タスクの変更操作（作成・更新・削除・ステータス切替・ドラッグ&ドロップ移動）に楽観的UI更新を導入し、操作の体感速度を改善する。

## 変更内容

- `@tanstack/react-query` を導入し、`QueryClientProvider` を `main.tsx` に設置
- カスタム hooks を新規作成（`useTasks` / `useCreateTask` / `useUpdateTask` / `useDeleteTask`）
  - `onMutate` でキャッシュを即時更新（楽観的更新）
  - `onError` でスナップショットにロールバック
  - `onSettled` で `invalidateQueries` によるサーバー再同期
- `Calendar.tsx` の `useState` + `useEffect` + `refreshKey` パターンを `useQuery` に移行
- `TaskFormModal.tsx` / `TaskDetailModal.tsx` の API 直接呼び出しを `useMutation` に移行
- 既存テストを `QueryClientProvider` ラッパーで対応

## 変更しないもの

- サーバーサイド（API）のコード
- `apps/web/src/api/tasks.ts`（既存 API クライアントはそのまま活用）

## テスト計画

- [x] `make typecheck` 通過
- [x] `make lint` 通過
- [x] `make format-check` 通過
- [x] `make test` 通過（API 17件 + Web 27件）
- [ ] CI 通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)