### PR TITLE
feat: API に bearer 認証を追加

### DIFF
--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -1,5 +1,6 @@
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
+import { bearer } from "better-auth/plugins";
 import { getDb } from "./db/index.js";
 import * as schema from "./db/schema.js";
 
@@ -13,6 +14,7 @@ function createAuth() {
     emailAndPassword: {
       enabled: true,
     },
+    plugins: [bearer()],
     trustedOrigins: process.env.TRUSTED_ORIGINS
       ? process.env.TRUSTED_ORIGINS.split(",")
           .map((s) => s.trim())


### PR DESCRIPTION
close #70

## 概要

CLI からのトークンベース認証を受け付けるため、better-auth の bearer プラグインを API に導入した。

## 変更内容

- `apps/api/src/auth.ts` に `bearer()` プラグインを追加
- これにより `Authorization: Bearer <token>` ヘッダーによるセッション認証が有効になる
- 既存の Cookie ベース認証（Web）はそのまま動作する

## テスト計画

- [x] lint / typecheck / format-check / test がすべてパスすることを確認
- [x] 既存テスト（19 + 33 件）が全件パス
- [ ] CI パス確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)