### PR TITLE
feat: DragOverlay を追加してドラッグ中のタスクプレビューを表示する

### DIFF
--- a/apps/web/src/components/Calendar.tsx
+++ b/apps/web/src/components/Calendar.tsx
@@ -1,5 +1,10 @@
 import { useMemo, useState } from "react";
-import { DndContext, type DragEndEvent } from "@dnd-kit/core";
+import {
+  DndContext,
+  DragOverlay,
+  type DragEndEvent,
+  type DragStartEvent,
+} from "@dnd-kit/core";
 import type { Task } from "../types/task";
 import { useTasks, useUpdateTask } from "../hooks/useTasks";
 import { getCalendarDays, formatDateKey } from "../utils/calendar";
@@ -13,6 +18,9 @@ export function Calendar() {
   const now = new Date();
   const [year, setYear] = useState(now.getFullYear());
   const [month, setMonth] = useState(now.getMonth() + 1);
+
+  // ドラッグ状態
+  const [activeTask, setActiveTask] = useState<Task | null>(null);
 
   // モーダル状態
   const [addDate, setAddDate] = useState<string | null>(null);
@@ -76,7 +84,18 @@ export function Calendar() {
     );
   };
 
+  const handleDragStart = (event: DragStartEvent) => {
+    const task = event.active.data.current?.task as Task | undefined;
+    setActiveTask(task ?? null);
+  };
+
+  const handleDragCancel = () => {
+    setActiveTask(null);
+  };
+
   const handleDragEnd = (event: DragEndEvent) => {
+    setActiveTask(null);
+
     const { active, over } = event;
     if (!over) return;
 
@@ -134,7 +153,11 @@ export function Calendar() {
         </div>
       )}
 
-      <DndContext onDragEnd={handleDragEnd}>
+      <DndContext
+        onDragStart={handleDragStart}
+        onDragEnd={handleDragEnd}
+        onDragCancel={handleDragCancel}
+      >
         <div
           className={`overflow-hidden rounded-lg border border-gray-200 ${isLoading ? "opacity-50" : ""}`}
         >
@@ -172,6 +195,26 @@ export function Calendar() {
             })}
           </div>
         </div>
+        <DragOverlay>
+          {activeTask && (
+            <div
+              className={`flex items-center gap-1 rounded px-1 py-0.5 text-sm ${
+                activeTask.status === "done"
+                  ? "text-gray-400 line-through"
+                  : "bg-blue-100 text-blue-800"
+              }`}
+            >
+              <input
+                type="checkbox"
+                checked={activeTask.status === "done"}
+                readOnly
+                className="h-3.5 w-3.5 shrink-0"
+              />
+              <span className="truncate">{activeTask.title}</span>
+              <span className="ml-auto shrink-0 text-gray-400">⠿</span>
+            </div>
+          )}
+        </DragOverlay>
       </DndContext>
 
       {addDate && (

--- a/apps/web/src/components/__tests__/Calendar.test.tsx
+++ b/apps/web/src/components/__tests__/Calendar.test.tsx
@@ -17,20 +17,31 @@ vi.mock("../../api/tasks", () => ({
   deleteTask: (...args: unknown[]) => mockDeleteTask(...args) as unknown,
 }));
 
-// dnd-kit モック - onDragEnd をキャプチャして手動発火可能にする
+// dnd-kit モック - onDragStart/onDragEnd/onDragCancel をキャプチャして手動発火可能にする
+let capturedOnDragStart: ((event: unknown) => void) | null = null;
 let capturedOnDragEnd: ((event: unknown) => void) | null = null;
+let capturedOnDragCancel: (() => void) | null = null;
 
 vi.mock("@dnd-kit/core", () => ({
   DndContext: ({
     children,
+    onDragStart,
     onDragEnd,
+    onDragCancel,
   }: {
     children: React.ReactNode;
+    onDragStart?: (event: unknown) => void;
     onDragEnd?: (event: unknown) => void;
+    onDragCancel?: () => void;
   }) => {
+    capturedOnDragStart = onDragStart ?? null;
     capturedOnDragEnd = onDragEnd ?? null;
+    capturedOnDragCancel = onDragCancel ?? null;
     return <div>{children}</div>;
   },
+  DragOverlay: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="drag-overlay">{children}</div>
+  ),
   useDraggable: () => ({
     attributes: {},
     listeners: {},
@@ -334,6 +345,57 @@ describe("Calendar", () => {
     });
 
     expect(mockUpdateTask).not.toHaveBeenCalled();
+  });
+
+  it("ドラッグ開始時にDragOverlayにタスクのプレビューが表示される", async () => {
+    mockFetchTasks.mockResolvedValue([mockTask]);
+
+    renderWithQueryClient(<Calendar />);
+
+    await waitFor(() => {
+      expect(screen.getByText("テストタスク")).toBeInTheDocument();
+    });
+
+    // ドラッグ開始前はオーバーレイにタスクが表示されない
+    const overlay = screen.getByTestId("drag-overlay");
+    expect(overlay.textContent).toBe("");
+
+    // onDragStart を手動発火
+    capturedOnDragStart!({
+      active: { id: mockTask.id, data: { current: { task: mockTask } } },
+    });
+
+    await waitFor(() => {
+      expect(overlay.textContent).toContain("テストタスク");
+    });
+  });
+
+  it("ドラッグキャンセル時にDragOverlayのプレビューが消える", async () => {
+    mockFetchTasks.mockResolvedValue([mockTask]);
+
+    renderWithQueryClient(<Calendar />);
+
+    await waitFor(() => {
+      expect(screen.getByText("テストタスク")).toBeInTheDocument();
+    });
+
+    const overlay = screen.getByTestId("drag-overlay");
+
+    // ドラッグ開始
+    capturedOnDragStart!({
+      active: { id: mockTask.id, data: { current: { task: mockTask } } },
+    });
+
+    await waitFor(() => {
+      expect(overlay.textContent).toContain("テストタスク");
+    });
+
+    // キャンセル
+    capturedOnDragCancel!();
+
+    await waitFor(() => {
+      expect(overlay.textContent).toBe("");
+    });
   });
 
   it("チェックボックスでタスクのステータスを切り替えられる", async () => {


### PR DESCRIPTION
close #59

## 概要

dnd-kit の `DragOverlay` コンポーネントを導入し、ドラッグ中のタスクがカーソルに追従するプレビュー（ゴースト）として表示されるようにした。

## 変更内容

- `Calendar.tsx` に `onDragStart` / `onDragCancel` ハンドラーを追加し、ドラッグ中のタスク情報を state で管理
- `DndContext` の子として `DragOverlay` コンポーネントを配置し、タスクのプレビューをレンダリング
- ドラッグキャンセル時（Esc キー等）にもプレビューが正しく消えるよう `onDragCancel` を実装
- テストに `DragOverlay` の表示/非表示の検証を追加

## テスト計画

- [x] lint / format / typecheck / knip 通過
- [x] 全テスト通過（33 tests）
- [x] DragOverlay の表示/非表示テスト追加
- [ ] CI 通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)