### PR TITLE
fix: bin から tascal エントリを削除し tascal-cli に統一

### DIFF
--- a/.changeset/fix-cli-remove-bin-tascal-entry.md
+++ b/.changeset/fix-cli-remove-bin-tascal-entry.md
@@ -1,0 +1,5 @@
+---
+"tascal-cli": patch
+---
+
+fix: bin から "tascal" エントリを削除し "tascal-cli" のみに統一

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -12,27 +12,27 @@ npm install -g tascal-cli
 
 ```bash
 # Log in to tascal
-tascal login
+tascal-cli login
 
 # List tasks
-tascal list
-tascal list --month 4 --year 2026
+tascal-cli list
+tascal-cli list --month 4 --year 2026
 
 # Add a task
-tascal add --title "Buy milk" --date 2026-04-12
+tascal-cli add --title "Buy milk" --date 2026-04-12
 
 # Edit a task
-tascal edit <id> --title "Buy oat milk"
+tascal-cli edit <id> --title "Buy oat milk"
 
 # Mark as done / undo
-tascal done <id>
-tascal undo <id>
+tascal-cli done <id>
+tascal-cli undo <id>
 
 # Delete a task
-tascal delete <id>
+tascal-cli delete <id>
 
 # Log out
-tascal logout
+tascal-cli logout
 ```
 
 ## Commands

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -4,7 +4,6 @@
   "description": "tascal CLI — カレンダータスク管理",
   "type": "module",
   "bin": {
-    "tascal": "dist/src/index.js",
     "tascal-cli": "dist/src/index.js"
   },
   "files": [


### PR DESCRIPTION
close #120

## 概要

- `apps/cli/package.json` の `bin` フィールドから `"tascal"` エントリを削除し、`"tascal-cli"` のみに統一
- README の使用例コマンドを `tascal` → `tascal-cli` に更新

## 変更内容

- `apps/cli/package.json`: `bin.tascal` エントリを削除
- `apps/cli/README.md`: コマンド例を `tascal-cli` に統一
- changeset 追加（patch）

## テストプラン

- [ ] `pnpm build` が正常に完了する
- [ ] `npx tascal-cli --help` で正常に動作する
- [ ] CI が通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)