### PR TITLE
fix: CLI login の CSRF エラーを修正

### DIFF
--- a/.changeset/fix-cli-login-csrf.md
+++ b/.changeset/fix-cli-login-csrf.md
@@ -1,0 +1,5 @@
+---
+"tascal-cli": patch
+---
+
+CLI login で Origin ヘッダーを付与し、better-auth の CSRF 保護による 403 エラーを修正。エラー時のログにステータスコードとレスポンスボディを含めるよう改善。

--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -37,14 +37,27 @@ export default defineCommand({
 
     const res = await fetch(`${apiUrl}/api/auth/sign-in/email`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        Origin: new URL(apiUrl).origin,
+      },
       body: JSON.stringify({ email, password: pw }),
     });
 
     if (!res.ok) {
-      consola.error(
-        "ログインに失敗しました。メールアドレスまたはパスワードを確認してください。",
-      );
+      let detail = "";
+      try {
+        const raw = await res.text();
+        const contentType = res.headers.get("content-type") ?? "";
+        if (contentType.includes("application/json")) {
+          detail = JSON.stringify(JSON.parse(raw));
+        } else {
+          detail = raw;
+        }
+      } catch {
+        detail = "(レスポンスの読み取りに失敗)";
+      }
+      consola.error(`ログインに失敗しました (${res.status}): ${detail}`);
       process.exit(1);
     }
 


### PR DESCRIPTION
close #130

## Summary

- CLI の `login` コマンドで `Origin` ヘッダーを明示的に追加し、better-auth の CSRF 保護による 403 エラーを修正
- `new URL(apiUrl).origin` で Origin を正規化し、末尾スラッシュやパス付き URL でも正しく動作するよう対応
- エラー時のログにステータスコードとレスポンスボディを含め、原因の切り分けを容易に

## 変更内容

### `apps/cli/src/commands/login.ts`

- fetch リクエストに `Origin` ヘッダーを追加（Node.js fetch は自動付与しないため）
- `!res.ok` 時のエラーメッセージにステータスコードとレスポンス詳細を表示
- レスポンス読み取り失敗時のフォールバック処理を追加

## Test plan

- [ ] `tascal login` で正しい認証情報を入力し、ログインが成功することを確認
- [ ] 誤った認証情報でログインした場合、ステータスコードとエラー詳細がログに表示されることを確認
- [ ] `--api-url` に末尾スラッシュ付き URL を指定した場合でも正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)