### PR TITLE
feat: DragOverlayのビジュアル強化（シャドウ・スケール追加）

### DIFF
--- a/apps/web/src/components/Calendar.tsx
+++ b/apps/web/src/components/Calendar.tsx
@@ -208,9 +208,9 @@ export function Calendar() {
         <DragOverlay>
           {activeTask && (
             <div
-              className={`flex items-center gap-1 rounded px-1 py-0.5 text-sm ${
+              className={`flex items-center gap-1 rounded px-1 py-0.5 text-sm shadow-lg scale-105 ${
                 activeTask.status === "done"
-                  ? "text-gray-400 line-through"
+                  ? "bg-white text-gray-400 line-through"
                   : "bg-blue-100 text-blue-800"
               }`}
             >


### PR DESCRIPTION
close #82

## 概要

- DragOverlay にドロップシャドウ（`shadow-lg`）とスケールアップ（`scale-105`）を追加し、ドラッグ中の「持ち上げている感」を演出
- done 状態のタスクにも `bg-white` を追加し、シャドウが視覚的に効果を発揮するよう調整

## 変更ファイル

- `apps/web/src/components/Calendar.tsx` — DragOverlay のクラス名を変更（2行）

## テストプラン

- [ ] todo 状態のタスクをドラッグし、シャドウとスケールアップが適用されていることを確認
- [ ] done 状態のタスクをドラッグし、白背景 + シャドウ + スケールアップが適用されていることを確認
- [ ] ドラッグ中の要素が周囲のタスクから視覚的に際立っていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)