### PR TITLE
feat: 削除確認をカスタムダイアログに置き換える

### DIFF
--- a/apps/web/src/components/DeleteConfirmDialog.tsx
+++ b/apps/web/src/components/DeleteConfirmDialog.tsx
@@ -1,0 +1,56 @@
+import {
+  Dialog,
+  DialogBackdrop,
+  DialogPanel,
+  DialogTitle,
+} from "@headlessui/react";
+
+type DeleteConfirmDialogProps = {
+  open: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+};
+
+export function DeleteConfirmDialog({
+  open,
+  onConfirm,
+  onCancel,
+}: DeleteConfirmDialogProps) {
+  return (
+    <Dialog open={open} onClose={onCancel} className="relative z-50">
+      <DialogBackdrop
+        transition
+        className="fixed inset-0 bg-black/50 transition-opacity duration-200 ease-out data-[closed]:opacity-0"
+      />
+      <div className="fixed inset-0 flex items-center justify-center">
+        <DialogPanel
+          transition
+          className="w-full max-w-sm rounded-lg bg-white p-6 shadow-xl transition duration-200 ease-out data-[closed]:scale-95 data-[closed]:opacity-0"
+        >
+          <DialogTitle className="mb-2 text-lg font-bold text-gray-900">
+            タスクの削除
+          </DialogTitle>
+          <p className="mb-6 text-sm text-gray-600">
+            このタスクを削除しますか？この操作は取り消せません。
+          </p>
+          <div className="flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={onCancel}
+              className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm text-gray-700 hover:bg-gray-50"
+            >
+              キャンセル
+            </button>
+            <button
+              type="button"
+              onClick={onConfirm}
+              className="rounded-md bg-red-600 px-4 py-2 text-sm text-white hover:bg-red-700"
+            >
+              削除
+            </button>
+          </div>
+        </DialogPanel>
+      </div>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/TaskDetailModal.tsx
+++ b/apps/web/src/components/TaskDetailModal.tsx
@@ -1,7 +1,8 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import type { Task } from "../types/task";
 import { useUpdateTask, useDeleteTask } from "../hooks/useTasks";
 import { ModalWrapper } from "./ModalWrapper";
+import { DeleteConfirmDialog } from "./DeleteConfirmDialog";
 
 type TaskDetailModalProps = {
   open: boolean;
@@ -24,6 +25,11 @@ export function TaskDetailModal({
   const [description, setDescription] = useState(task.description ?? "");
   const [date, setDate] = useState(task.date);
   const [error, setError] = useState<string | null>(null);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
+  useEffect(() => {
+    if (!open) setShowDeleteConfirm(false);
+  }, [open]);
 
   const updateTaskMutation = useUpdateTask(year, month);
   const deleteTaskMutation = useDeleteTask(year, month);
@@ -54,8 +60,11 @@ export function TaskDetailModal({
   };
 
   const handleDelete = () => {
-    if (!window.confirm("このタスクを削除しますか？")) return;
+    setShowDeleteConfirm(true);
+  };
 
+  const handleDeleteConfirm = () => {
+    setShowDeleteConfirm(false);
     setError(null);
     deleteTaskMutation.mutate(task.id, {
       onSuccess: () => onUpdated(),
@@ -64,88 +73,95 @@ export function TaskDetailModal({
   };
 
   return (
-    <ModalWrapper open={open} onClose={onClose}>
-      <h3 className="mb-4 text-lg font-bold text-gray-900">タスクの詳細</h3>
-      {error && (
-        <div className="mb-3 rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">
-          {error}
-        </div>
-      )}
-      <form onSubmit={handleSave} className="space-y-4">
-        <div>
-          <label
-            htmlFor="detail-title"
-            className="mb-1 block text-sm font-medium text-gray-700"
-          >
-            タイトル <span className="text-red-500">*</span>
-          </label>
-          <input
-            id="detail-title"
-            type="text"
-            value={title}
-            onChange={(e) => setTitle(e.target.value)}
-            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-            required
-          />
-        </div>
-        <div>
-          <label
-            htmlFor="detail-description"
-            className="mb-1 block text-sm font-medium text-gray-700"
-          >
-            説明
-          </label>
-          <textarea
-            id="detail-description"
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
-            rows={3}
-            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-          />
-        </div>
-        <div>
-          <label
-            htmlFor="detail-date"
-            className="mb-1 block text-sm font-medium text-gray-700"
-          >
-            日付
-          </label>
-          <input
-            id="detail-date"
-            type="date"
-            value={date}
-            onChange={(e) => setDate(e.target.value)}
-            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-            required
-          />
-        </div>
-        <div className="flex justify-between">
-          <button
-            type="button"
-            onClick={handleDelete}
-            disabled={busy}
-            className="rounded-md bg-red-600 px-4 py-2 text-sm text-white hover:bg-red-700 disabled:opacity-50"
-          >
-            {deleting ? "削除中..." : "削除"}
-          </button>
-          <div className="flex gap-2">
+    <>
+      <ModalWrapper open={open} onClose={onClose}>
+        <h3 className="mb-4 text-lg font-bold text-gray-900">タスクの詳細</h3>
+        {error && (
+          <div className="mb-3 rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">
+            {error}
+          </div>
+        )}
+        <form onSubmit={handleSave} className="space-y-4">
+          <div>
+            <label
+              htmlFor="detail-title"
+              className="mb-1 block text-sm font-medium text-gray-700"
+            >
+              タイトル <span className="text-red-500">*</span>
+            </label>
+            <input
+              id="detail-title"
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              required
+            />
+          </div>
+          <div>
+            <label
+              htmlFor="detail-description"
+              className="mb-1 block text-sm font-medium text-gray-700"
+            >
+              説明
+            </label>
+            <textarea
+              id="detail-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              rows={3}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            />
+          </div>
+          <div>
+            <label
+              htmlFor="detail-date"
+              className="mb-1 block text-sm font-medium text-gray-700"
+            >
+              日付
+            </label>
+            <input
+              id="detail-date"
+              type="date"
+              value={date}
+              onChange={(e) => setDate(e.target.value)}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              required
+            />
+          </div>
+          <div className="flex justify-between">
             <button
               type="button"
-              onClick={onClose}
-              className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm text-gray-700 hover:bg-gray-50"
+              onClick={handleDelete}
+              disabled={busy}
+              className="rounded-md bg-red-600 px-4 py-2 text-sm text-white hover:bg-red-700 disabled:opacity-50"
             >
-              キャンセル
+              {deleting ? "削除中..." : "削除"}
             </button>
-            <button
-              type="submit"
-              disabled={busy || !title.trim()}
-              className="rounded-md bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
-            >
-              {saving ? "保存中..." : "保存"}
-            </button>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={onClose}
+                className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm text-gray-700 hover:bg-gray-50"
+              >
+                キャンセル
+              </button>
+              <button
+                type="submit"
+                disabled={busy || !title.trim()}
+                className="rounded-md bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
+              >
+                {saving ? "保存中..." : "保存"}
+              </button>
+            </div>
           </div>
-        </div>
-      </form>
-    </ModalWrapper>
+        </form>
+      </ModalWrapper>
+      <DeleteConfirmDialog
+        open={showDeleteConfirm}
+        onConfirm={handleDeleteConfirm}
+        onCancel={() => setShowDeleteConfirm(false)}
+      />
+    </>
   );
 }

--- a/apps/web/src/components/__tests__/Calendar.test.tsx
+++ b/apps/web/src/components/__tests__/Calendar.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { screen, waitFor } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Calendar } from "../Calendar";
 import { renderWithQueryClient } from "../../test/helpers";
@@ -249,7 +249,6 @@ describe("Calendar", () => {
   it("詳細モーダルからタスクを削除できる", async () => {
     mockFetchTasks.mockResolvedValue([mockTask]);
     mockDeleteTask.mockResolvedValue(undefined);
-    vi.spyOn(window, "confirm").mockReturnValue(true);
 
     const user = userEvent.setup();
     renderWithQueryClient(<Calendar />);
@@ -262,6 +261,11 @@ describe("Calendar", () => {
     expect(screen.getByText("タスクの詳細")).toBeInTheDocument();
 
     await user.click(screen.getByText("削除"));
+
+    const confirmDialog = screen.getByRole("dialog", { name: "タスクの削除" });
+    await user.click(
+      within(confirmDialog).getByRole("button", { name: "削除" }),
+    );
 
     await waitFor(() => {
       expect(mockDeleteTask).toHaveBeenCalledWith(mockTask.id);

--- a/apps/web/src/components/__tests__/TaskDetailModal.test.tsx
+++ b/apps/web/src/components/__tests__/TaskDetailModal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { screen, waitFor } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { TaskDetailModal } from "../TaskDetailModal";
 import { renderWithQueryClient } from "../../test/helpers";
@@ -71,14 +71,23 @@ describe("TaskDetailModal", () => {
     });
   });
 
-  it("削除ボタンで確認後に削除できる", async () => {
+  it("削除ボタンで確認ダイアログが表示され、確認後に削除できる", async () => {
     mockDeleteTask.mockResolvedValue(undefined);
-    vi.spyOn(window, "confirm").mockReturnValue(true);
 
     const user = userEvent.setup();
     renderWithQueryClient(<TaskDetailModal {...defaultProps} />);
 
     await user.click(screen.getByText("削除"));
+
+    expect(screen.getByText("タスクの削除")).toBeInTheDocument();
+    expect(
+      screen.getByText("このタスクを削除しますか？この操作は取り消せません。"),
+    ).toBeInTheDocument();
+
+    const confirmDialog = screen.getByRole("dialog", { name: "タスクの削除" });
+    await user.click(
+      within(confirmDialog).getByRole("button", { name: "削除" }),
+    );
 
     await waitFor(() => {
       expect(mockDeleteTask).toHaveBeenCalledWith("task-1");
@@ -88,14 +97,22 @@ describe("TaskDetailModal", () => {
     });
   });
 
-  it("削除確認でキャンセルすると削除されない", async () => {
-    vi.spyOn(window, "confirm").mockReturnValue(false);
-
+  it("削除確認ダイアログでキャンセルすると削除されない", async () => {
     const user = userEvent.setup();
     renderWithQueryClient(<TaskDetailModal {...defaultProps} />);
 
     await user.click(screen.getByText("削除"));
 
+    expect(screen.getByText("タスクの削除")).toBeInTheDocument();
+
+    const confirmDialog = screen.getByRole("dialog", { name: "タスクの削除" });
+    await user.click(
+      within(confirmDialog).getByRole("button", { name: "キャンセル" }),
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText("タスクの削除")).not.toBeInTheDocument();
+    });
     expect(mockDeleteTask).not.toHaveBeenCalled();
   });
 
@@ -124,12 +141,16 @@ describe("TaskDetailModal", () => {
 
   it("削除失敗時にエラーメッセージを表示する", async () => {
     mockDeleteTask.mockRejectedValue(new Error("削除失敗"));
-    vi.spyOn(window, "confirm").mockReturnValue(true);
 
     const user = userEvent.setup();
     renderWithQueryClient(<TaskDetailModal {...defaultProps} />);
 
     await user.click(screen.getByText("削除"));
+
+    const confirmDialog = screen.getByRole("dialog", { name: "タスクの削除" });
+    await user.click(
+      within(confirmDialog).getByRole("button", { name: "削除" }),
+    );
 
     await waitFor(() => {
       expect(


### PR DESCRIPTION
close #105

## Summary

- タスク削除時の `window.confirm()` を Headless UI ベースのカスタム確認ダイアログ（`DeleteConfirmDialog`）に置き換え
- `DialogTitle` を使用してアクセシビリティ対応（`role="dialog"` + `aria-labelledby`）
- 親モーダル閉時に確認ダイアログの状態をリセットする `useEffect` を追加
- 関連するテストを `within` を使ったロバストな取得方法に更新

## Test plan

- [x] 削除ボタンクリックでカスタム確認ダイアログが表示される
- [x] 確認ダイアログの「削除」ボタンでタスクが削除される
- [x] 確認ダイアログの「キャンセル」ボタンでダイアログが閉じ、削除されない
- [x] Escape キーでダイアログが閉じる（Headless UI Dialog の標準機能）
- [x] 削除失敗時にエラーメッセージが表示される
- [x] 全テスト通過（API + Web）
- [x] lint / format / typecheck / knip 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)