### PR TITLE
fix: Dependabot PR でプレビューデプロイをスキップする

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   deploy-preview:
-    if: github.event.action != 'closed' && github.event.pull_request.head.repo.fork == false
+    if: github.event.action != 'closed' && github.event.pull_request.head.repo.fork == false && github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -134,7 +134,7 @@ jobs:
             }
 
   cleanup-preview:
-    if: github.event.action == 'closed' && github.event.pull_request.head.repo.fork == false
+    if: github.event.action == 'closed' && github.event.pull_request.head.repo.fork == false && github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
close #88

## 概要

`preview.yml` の `deploy-preview` および `cleanup-preview` ジョブの `if` 条件に `github.event.pull_request.user.login != 'dependabot[bot]'` を追加し、Dependabot PR ではプレビュー環境のデプロイ・クリーンアップを実行しないようにする。

## 変更内容

- `deploy-preview` ジョブ: `if` 条件に Dependabot チェックを追加
- `cleanup-preview` ジョブ: `if` 条件に Dependabot チェックを追加

## 補足

- issue の実装方針では `github.actor` を使用する案だったが、PR を人間が reopen/close した場合に actor が変わりスキップが効かなくなるため、`github.event.pull_request.user.login` を使用した（Codex レビューによる指摘）

## テストプラン

- [ ] Dependabot PR で preview deploy / cleanup がスキップされること
- [ ] 通常の PR では従来通りプレビュー環境がデプロイされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)