### PR TITLE
fix: CLI のデフォルト API URL を本番環境に変更

### DIFF
--- a/.changeset/fix-cli-default-api-url.md
+++ b/.changeset/fix-cli-default-api-url.md
@@ -1,0 +1,5 @@
+---
+"tascal-cli": patch
+---
+
+fix: デフォルト API URL を https://tascal.dev に変更

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 
 const CONFIG_PATH = join(homedir(), ".tascalrc");
 
-const DEFAULT_API_URL = "http://localhost:3000";
+const DEFAULT_API_URL = "https://tascal.dev";
 
 interface Config {
   token?: string;


### PR DESCRIPTION
close #121

## Summary

- CLI の `DEFAULT_API_URL` を `http://localhost:3000` から `https://tascal.dev` に変更
- npm パッケージ利用者が `--api-url` を指定せずに本番環境へ接続可能に
- 環境変数 `TASCAL_API_URL` や `--api-url` による上書きは引き続き可能

## Test plan

- [ ] `npx tascal-cli login` で `--api-url` 未指定時に `https://tascal.dev` へ接続されることを確認
- [ ] `--api-url http://localhost:3000` 指定時にローカル環境へ接続されることを確認
- [ ] `TASCAL_API_URL` 環境変数での上書きが機能することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)