### PR TITLE
カレンダーセルの幅を拡張しUIを改善

### DIFF
--- a/apps/web/src/components/Calendar.tsx
+++ b/apps/web/src/components/Calendar.tsx
@@ -155,7 +155,7 @@ export function Calendar() {
   const error = queryError ? "タスクの取得に失敗しました" : mutationError;
 
   return (
-    <div className="mx-auto max-w-7xl">
+    <div className="mx-auto max-w-[1600px]">
       <div className="mb-4 flex items-center justify-between">
         <h2 className="text-xl font-bold text-gray-900">
           {year}年{month}月

--- a/apps/web/src/components/Calendar.tsx
+++ b/apps/web/src/components/Calendar.tsx
@@ -156,7 +156,7 @@ export function Calendar() {
 
   return (
     <div className="mx-auto max-w-[1600px]">
-      <div className="mb-4 flex items-center justify-between">
+      <div className="mb-2 flex items-center justify-between">
         <h2 className="text-xl font-bold text-gray-900">
           {year}年{month}月
         </h2>
@@ -164,21 +164,21 @@ export function Calendar() {
           <button
             type="button"
             onClick={goToToday}
-            className="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50"
+            className="rounded-md border border-gray-300 bg-white px-2 py-1 text-xs text-gray-700 hover:bg-gray-50"
           >
             今日
           </button>
           <button
             type="button"
             onClick={goToPrevMonth}
-            className="rounded-md border border-gray-300 bg-white px-2.5 py-1.5 text-sm text-gray-700 hover:bg-gray-50"
+            className="rounded-md border border-gray-300 bg-white px-2 py-1 text-xs text-gray-700 hover:bg-gray-50"
           >
             ←
           </button>
           <button
             type="button"
             onClick={goToNextMonth}
-            className="rounded-md border border-gray-300 bg-white px-2.5 py-1.5 text-sm text-gray-700 hover:bg-gray-50"
+            className="rounded-md border border-gray-300 bg-white px-2 py-1 text-xs text-gray-700 hover:bg-gray-50"
           >
             →
           </button>
@@ -204,7 +204,7 @@ export function Calendar() {
             {WEEKDAY_LABELS.map((label, i) => (
               <div
                 key={label}
-                className={`border-b border-gray-200 py-2 text-center text-sm font-medium ${
+                className={`border-b border-gray-200 py-1 text-center text-sm font-medium ${
                   i === 5
                     ? "text-blue-500"
                     : i === 6
@@ -252,7 +252,7 @@ export function Calendar() {
                 readOnly
                 className="h-3.5 w-3.5 shrink-0"
               />
-              <span className="truncate">{activeTask.title}</span>
+              <span className="break-all">{activeTask.title}</span>
             </div>
           )}
         </DragOverlay>

--- a/apps/web/src/components/CalendarDayCell.tsx
+++ b/apps/web/src/components/CalendarDayCell.tsx
@@ -4,7 +4,7 @@ import type { Task } from "../types/task";
 import { isToday, formatDateKey } from "../utils/calendar";
 import { DraggableTask } from "./DraggableTask";
 
-const MAX_VISIBLE_TASKS = 3;
+const MAX_VISIBLE_TASKS = 4;
 
 type CalendarDayCellProps = {
   date: Date;
@@ -66,11 +66,11 @@ export function CalendarDayCell({
         }
       }}
       aria-label={`${dateKey}にタスクを追加`}
-      className={`group relative min-h-32 cursor-pointer border border-gray-200 p-1.5 ${
+      className={`group relative min-h-40 cursor-pointer border-[0.5px] border-gray-200 p-1.5 ${
         !isCurrentMonth ? "bg-gray-50" : "bg-white"
       } ${isOver ? "bg-blue-50 ring-2 ring-blue-400 ring-inset" : isExpanded ? "z-10 shadow-lg ring-2 ring-blue-300" : ""}`}
     >
-      <div className="mb-1 flex items-center justify-center">
+      <div className="mb-1 flex items-center">
         <span
           className={`inline-flex h-7 w-7 items-center justify-center rounded-full text-sm ${
             today
@@ -83,7 +83,7 @@ export function CalendarDayCell({
           {date.getDate()}
         </span>
       </div>
-      <div className="space-y-0.5">
+      <div className="space-y-1">
         {visibleTasks.map((task) => (
           <DraggableTask
             key={task.id}

--- a/apps/web/src/components/DraggableTask.tsx
+++ b/apps/web/src/components/DraggableTask.tsx
@@ -23,7 +23,7 @@ export function DraggableTask({
       {...listeners}
       {...attributes}
       onClick={(e) => e.stopPropagation()}
-      className={`flex items-center gap-1 rounded px-1 py-0.5 text-sm touch-none ${isDragging ? "cursor-grabbing" : "cursor-grab"} ${
+      className={`flex items-center gap-1 rounded px-1 py-0 text-xs leading-tight min-h-[2.5rem] touch-none ${isDragging ? "cursor-grabbing" : "cursor-grab"} ${
         isDragging
           ? "border border-dashed border-gray-300 bg-gray-100 text-transparent [&_input]:invisible"
           : task.status === "done"
@@ -40,7 +40,7 @@ export function DraggableTask({
         className="h-3.5 w-3.5 shrink-0 cursor-pointer"
       />
       <span
-        className="cursor-pointer truncate"
+        className="cursor-pointer break-all line-clamp-2"
         onClick={() => onTaskClick(task)}
       >
         {task.title}

--- a/apps/web/src/components/__tests__/Calendar.test.tsx
+++ b/apps/web/src/components/__tests__/Calendar.test.tsx
@@ -405,10 +405,10 @@ describe("Calendar", () => {
     });
   });
 
-  it("4件以上タスクがある日セルで「+N件」をクリックするとセルが展開され全タスクが表示される", async () => {
+  it("5件以上タスクがある日セルで「+N件」をクリックするとセルが展開され全タスクが表示される", async () => {
     const now = new Date();
     const dateKey = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-15`;
-    const manyTasks = Array.from({ length: 5 }, (_, i) => ({
+    const manyTasks = Array.from({ length: 6 }, (_, i) => ({
       ...mockTask,
       id: `task-${i + 1}`,
       title: `タスク${i + 1}`,
@@ -431,8 +431,8 @@ describe("Calendar", () => {
     await user.click(showMoreButton);
 
     await waitFor(() => {
-      expect(screen.getByText("タスク4")).toBeInTheDocument();
       expect(screen.getByText("タスク5")).toBeInTheDocument();
+      expect(screen.getByText("タスク6")).toBeInTheDocument();
     });
 
     // 「折りたたむ」ボタンが表示される
@@ -445,7 +445,7 @@ describe("Calendar", () => {
   it("展開されたセルの「折りたたむ」をクリックするとセルが折りたたまれる", async () => {
     const now = new Date();
     const dateKey = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-15`;
-    const manyTasks = Array.from({ length: 5 }, (_, i) => ({
+    const manyTasks = Array.from({ length: 6 }, (_, i) => ({
       ...mockTask,
       id: `task-${i + 1}`,
       title: `タスク${i + 1}`,
@@ -471,8 +471,8 @@ describe("Calendar", () => {
     await user.click(screen.getByText("折りたたむ"));
 
     await waitFor(() => {
-      expect(screen.queryByText("タスク4")).not.toBeInTheDocument();
       expect(screen.queryByText("タスク5")).not.toBeInTheDocument();
+      expect(screen.queryByText("タスク6")).not.toBeInTheDocument();
       expect(screen.getByText("+2 件")).toBeInTheDocument();
     });
   });
@@ -480,14 +480,14 @@ describe("Calendar", () => {
   it("展開されたセルでタスクをクリックすると詳細モーダルが開く", async () => {
     const now = new Date();
     const dateKey = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-15`;
-    const manyTasks = Array.from({ length: 4 }, (_, i) => ({
+    const manyTasks = Array.from({ length: 5 }, (_, i) => ({
       ...mockTask,
       id: `task-${i + 1}`,
       title: `タスク${i + 1}`,
       date: dateKey,
     }));
     mockFetchTasks.mockResolvedValue(manyTasks);
-    mockUpdateTask.mockResolvedValue({ ...manyTasks[3], title: "更新タスク" });
+    mockUpdateTask.mockResolvedValue({ ...manyTasks[4], title: "更新タスク" });
 
     const user = userEvent.setup();
     renderWithQueryClient(<Calendar />);
@@ -500,11 +500,11 @@ describe("Calendar", () => {
     await user.click(screen.getByText("+1 件"));
 
     await waitFor(() => {
-      expect(screen.getByText("タスク4")).toBeInTheDocument();
+      expect(screen.getByText("タスク5")).toBeInTheDocument();
     });
 
-    // タスク4をクリック → 詳細モーダルが開く
-    await user.click(screen.getByText("タスク4"));
+    // タスク5をクリック → 詳細モーダルが開く
+    await user.click(screen.getByText("タスク5"));
 
     await waitFor(() => {
       expect(screen.getByText("タスクの詳細")).toBeInTheDocument();

--- a/apps/web/src/routes/_authenticated/index.tsx
+++ b/apps/web/src/routes/_authenticated/index.tsx
@@ -18,7 +18,7 @@ function HomePage() {
   return (
     <div className="min-h-screen bg-gray-100">
       <header className="border-b border-gray-200 bg-white px-4 py-3">
-        <div className="mx-auto flex max-w-7xl items-center justify-between">
+        <div className="mx-auto flex max-w-[1600px] items-center justify-between">
           <h1 className="text-lg font-bold text-gray-900">tascal</h1>
           <div className="flex items-center gap-4">
             <span className="text-sm text-gray-600">{session?.user?.name}</span>

--- a/apps/web/src/routes/_authenticated/index.tsx
+++ b/apps/web/src/routes/_authenticated/index.tsx
@@ -17,7 +17,7 @@ function HomePage() {
 
   return (
     <div className="min-h-screen bg-gray-100">
-      <header className="border-b border-gray-200 bg-white px-4 py-3">
+      <header className="border-b border-gray-200 bg-white px-4 py-1.5">
         <div className="mx-auto flex max-w-[1600px] items-center justify-between">
           <h1 className="text-lg font-bold text-gray-900">tascal</h1>
           <div className="flex items-center gap-4">


### PR DESCRIPTION
## Summary

- カレンダーの最大幅を `max-w-7xl` (1280px) から `max-w-[1600px]` に変更し、各セルに日本語約15文字が表示可能に
- ヘッダーの最大幅も同様に統一し、レイアウトの一貫性を維持

## Test plan

- [ ] カレンダー画面で各セルの幅が広がっていることを確認
- [ ] 長いタスク名（日本語15文字程度）が従来より多く表示されることを確認
- [ ] ヘッダーとカレンダーの幅が揃っていることを確認
- [ ] レスポンシブ表示（画面幅1600px未満）でもレイアウトが崩れないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)