### PR TITLE
カレンダーのレイアウトを広げて余白を減らす

### DIFF
--- a/apps/web/src/components/Calendar.tsx
+++ b/apps/web/src/components/Calendar.tsx
@@ -98,7 +98,7 @@ export function Calendar() {
   const error = queryError ? "タスクの取得に失敗しました" : mutationError;
 
   return (
-    <div className="mx-auto max-w-5xl">
+    <div className="mx-auto max-w-7xl">
       <div className="mb-4 flex items-center justify-between">
         <h2 className="text-xl font-bold text-gray-900">
           {year}年{month}月

--- a/apps/web/src/components/CalendarDayCell.tsx
+++ b/apps/web/src/components/CalendarDayCell.tsx
@@ -32,7 +32,7 @@ export function CalendarDayCell({
   return (
     <div
       ref={setNodeRef}
-      className={`group relative min-h-24 border border-gray-200 p-1 ${
+      className={`group relative min-h-32 border border-gray-200 p-1.5 ${
         !isCurrentMonth ? "bg-gray-50" : "bg-white"
       } ${isOver ? "bg-blue-50" : ""}`}
     >

--- a/apps/web/src/components/DraggableTask.tsx
+++ b/apps/web/src/components/DraggableTask.tsx
@@ -20,7 +20,7 @@ export function DraggableTask({
   return (
     <div
       ref={setNodeRef}
-      className={`flex items-center gap-1 rounded px-1 text-xs ${
+      className={`flex items-center gap-1 rounded px-1 py-0.5 text-sm ${
         task.status === "done"
           ? "text-gray-400 line-through"
           : "bg-blue-100 text-blue-800"
@@ -31,7 +31,7 @@ export function DraggableTask({
         checked={task.status === "done"}
         onChange={() => onToggleStatus(task)}
         onClick={(e) => e.stopPropagation()}
-        className="h-3 w-3 shrink-0 cursor-pointer"
+        className="h-3.5 w-3.5 shrink-0 cursor-pointer"
       />
       <span
         className="cursor-pointer truncate"

--- a/apps/web/src/routes/_authenticated/index.tsx
+++ b/apps/web/src/routes/_authenticated/index.tsx
@@ -17,8 +17,8 @@ function HomePage() {
 
   return (
     <div className="min-h-screen bg-gray-100">
-      <header className="border-b border-gray-200 bg-white px-6 py-3">
-        <div className="mx-auto flex max-w-5xl items-center justify-between">
+      <header className="border-b border-gray-200 bg-white px-4 py-3">
+        <div className="mx-auto flex max-w-7xl items-center justify-between">
           <h1 className="text-lg font-bold text-gray-900">tascal</h1>
           <div className="flex items-center gap-4">
             <span className="text-sm text-gray-600">{session?.user?.name}</span>
@@ -32,7 +32,7 @@ function HomePage() {
           </div>
         </div>
       </header>
-      <main className="p-6">
+      <main className="p-4">
         <Calendar />
       </main>
     </div>


### PR DESCRIPTION
close #45

## 概要

- カレンダーとヘッダーの最大幅を `max-w-5xl` から `max-w-7xl` に拡大
- 日付セルの最小高さを `min-h-24` から `min-h-32` に拡大
- タスク表示の文字サイズを `text-xs` から `text-sm` に拡大
- チェックボックスを `h-3 w-3` から `h-3.5 w-3.5` に拡大
- ページ外側の余白を `p-6` / `px-6` から `p-4` / `px-4` に縮小

## テスト計画

- [x] lint / format-check / typecheck / test / knip すべてパス
- [ ] ブラウザでカレンダー画面を確認し、レイアウトのバランスが取れていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)