### PR TITLE
feat: CLI タスク操作コマンドを実装

### DIFF
--- a/apps/cli/package-lock.json
+++ b/apps/cli/package-lock.json
@@ -26,6 +26,43 @@
         "typescript-eslint": "^8.31.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",

--- a/apps/cli/package-lock.json
+++ b/apps/cli/package-lock.json
@@ -26,43 +26,6 @@
         "typescript-eslint": "^8.31.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",

--- a/apps/cli/src/api.ts
+++ b/apps/cli/src/api.ts
@@ -1,0 +1,65 @@
+import { consola } from "consola";
+import { readConfig, getApiUrl } from "./config.js";
+
+interface ApiContext {
+  apiUrl: string;
+  token: string;
+}
+
+export async function requireAuth(): Promise<ApiContext> {
+  const config = await readConfig();
+  const token = config.token;
+
+  if (!token) {
+    consola.error("ログインしていません。`tascal login` を実行してください。");
+    process.exit(1);
+  }
+
+  return { apiUrl: getApiUrl(config), token };
+}
+
+export async function apiRequest(
+  ctx: ApiContext,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<Response> {
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${ctx.token}`,
+  };
+
+  if (body !== undefined) {
+    headers["Content-Type"] = "application/json";
+  }
+
+  const res = await fetch(`${ctx.apiUrl}${path}`, {
+    method,
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+
+  if (res.status === 401) {
+    consola.error(
+      "認証エラー: セッションが無効です。`tascal login` で再ログインしてください。",
+    );
+    process.exit(1);
+  }
+
+  return res;
+}
+
+export async function handleApiError(
+  res: Response,
+  fallbackMessage: string,
+): Promise<never> {
+  let message = fallbackMessage;
+  const contentType = res.headers.get("content-type") ?? "";
+  if (contentType.includes("application/json")) {
+    const body = (await res.json()) as { error?: string };
+    if (body.error) {
+      message = body.error;
+    }
+  }
+  consola.error(message);
+  process.exit(1);
+}

--- a/apps/cli/src/commands/add.ts
+++ b/apps/cli/src/commands/add.ts
@@ -1,0 +1,53 @@
+import { defineCommand } from "citty";
+import { consola } from "consola";
+import { requireAuth, apiRequest, handleApiError } from "../api.js";
+
+interface Task {
+  id: string;
+  title: string;
+  date: string;
+}
+
+export default defineCommand({
+  meta: {
+    name: "add",
+    description: "タスクを作成する",
+  },
+  args: {
+    title: {
+      type: "string",
+      description: "タスクのタイトル",
+      required: true,
+    },
+    date: {
+      type: "string",
+      description: "日付 (YYYY-MM-DD)",
+      required: true,
+    },
+    description: {
+      type: "string",
+      description: "タスクの説明",
+    },
+  },
+  async run({ args }) {
+    const ctx = await requireAuth();
+
+    const body: Record<string, string> = {
+      title: args.title,
+      date: args.date,
+    };
+
+    if (args.description) {
+      body.description = args.description;
+    }
+
+    const res = await apiRequest(ctx, "POST", "/api/tasks", body);
+
+    if (!res.ok) {
+      await handleApiError(res, "タスクの作成に失敗しました。");
+    }
+
+    const task = (await res.json()) as Task;
+    consola.success(`タスクを作成しました: ${task.title} (${task.id})`);
+  },
+});

--- a/apps/cli/src/commands/delete.ts
+++ b/apps/cli/src/commands/delete.ts
@@ -1,0 +1,28 @@
+import { defineCommand } from "citty";
+import { consola } from "consola";
+import { requireAuth, apiRequest, handleApiError } from "../api.js";
+
+export default defineCommand({
+  meta: {
+    name: "delete",
+    description: "タスクを削除する",
+  },
+  args: {
+    id: {
+      type: "positional",
+      description: "タスク ID",
+      required: true,
+    },
+  },
+  async run({ args }) {
+    const ctx = await requireAuth();
+
+    const res = await apiRequest(ctx, "DELETE", `/api/tasks/${args.id}`);
+
+    if (!res.ok) {
+      await handleApiError(res, "タスクの削除に失敗しました。");
+    }
+
+    consola.success("タスクを削除しました。");
+  },
+});

--- a/apps/cli/src/commands/done.ts
+++ b/apps/cli/src/commands/done.ts
@@ -1,0 +1,36 @@
+import { defineCommand } from "citty";
+import { consola } from "consola";
+import { requireAuth, apiRequest, handleApiError } from "../api.js";
+
+interface Task {
+  id: string;
+  title: string;
+}
+
+export default defineCommand({
+  meta: {
+    name: "done",
+    description: "タスクのステータスを done に変更する",
+  },
+  args: {
+    id: {
+      type: "positional",
+      description: "タスク ID",
+      required: true,
+    },
+  },
+  async run({ args }) {
+    const ctx = await requireAuth();
+
+    const res = await apiRequest(ctx, "PATCH", `/api/tasks/${args.id}`, {
+      status: "done",
+    });
+
+    if (!res.ok) {
+      await handleApiError(res, "タスクの更新に失敗しました。");
+    }
+
+    const task = (await res.json()) as Task;
+    consola.success(`タスクを完了にしました: ${task.title}`);
+  },
+});

--- a/apps/cli/src/commands/edit.ts
+++ b/apps/cli/src/commands/edit.ts
@@ -1,0 +1,59 @@
+import { defineCommand } from "citty";
+import { consola } from "consola";
+import { requireAuth, apiRequest, handleApiError } from "../api.js";
+
+interface Task {
+  id: string;
+  title: string;
+  date: string;
+}
+
+export default defineCommand({
+  meta: {
+    name: "edit",
+    description: "タスクを更新する",
+  },
+  args: {
+    id: {
+      type: "positional",
+      description: "タスク ID",
+      required: true,
+    },
+    title: {
+      type: "string",
+      description: "タスクのタイトル",
+    },
+    date: {
+      type: "string",
+      description: "日付 (YYYY-MM-DD)",
+    },
+    description: {
+      type: "string",
+      description: "タスクの説明",
+    },
+  },
+  async run({ args }) {
+    const ctx = await requireAuth();
+
+    const body: Record<string, string> = {};
+    if (args.title) body.title = args.title;
+    if (args.date) body.date = args.date;
+    if (args.description !== undefined) body.description = args.description;
+
+    if (Object.keys(body).length === 0) {
+      consola.error(
+        "更新する項目を指定してください (--title, --date, --description)。",
+      );
+      process.exit(1);
+    }
+
+    const res = await apiRequest(ctx, "PATCH", `/api/tasks/${args.id}`, body);
+
+    if (!res.ok) {
+      await handleApiError(res, "タスクの更新に失敗しました。");
+    }
+
+    const task = (await res.json()) as Task;
+    consola.success(`タスクを更新しました: ${task.title} (${task.id})`);
+  },
+});

--- a/apps/cli/src/commands/list.ts
+++ b/apps/cli/src/commands/list.ts
@@ -1,0 +1,67 @@
+import { defineCommand } from "citty";
+import { consola } from "consola";
+import { requireAuth, apiRequest, handleApiError } from "../api.js";
+
+interface Task {
+  id: string;
+  title: string;
+  description: string | null;
+  date: string;
+  status: "todo" | "done";
+}
+
+export default defineCommand({
+  meta: {
+    name: "list",
+    description: "タスク一覧を表示する",
+  },
+  args: {
+    year: {
+      type: "string",
+      description: "年 (デフォルト: 今年)",
+    },
+    month: {
+      type: "string",
+      description: "月 (デフォルト: 今月)",
+    },
+  },
+  async run({ args }) {
+    const ctx = await requireAuth();
+
+    const now = new Date();
+    const year = args.year ? Number(args.year) : now.getFullYear();
+    const month = args.month ? Number(args.month) : now.getMonth() + 1;
+
+    const res = await apiRequest(
+      ctx,
+      "GET",
+      `/api/tasks?year=${year}&month=${month}`,
+    );
+
+    if (!res.ok) {
+      await handleApiError(res, "タスクの取得に失敗しました。");
+    }
+
+    const tasks = (await res.json()) as Task[];
+
+    if (tasks.length === 0) {
+      consola.info(`${year}年${month}月のタスクはありません。`);
+      return;
+    }
+
+    consola.info(`${year}年${month}月のタスク (${tasks.length}件):\n`);
+
+    const sorted = tasks.sort(
+      (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
+    );
+
+    for (const task of sorted) {
+      const status = task.status === "done" ? "✔" : "○";
+      const desc = task.description ? `  ${task.description}` : "";
+      console.log(`  ${status} [${task.date}] ${task.title} (${task.id})`);
+      if (desc) {
+        console.log(`    ${task.description}`);
+      }
+    }
+  },
+});

--- a/apps/cli/src/commands/undo.ts
+++ b/apps/cli/src/commands/undo.ts
@@ -1,0 +1,36 @@
+import { defineCommand } from "citty";
+import { consola } from "consola";
+import { requireAuth, apiRequest, handleApiError } from "../api.js";
+
+interface Task {
+  id: string;
+  title: string;
+}
+
+export default defineCommand({
+  meta: {
+    name: "undo",
+    description: "タスクのステータスを todo に戻す",
+  },
+  args: {
+    id: {
+      type: "positional",
+      description: "タスク ID",
+      required: true,
+    },
+  },
+  async run({ args }) {
+    const ctx = await requireAuth();
+
+    const res = await apiRequest(ctx, "PATCH", `/api/tasks/${args.id}`, {
+      status: "todo",
+    });
+
+    if (!res.ok) {
+      await handleApiError(res, "タスクの更新に失敗しました。");
+    }
+
+    const task = (await res.json()) as Task;
+    consola.success(`タスクを未完了に戻しました: ${task.title}`);
+  },
+});

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -9,6 +9,12 @@ const main = defineCommand({
   subCommands: {
     login: () => import("./commands/login.js").then((m) => m.default),
     logout: () => import("./commands/logout.js").then((m) => m.default),
+    list: () => import("./commands/list.js").then((m) => m.default),
+    add: () => import("./commands/add.js").then((m) => m.default),
+    edit: () => import("./commands/edit.js").then((m) => m.default),
+    delete: () => import("./commands/delete.js").then((m) => m.default),
+    done: () => import("./commands/done.js").then((m) => m.default),
+    undo: () => import("./commands/undo.js").then((m) => m.default),
   },
 });
 


### PR DESCRIPTION
close #72

## 概要

CLI からタスクを操作するサブコマンド（list/add/edit/delete/done/undo）を実装しました。既存の API エンドポイントをそのまま利用しています。

## 変更内容

- **`apps/cli/src/api.ts`**: 認証チェック (`requireAuth`)、API リクエスト (`apiRequest`)、エラーハンドリング (`handleApiError`) の共通処理を追加
- **`tascal list`**: タスク一覧表示（デフォルト今月、`--year`/`--month` オプション対応）
- **`tascal add`**: タスク作成（`--title`、`--date` 必須、`--description` 任意）
- **`tascal edit <id>`**: タスク更新（`--title`、`--date`、`--description` で更新対象指定）
- **`tascal delete <id>`**: タスク削除
- **`tascal done <id>`**: ステータスを done に変更
- **`tascal undo <id>`**: ステータスを todo に戻す
- 共通: 未ログイン時のエラーメッセージ、401 応答時の再ログイン案内、非 JSON レスポンスへの安全なエラーハンドリング

## テストプラン

- [ ] `tascal list` でタスク一覧が表示されること
- [ ] `tascal list --year 2026 --month 4` で指定月のタスクが表示されること
- [ ] `tascal add --title "テスト" --date "2026-04-12"` でタスクが作成されること
- [ ] `tascal edit <id> --title "更新"` でタスクが更新されること
- [ ] `tascal delete <id>` でタスクが削除されること
- [ ] `tascal done <id>` でステータスが done になること
- [ ] `tascal undo <id>` でステータスが todo に戻ること
- [ ] 未ログイン状態で各コマンドを実行するとエラーメッセージが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)