### PR TITLE
fix: release ワークフローの npm publish provenance エラーを修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -16,7 +16,7 @@
     "directory": "apps/cli"
   },
   "publishConfig": {
-    "provenance": true
+    "access": "public"
   },
   "keywords": [
     "cli",


### PR DESCRIPTION
close #117

## 概要

release ワークフローで `tascal-cli` の npm publish が provenance 検証エラー (E422) で失敗する問題を修正。

## 変更内容

- `.github/workflows/release.yml` の permissions から `id-token: write` を削除
- `apps/cli/package.json` の `publishConfig.provenance: true` を `access: public` に変更

## 背景

private リポジトリでは npm の provenance 機能（sigstore による署名）がサポートされていないため、`id-token: write` が設定されていると npm が自動的に provenance 付きで publish しようとして `E422 Unsupported GitHub Actions source repository visibility: "private"` エラーになる。

`publishConfig.provenance: true` も明示的に provenance を要求するため、合わせて削除する。

## テスト計画

- [ ] CI が成功すること
- [ ] main マージ後、release ワークフローで `tascal-cli` が正常に npm publish されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)