### PR TITLE
fix: CLI の readPassword が特殊文字を正しく読み取れないバグを修正

### DIFF
--- a/.changeset/fix-cli-password-special-chars.md
+++ b/.changeset/fix-cli-password-special-chars.md
@@ -1,0 +1,5 @@
+---
+"tascal-cli": patch
+---
+
+fix: readPassword が特殊文字を正しく読み取れないバグを修正

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -37,6 +37,7 @@
     "knip": "knip"
   },
   "dependencies": {
+    "@clack/prompts": "^1.2.0",
     "citty": "^0.1.6",
     "consola": "^3.4.2"
   },

--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -1,5 +1,5 @@
 import { defineCommand } from "citty";
-import { createInterface } from "node:readline/promises";
+import { text, password, isCancel } from "@clack/prompts";
 import { consola } from "consola";
 import { readConfig, writeConfig, getApiUrl } from "../config.js";
 
@@ -15,97 +15,52 @@ export default defineCommand({
     },
   },
   async run({ args }) {
+    if (!process.stdin.isTTY) {
+      consola.error("login は対話端末で実行してください。");
+      process.exit(1);
+    }
+
     const config = await readConfig();
     const apiUrl = args["api-url"] ?? getApiUrl(config);
 
-    const rl = createInterface({
-      input: process.stdin,
-      output: process.stderr,
+    const email = await text({ message: "Email" });
+    if (isCancel(email)) {
+      process.exit(1);
+    }
+
+    const pw = await password({ message: "Password" });
+    if (isCancel(pw)) {
+      process.exit(1);
+    }
+
+    consola.start("ログイン中...");
+
+    const res = await fetch(`${apiUrl}/api/auth/sign-in/email`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password: pw }),
     });
 
-    try {
-      const email = await rl.question("Email: ");
-      const password = await readPassword(rl, "Password: ");
-
-      consola.start("ログイン中...");
-
-      const res = await fetch(`${apiUrl}/api/auth/sign-in/email`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email, password }),
-      });
-
-      if (!res.ok) {
-        consola.error(
-          "ログインに失敗しました。メールアドレスまたはパスワードを確認してください。",
-        );
-        process.exit(1);
-      }
-
-      const body = (await res.json()) as { token?: string };
-
-      if (!body.token) {
-        consola.error("トークンを取得できませんでした。");
-        process.exit(1);
-      }
-
-      await writeConfig({
-        ...config,
-        token: body.token,
-        apiUrl,
-      });
-
-      consola.success("ログインしました。");
-    } finally {
-      rl.close();
+    if (!res.ok) {
+      consola.error(
+        "ログインに失敗しました。メールアドレスまたはパスワードを確認してください。",
+      );
+      process.exit(1);
     }
+
+    const body = (await res.json()) as { token?: string };
+
+    if (!body.token) {
+      consola.error("トークンを取得できませんでした。");
+      process.exit(1);
+    }
+
+    await writeConfig({
+      ...config,
+      token: body.token,
+      apiUrl,
+    });
+
+    consola.success("ログインしました。");
   },
 });
