### PR TITLE
feat: ドラッグ中のカーソルを cursor-grabbing に切り替える

### DIFF
--- a/apps/web/src/components/Calendar.tsx
+++ b/apps/web/src/components/Calendar.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   DndContext,
   DragOverlay,
@@ -92,6 +92,15 @@ export function Calendar() {
       },
     );
   };
+
+  useEffect(() => {
+    if (activeTask) {
+      document.body.style.cursor = "grabbing";
+      return () => {
+        document.body.style.cursor = "";
+      };
+    }
+  }, [activeTask]);
 
   const handleDragStart = (event: DragStartEvent) => {
     const task = event.active.data.current?.task as Task | undefined;

--- a/apps/web/src/components/DraggableTask.tsx
+++ b/apps/web/src/components/DraggableTask.tsx
@@ -23,7 +23,7 @@ export function DraggableTask({
       {...listeners}
       {...attributes}
       onClick={(e) => e.stopPropagation()}
-      className={`flex cursor-grab items-center gap-1 rounded px-1 py-0.5 text-sm touch-none ${
+      className={`flex items-center gap-1 rounded px-1 py-0.5 text-sm touch-none ${isDragging ? "cursor-grabbing" : "cursor-grab"} ${
         task.status === "done"
           ? "text-gray-400 line-through"
           : "bg-blue-100 text-blue-800"


### PR DESCRIPTION
close #83

## 概要

- ドラッグ開始時にカーソルを `cursor-grabbing` に変更し、ドラッグ中であることを視覚的に明示
- ドラッグ終了・キャンセル時にカーソルを `cursor-grab` に復元

## 変更内容

- `DraggableTask.tsx`: `isDragging` 状態に応じて `cursor-grab` / `cursor-grabbing` を切り替え
- `Calendar.tsx`: ドラッグ中に `document.body.style.cursor` を `grabbing` に設定し、要素外でもカーソルが変わるように対応

## テストプラン

- [ ] タスクをドラッグ開始するとカーソルが掴んでいる手（grabbing）に変わることを確認
- [ ] ドラッグ中にカーソルを要素外に移動してもカーソルが grabbing のままであることを確認
- [ ] ドラッグ終了（ドロップ）後にカーソルが元の grab に戻ることを確認
- [ ] ドラッグをキャンセル（Escape キー等）した場合もカーソルが元に戻ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)