### PR TITLE
feat: 404ページを追加

### DIFF
--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -1,5 +1,25 @@
-import { createRootRoute, Outlet } from "@tanstack/react-router";
+import { createRootRoute, Link, Outlet } from "@tanstack/react-router";
+
+function NotFoundPage() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-100 px-4">
+      <div className="w-full max-w-sm rounded-lg bg-white p-6 text-center shadow-xl">
+        <h1 className="mb-2 text-6xl font-bold text-gray-900">404</h1>
+        <p className="mb-6 text-sm text-gray-600">
+          お探しのページが見つかりませんでした
+        </p>
+        <Link
+          to="/"
+          className="inline-block rounded-md bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700"
+        >
+          トップページへ戻る
+        </Link>
+      </div>
+    </div>
+  );
+}
 
 export const Route = createRootRoute({
   component: () => <Outlet />,
+  notFoundComponent: NotFoundPage,
 });


### PR DESCRIPTION
close #48

## 概要

存在しないパスにアクセスした際に 404 ページを表示するようにした。

## 変更内容

- `__root.tsx` に `notFoundComponent` を設定
- 「404」見出し、説明文、トップページへのリンクを含むページを実装
- 認証状態に依存しない root レベルでの設定のため、認証済み・未認証どちらでも表示される

## テスト計画

- [ ] 存在しないパス（例: `/nonexistent`）にアクセスして 404 ページが表示されることを確認
- [ ] 「トップページへ戻る」リンクをクリックしてトップページに遷移することを確認
- [ ] 未ログイン状態で存在しないパスにアクセスして 404 ページが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)