### PR TITLE
docs: READMEをエンドユーザー向けの内容に改善する

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,17 +35,3 @@ npm install -g tascal-cli
 | `tascal done <id>` | タスクを完了にする |
 | `tascal undo <id>` | タスクを未完了に戻す |
 
-## 技術スタック
-
-| レイヤー | 技術 |
-|---|---|
-| フロントエンド | React, Vite, TanStack Router / Query, dnd-kit, Tailwind CSS |
-| バックエンド | Hono, Node.js, TypeScript |
-| データベース | PostgreSQL, Drizzle ORM |
-| 認証 | better-auth |
-| CLI | citty |
-| インフラ | Docker, Google Cloud Run |
-
-## 開発
-
-開発環境のセットアップや利用可能なコマンドについては [AGENTS.md](./AGENTS.md) を参照してください。

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # tascal
 
+**タスク管理を、カレンダーから。**
+
 **tascal** (task + calendar) は、カレンダービューでタスクを管理する Web アプリです。
 
 https://tascal.dev/

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # tascal
 
-[![CI](https://github.com/hirokisakabe/tascal/actions/workflows/ci.yml/badge.svg)](https://github.com/hirokisakabe/tascal/actions/workflows/ci.yml)
-
 **tascal** (task + calendar) は、カレンダービューでタスクを管理する Web アプリです。
+
+https://tascal.dev/
 
 日付ごとにタスクを視覚的に把握でき、ドラッグ&ドロップで手軽にスケジュールを調整できます。Web ブラウザに加え、CLI からもタスクを操作できます。
 

--- a/README.md
+++ b/README.md
@@ -2,53 +2,50 @@
 
 [![CI](https://github.com/hirokisakabe/tascal/actions/workflows/ci.yml/badge.svg)](https://github.com/hirokisakabe/tascal/actions/workflows/ci.yml)
 
-## ローカル開発
+**tascal** (task + calendar) は、カレンダービューでタスクを管理する Web アプリです。
 
-### 前提条件
+日付ごとにタスクを視覚的に把握でき、ドラッグ&ドロップで手軽にスケジュールを調整できます。Web ブラウザに加え、CLI からもタスクを操作できます。
 
-- Node.js
-- pnpm (corepack で自動有効化)
-- Docker
+## 主な機能
 
-### セットアップ
+### Web アプリ
 
-```bash
-corepack enable pnpm
-pnpm install
-```
+- **月間カレンダービュー** — タスクをカレンダー上に一覧表示。月の切り替えや「今日に戻る」ボタンで素早くナビゲーション
+- **タスクの作成・編集・削除** — カレンダーの日付をクリックしてタスクを作成。タイトル・説明・日付を編集可能
+- **ドラッグ&ドロップ** — タスクをドラッグして別の日付に移動
+- **完了管理** — チェックボックスでタスクの完了/未完了を切り替え。完了タスクは取り消し線で表示
+- **ユーザー認証** — メールアドレスとパスワードによるアカウント管理
 
-`apps/api/.env.example` を参考に `apps/api/.env` を作成します。
+### CLI (`tascal-cli`)
 
-```bash
-cp apps/api/.env.example apps/api/.env
-# 必要に応じて値を編集
-```
-
-初回のみ DB マイグレーションを実行します。
+npm パッケージ [`tascal-cli`](https://www.npmjs.com/package/tascal-cli) としてインストールできます。
 
 ```bash
-pnpm db:up
-pnpm db:migrate
-pnpm db:down
+npm install -g tascal-cli
 ```
-
-### 開発サーバーの起動
-
-DB（PostgreSQL）・API・Web をまとめて起動します。`Ctrl+C` で全て停止します。
-
-```bash
-pnpm dev
-```
-
-### その他のコマンド
 
 | コマンド | 説明 |
 |---|---|
-| `pnpm db:up` | DB のみ起動（デタッチモード） |
-| `pnpm db:down` | DB を停止 |
-| `pnpm db:migrate` | DB マイグレーション実行 |
-| `pnpm lint` | リンター実行 |
-| `pnpm format` | フォーマッター実行 |
-| `pnpm typecheck` | 型チェック |
-| `pnpm test` | テスト実行 |
-| `pnpm build` | ビルド |
+| `tascal login` | ログイン |
+| `tascal logout` | ログアウト |
+| `tascal list` | タスク一覧の表示（年月指定可） |
+| `tascal add` | タスクの作成 |
+| `tascal edit <id>` | タスクの編集 |
+| `tascal delete <id>` | タスクの削除 |
+| `tascal done <id>` | タスクを完了にする |
+| `tascal undo <id>` | タスクを未完了に戻す |
+
+## 技術スタック
+
+| レイヤー | 技術 |
+|---|---|
+| フロントエンド | React, Vite, TanStack Router / Query, dnd-kit, Tailwind CSS |
+| バックエンド | Hono, Node.js, TypeScript |
+| データベース | PostgreSQL, Drizzle ORM |
+| 認証 | better-auth |
+| CLI | citty |
+| インフラ | Docker, Google Cloud Run |
+
+## 開発
+
+開発環境のセットアップや利用可能なコマンドについては [AGENTS.md](./AGENTS.md) を参照してください。


### PR DESCRIPTION
## Summary

- README を開発者向けからエンドユーザー向けの内容に刷新
- tascal のコンセプト、Web アプリ・CLI の主な機能、技術スタックを記載
- 開発環境のセットアップ手順は AGENTS.md への参照に置き換え

## Test plan

- [ ] README.md の表示が GitHub 上で正しくレンダリングされることを確認
- [ ] AGENTS.md へのリンクが正しく機能することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)