### PR TITLE
feat: タスクアイテム全体をドラッグ可能にする

### DIFF
--- a/apps/web/src/components/Calendar.tsx
+++ b/apps/web/src/components/Calendar.tsx
@@ -2,6 +2,9 @@ import { useMemo, useState } from "react";
 import {
   DndContext,
   DragOverlay,
+  PointerSensor,
+  useSensor,
+  useSensors,
   type DragEndEvent,
   type DragStartEvent,
 } from "@dnd-kit/core";
@@ -18,6 +21,12 @@ export function Calendar() {
   const now = new Date();
   const [year, setYear] = useState(now.getFullYear());
   const [month, setMonth] = useState(now.getMonth() + 1);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 5 },
+    }),
+  );
 
   // ドラッグ状態
   const [activeTask, setActiveTask] = useState<Task | null>(null);
@@ -154,6 +163,7 @@ export function Calendar() {
       )}
 
       <DndContext
+        sensors={sensors}
         onDragStart={handleDragStart}
         onDragEnd={handleDragEnd}
         onDragCancel={handleDragCancel}
@@ -211,7 +221,6 @@ export function Calendar() {
                 className="h-3.5 w-3.5 shrink-0"
               />
               <span className="truncate">{activeTask.title}</span>
-              <span className="ml-auto shrink-0 text-gray-400">⠿</span>
             </div>
           )}
         </DragOverlay>

--- a/apps/web/src/components/DraggableTask.tsx
+++ b/apps/web/src/components/DraggableTask.tsx
@@ -20,8 +20,10 @@ export function DraggableTask({
   return (
     <div
       ref={setNodeRef}
+      {...listeners}
+      {...attributes}
       onClick={(e) => e.stopPropagation()}
-      className={`flex items-center gap-1 rounded px-1 py-0.5 text-sm ${
+      className={`flex cursor-grab items-center gap-1 rounded px-1 py-0.5 text-sm touch-none ${
         task.status === "done"
           ? "text-gray-400 line-through"
           : "bg-blue-100 text-blue-800"
@@ -32,6 +34,7 @@ export function DraggableTask({
         checked={task.status === "done"}
         onChange={() => onToggleStatus(task)}
         onClick={(e) => e.stopPropagation()}
+        onPointerDown={(e) => e.stopPropagation()}
         className="h-3.5 w-3.5 shrink-0 cursor-pointer"
       />
       <span
@@ -39,14 +42,6 @@ export function DraggableTask({
         onClick={() => onTaskClick(task)}
       >
         {task.title}
-      </span>
-      <span
-        className="ml-auto shrink-0 cursor-grab touch-none text-gray-400"
-        {...listeners}
-        {...attributes}
-        aria-label="ドラッグして移動"
-      >
-        ⠿
       </span>
     </div>
   );

--- a/apps/web/src/components/__tests__/Calendar.test.tsx
+++ b/apps/web/src/components/__tests__/Calendar.test.tsx
@@ -52,6 +52,9 @@ vi.mock("@dnd-kit/core", () => ({
     setNodeRef: vi.fn(),
     isOver: false,
   }),
+  PointerSensor: class PointerSensor {},
+  useSensor: () => ({}),
+  useSensors: () => [],
 }));
 
 const mockTask = {


### PR DESCRIPTION
close #60

## 概要
- ドラッグ操作を⠿ハンドルからタスクアイテム全体に変更し、操作性を向上
- `PointerSensor` に `activationConstraint: { distance: 5 }` を設定し、クリックとドラッグを区別
- チェックボックスに `onPointerDown` の `stopPropagation` を追加し、ドラッグ誤発火を防止
- DragOverlay からもドラッグハンドルアイコンを削除

## テスト計画
- [ ] タスクアイテム全体をドラッグして日付間の移動ができること
- [ ] チェックボックスのクリック（ステータス切り替え）が正常に動作すること
- [ ] タスクタイトルのクリック（詳細表示）が正常に動作すること
- [ ] ドラッグとクリックが誤認しないこと
- [ ] 既存テストが全て通過すること ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)