### PR TITLE
feat: カレンダーを月曜始まりに変更

### DIFF
--- a/apps/web/src/components/Calendar.tsx
+++ b/apps/web/src/components/Calendar.tsx
@@ -7,7 +7,7 @@ import { CalendarDayCell } from "./CalendarDayCell";
 import { TaskFormModal } from "./TaskFormModal";
 import { TaskDetailModal } from "./TaskDetailModal";
 
-const WEEKDAY_LABELS = ["日", "月", "火", "水", "木", "金", "土"];
+const WEEKDAY_LABELS = ["月", "火", "水", "木", "金", "土", "日"];
 
 export function Calendar() {
   const now = new Date();
@@ -143,10 +143,10 @@ export function Calendar() {
               <div
                 key={label}
                 className={`border-b border-gray-200 py-2 text-center text-sm font-medium ${
-                  i === 0
-                    ? "text-red-500"
+                  i === 5
+                    ? "text-blue-500"
                     : i === 6
-                      ? "text-blue-500"
+                      ? "text-red-500"
                       : "text-gray-600"
                 }`}
               >

--- a/apps/web/src/components/__tests__/Calendar.test.tsx
+++ b/apps/web/src/components/__tests__/Calendar.test.tsx
@@ -70,9 +70,10 @@ describe("Calendar", () => {
       ).toBeInTheDocument();
     });
 
-    for (const label of ["日", "月", "火", "水", "木", "金", "土"]) {
-      expect(screen.getByText(label)).toBeInTheDocument();
-    }
+    const headers = screen
+      .getAllByText(/^[月火水木金土日]$/)
+      .map((el) => el.textContent);
+    expect(headers).toEqual(["月", "火", "水", "木", "金", "土", "日"]);
   });
 
   it("マウント時にタスクを取得して表示する", async () => {

--- a/apps/web/src/utils/__tests__/calendar.test.ts
+++ b/apps/web/src/utils/__tests__/calendar.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { getCalendarDays } from "../calendar";
+
+describe("getCalendarDays (月曜始まり)", () => {
+  it("2026年4月: 水曜始まり → 先頭2日が前月パディング", () => {
+    // 2026-04-01 は水曜日
+    const days = getCalendarDays(2026, 4);
+
+    // 先頭は前月パディング（3/30 月曜, 3/31 火曜）
+    expect(days[0].date.getDate()).toBe(30);
+    expect(days[0].date.getMonth()).toBe(2); // 3月 = index 2
+    expect(days[0].isCurrentMonth).toBe(false);
+
+    expect(days[1].date.getDate()).toBe(31);
+    expect(days[1].isCurrentMonth).toBe(false);
+
+    // 3番目が4/1（水曜）
+    expect(days[2].date.getDate()).toBe(1);
+    expect(days[2].date.getMonth()).toBe(3); // 4月 = index 3
+    expect(days[2].isCurrentMonth).toBe(true);
+  });
+
+  it("2026年6月: 月曜始まり → パディングなし", () => {
+    // 2026-06-01 は月曜日
+    const days = getCalendarDays(2026, 6);
+
+    // 先頭が6/1（月曜）
+    expect(days[0].date.getDate()).toBe(1);
+    expect(days[0].date.getMonth()).toBe(5); // 6月 = index 5
+    expect(days[0].isCurrentMonth).toBe(true);
+  });
+
+  it("2026年3月: 日曜始まり → 前月パディング6日", () => {
+    // 2026-03-01 は日曜日 → 月曜始まりなので前に6日のパディング
+    const days = getCalendarDays(2026, 3);
+
+    // 先頭は2/23（月曜）
+    expect(days[0].date.getDate()).toBe(23);
+    expect(days[0].date.getMonth()).toBe(1); // 2月 = index 1
+    expect(days[0].isCurrentMonth).toBe(false);
+
+    // 7番目が3/1（日曜）
+    expect(days[6].date.getDate()).toBe(1);
+    expect(days[6].date.getMonth()).toBe(2); // 3月 = index 2
+    expect(days[6].isCurrentMonth).toBe(true);
+  });
+
+  it("各行が月〜日の順に並ぶ", () => {
+    const days = getCalendarDays(2026, 4);
+
+    // 各行（7日ずつ）の最初は月曜、最後は日曜
+    for (let row = 0; row < days.length / 7; row++) {
+      const firstOfRow = days[row * 7].date.getDay();
+      const lastOfRow = days[row * 7 + 6].date.getDay();
+      expect(firstOfRow).toBe(1); // 月曜
+      expect(lastOfRow).toBe(0); // 日曜
+    }
+  });
+});

--- a/apps/web/src/utils/calendar.ts
+++ b/apps/web/src/utils/calendar.ts
@@ -5,7 +5,7 @@ export type CalendarDay = {
 
 export function getCalendarDays(year: number, month: number): CalendarDay[] {
   const firstDay = new Date(year, month - 1, 1);
-  const startDayOfWeek = firstDay.getDay(); // 0 = Sunday
+  const startDayOfWeek = (firstDay.getDay() + 6) % 7; // 0 = Monday
 
   const days: CalendarDay[] = [];
 


### PR DESCRIPTION
close #44

## 概要

カレンダーの週始まりを日曜から月曜に変更しました。

## 変更内容

- `getCalendarDays` の曜日計算を月曜始まり `(getDay()+6)%7` に変換
- `WEEKDAY_LABELS` を「月・火・水・木・金・土・日」の順に変更
- 曜日ヘッダーの色分けを土=青(index 5)、日=赤(index 6)に調整
- `getCalendarDays` のユニットテストを新規追加（月曜始まりのパディング検証）
- Calendar テストの曜日順序検証を存在確認から順序の厳密比較に強化

## テスト計画

- [x] `make test` — 全31テストパス（新規4テスト含む）
- [x] `make lint` / `make format-check` / `make typecheck` パス
- [ ] ブラウザで月間カレンダーを表示し、月曜始まりになっていることを目視確認
- [ ] 月初が日曜の月（例: 2026年3月）で前月パディングが正しいことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)