-
-async function readPassword(
-  rl: import("node:readline/promises").Interface,
-  prompt: string,
-): Promise<string> {
-  const stdin = process.stdin;
-  const wasRaw = stdin.isRaw;
-
-  if (stdin.isTTY) {
-    stdin.setRawMode(true);
-  }
-
-  process.stderr.write(prompt);
-
-  let password = "";
-
-  return new Promise((resolve) => {
-    const onData = (buf: Buffer) => {
-      const ch = buf.toString("utf-8");
-      for (const c of ch) {
-        if (c === "\r" || c === "\n") {
-          process.stderr.write("\n");
-          stdin.removeListener("data", onData);
-          if (stdin.isTTY) {
-            stdin.setRawMode(wasRaw ?? false);
-          }
-          // Resume normal readline behavior
-          stdin.pause();
-          resolve(password);
-          return;
-        } else if (c === "\u007F" || c === "\b") {
-          // backspace
-          password = password.slice(0, -1);
-        } else if (c === "\u0003") {
-          // Ctrl+C
-          process.stderr.write("\n");
-          process.exit(1);
-        } else {
-          password += c;
-        }
-      }
-    };
-
-    stdin.resume();
-    stdin.on("data", onData);
-    void rl; // rl is kept for the interface but raw mode handles input
-  });
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
 
   apps/cli:
     dependencies:
+      '@clack/prompts':
+        specifier: ^1.2.0
+        version: 1.2.0
       citty:
         specifier: ^0.1.6
         version: 0.1.6
@@ -400,6 +403,12 @@ packages:
 
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
+
+  '@clack/core@1.2.0':
+    resolution: {integrity: sha512-qfxof/3T3t9DPU/Rj3OmcFyZInceqj/NVtO9rwIuJqCUgh32gwPjpFQQp/ben07qKlhpwq7GzfWpST4qdJ5Drg==}
+
+  '@clack/prompts@1.2.0':
+    resolution: {integrity: sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w==}
 
   '@csstools/color-helpers@6.0.2':
     resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
@@ -2337,6 +2346,15 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-string-truncated-width@1.2.1:
+    resolution: {integrity: sha512-Q9acT/+Uu3GwGj+5w/zsGuQjh9O1TyywhIwAxHudtWrgF09nHOPrvTLhQevPbttcxjr/SNN7mJmfOw/B1bXgow==}
+
+  fast-string-width@1.1.0:
+    resolution: {integrity: sha512-O3fwIVIH5gKB38QNbdg+3760ZmGz0SZMgvwJbA1b2TGXceKE6A2cOlfogh1iw8lr049zPyd7YADHy+B7U4W9bQ==}
+
+  fast-wrap-ansi@0.1.6:
+    resolution: {integrity: sha512-HlUwET7a5gqjURj70D5jl7aC3Zmy4weA1SHUfM0JFI0Ptq987NH2TwbBFLoERhfwk+E+eaq4EK3jXoT+R3yp3w==}
+
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
@@ -3005,6 +3023,9 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
@@ -3705,6 +3726,18 @@ snapshots:
       fs-extra: 7.0.1
       human-id: 4.1.3
       prettier: 2.8.8
+
+  '@clack/core@1.2.0':
+    dependencies:
+      fast-wrap-ansi: 0.1.6
+      sisteransi: 1.0.5
+
+  '@clack/prompts@1.2.0':
+    dependencies:
+      '@clack/core': 1.2.0
+      fast-string-width: 1.1.0
+      fast-wrap-ansi: 0.1.6
+      sisteransi: 1.0.5
 
   '@csstools/color-helpers@6.0.2': {}
 
@@ -5299,6 +5332,16 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-string-truncated-width@1.2.1: {}
+
+  fast-string-width@1.1.0:
+    dependencies:
+      fast-string-truncated-width: 1.2.1
+
+  fast-wrap-ansi@0.1.6:
+    dependencies:
+      fast-string-width: 1.1.0
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -5943,6 +5986,8 @@ snapshots:
   siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
+
+  sisteransi@1.0.5: {}
 
   slash@3.0.0: {}
 


### PR DESCRIPTION
close #123

## 概要

- 自前の `readPassword` 関数を削除し、`@clack/prompts` の `password()` に置き換え
- 特殊文字（`*`, `!`, `#`, `$`, `@` 等）を含むパスワードが正しく読み取れるように修正
- 非 TTY 環境での実行時に明示的なエラーメッセージを返すガードを追加
- email 入力も `@clack/prompts` の `text()` に統一し、stdin の競合を回避

## テスト計画

- [ ] 特殊文字（`*`, `!`, `#`, `$`, `@` 等）を含むパスワードでログインできることを確認
- [ ] 通常の英数字パスワードでログインできることを確認
- [ ] Ctrl+C でキャンセルした場合に exit code 1 で終了することを確認
- [ ] 非 TTY 環境（パイプ入力など）でエラーメッセージが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)