### PR TITLE
fix: npx tascal-cli でコマンドが見つからない問題を修正

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -4,7 +4,8 @@
   "description": "tascal CLI — カレンダータスク管理",
   "type": "module",
   "bin": {
-    "tascal": "dist/src/index.js"
+    "tascal": "dist/src/index.js",
+    "tascal-cli": "dist/src/index.js"
   },
   "files": [
     "dist"

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "consola": "^3.4.2"
       },
       "bin": {
-        "tascal": "dist/src/index.js"
+        "tascal": "dist/src/index.js",
+        "tascal-cli": "dist/src/index.js"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.1",


### PR DESCRIPTION
close #112

## 概要

`npx tascal-cli` 実行時に `sh: tascal: command not found` となる問題を修正。

## 変更内容

- `apps/cli/package.json` の `bin` フィールドに `tascal-cli` エントリを追加
- 既存の `tascal` コマンド名はグローバルインストール時に引き続き利用可能

## テスト計画

- [ ] `npx tascal-cli --help` でヘルプが表示される
- [ ] `npx tascal-cli list` 等のサブコマンドが正常に動作する
- [ ] グローバルインストール時に `tascal` コマンドが引き続き利用可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)