### PR TITLE
fix: OIDC認証の id-token: write を復元し provenance のみ無効化

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
close #117

## 概要

#118 で `id-token: write` を削除したが、npm の OIDC 認証にも必要だったため復元する。

provenance エラーの真の原因は `apps/cli/package.json` の `publishConfig.provenance: true` であり、こちらは #118 で既に削除済み。

## 変更内容

- `.github/workflows/release.yml` の permissions に `id-token: write` を復元

## main との差分まとめ（#118 + 本 PR）

| ファイル | 変更 |
|---|---|
| `.github/workflows/release.yml` | `id-token: write` は維持（変更なし） |
| `apps/cli/package.json` | `publishConfig.provenance: true` → `access: public` |

## テスト計画

- [ ] CI が成功すること
- [ ] main マージ後、release ワークフローで `tascal-cli` が正常に npm publish されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)