### PR TITLE
日付セルクリックでタスク作成モーダルを開く（+ボタン廃止）

### DIFF
--- a/apps/web/src/components/CalendarDayCell.tsx
+++ b/apps/web/src/components/CalendarDayCell.tsx
@@ -32,7 +32,17 @@ export function CalendarDayCell({
   return (
     <div
       ref={setNodeRef}
-      className={`group relative min-h-32 border border-gray-200 p-1.5 ${
+      role="button"
+      tabIndex={0}
+      onClick={() => onAddClick(dateKey)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onAddClick(dateKey);
+        }
+      }}
+      aria-label={`${dateKey}にタスクを追加`}
+      className={`group relative min-h-32 cursor-pointer border border-gray-200 p-1.5 ${
         !isCurrentMonth ? "bg-gray-50" : "bg-white"
       } ${isOver ? "bg-blue-50" : ""}`}
     >
@@ -49,14 +59,6 @@ export function CalendarDayCell({
           {date.getDate()}
         </span>
       </div>
-      <button
-        type="button"
-        onClick={() => onAddClick(dateKey)}
-        className="absolute right-1 top-1 hidden h-5 w-5 items-center justify-center rounded text-gray-400 hover:bg-gray-200 hover:text-gray-600 focus:flex group-hover:flex group-focus-within:flex"
-        aria-label={`${dateKey}にタスクを追加`}
-      >
-        +
-      </button>
       <div className="space-y-0.5">
         {visibleTasks.map((task) => (
           <DraggableTask

--- a/apps/web/src/components/DraggableTask.tsx
+++ b/apps/web/src/components/DraggableTask.tsx
@@ -20,6 +20,7 @@ export function DraggableTask({
   return (
     <div
       ref={setNodeRef}
+      onClick={(e) => e.stopPropagation()}
       className={`flex items-center gap-1 rounded px-1 py-0.5 text-sm ${
         task.status === "done"
           ? "text-gray-400 line-through"

--- a/apps/web/src/components/__tests__/Calendar.test.tsx
+++ b/apps/web/src/components/__tests__/Calendar.test.tsx
@@ -163,7 +163,7 @@ describe("Calendar", () => {
     });
   });
 
-  it("＋ボタンからタスク作成モーダルを開いて作成できる", async () => {
+  it("日付セルクリックからタスク作成モーダルを開いて作成できる", async () => {
     mockFetchTasks.mockResolvedValue([]);
     mockCreateTask.mockResolvedValue(mockTask);
 
@@ -174,11 +174,12 @@ describe("Calendar", () => {
       expect(mockFetchTasks).toHaveBeenCalled();
     });
 
-    // 日付セルの + ボタンをクリック
-    const addButtons = screen.getAllByRole("button", {
-      name: /にタスクを追加/,
-    });
-    await user.click(addButtons[0]);
+    // 日付セルの15日をクリック
+    const now = new Date();
+    const dateKey = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-15`;
+    await user.click(
+      screen.getByRole("button", { name: `${dateKey}にタスクを追加` }),
+    );
 
     // モーダルが表示される
     expect(screen.getByText(/タスクを追加/)).toBeInTheDocument();
@@ -263,10 +264,11 @@ describe("Calendar", () => {
       expect(mockFetchTasks).toHaveBeenCalled();
     });
 
-    const addButtons = screen.getAllByRole("button", {
-      name: /にタスクを追加/,
-    });
-    await user.click(addButtons[0]);
+    const now = new Date();
+    const dateKey = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-15`;
+    await user.click(
+      screen.getByRole("button", { name: `${dateKey}にタスクを追加` }),
+    );
     expect(screen.getByText(/タスクを追加/)).toBeInTheDocument();
 
     await user.click(screen.getByText("キャンセル"));


### PR DESCRIPTION
close #38

## 概要
カレンダーの日付セル自体をクリックしてタスク作成モーダルを開くようにし、従来の `+` ボタンを廃止した。

## 変更内容
- `CalendarDayCell`: セル全体に `onClick` / `onKeyDown` / `role="button"` を追加し、クリックとキーボード操作でタスク作成モーダルを開けるようにした
- `CalendarDayCell`: `+` ボタンを削除
- `DraggableTask`: タスク要素で `e.stopPropagation()` を追加し、タスククリック・ドラッグとセルクリックの競合を防止
- テストを日付セルクリックベースに更新（`aria-label` + `getByRole` で取得）

## テスト計画
- [x] 既存テスト全13件通過
- [x] lint / format-check / typecheck / knip 通過
- [ ] 日付セルの空きエリアクリックでモーダルが開くことを確認
- [ ] タスククリック（詳細モーダル）に影響がないことを確認
- [ ] ドラッグ操作に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)