### PR TITLE
feat: ログイン済みユーザーを認証ページから /app へリダイレクト

### DIFF
--- a/apps/web/src/routes/__tests__/auth-redirect.test.ts
+++ b/apps/web/src/routes/__tests__/auth-redirect.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { isRedirect } from "@tanstack/react-router";
+
+const mockGetSession = vi.fn();
+
+vi.mock("../../auth-client", () => ({
+  authClient: {
+    getSession: (...args: unknown[]) => mockGetSession(...args) as unknown,
+  },
+}));
+
+describe("/login beforeLoad", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockGetSession.mockReset();
+  });
+
+  it("ログイン済みの場合 /app にリダイレクトする", async () => {
+    mockGetSession.mockResolvedValue({
+      data: { user: { id: "1" }, session: {} },
+    });
+
+    const { Route } = await import("../login");
+    const beforeLoad = Route.options.beforeLoad!;
+
+    try {
+      await (beforeLoad as () => Promise<void>)();
+      expect.fail("redirect が throw されるべき");
+    } catch (e) {
+      expect(isRedirect(e)).toBe(true);
+      expect((e as { options: { to: string } }).options.to).toBe("/app");
+    }
+  });
+
+  it("未ログインの場合リダイレクトしない", async () => {
+    mockGetSession.mockResolvedValue({ data: null });
+
+    const { Route } = await import("../login");
+    const beforeLoad = Route.options.beforeLoad!;
+
+    await expect(
+      (beforeLoad as () => Promise<void>)(),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("/signup beforeLoad", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockGetSession.mockReset();
+  });
+
+  it("ログイン済みの場合 /app にリダイレクトする", async () => {
+    mockGetSession.mockResolvedValue({
+      data: { user: { id: "1" }, session: {} },
+    });
+
+    const { Route } = await import("../signup");
+    const beforeLoad = Route.options.beforeLoad!;
+
+    try {
+      await (beforeLoad as () => Promise<void>)();
+      expect.fail("redirect が throw されるべき");
+    } catch (e) {
+      expect(isRedirect(e)).toBe(true);
+      expect((e as { options: { to: string } }).options.to).toBe("/app");
+    }
+  });
+
+  it("未ログインの場合リダイレクトしない", async () => {
+    mockGetSession.mockResolvedValue({ data: null });
+
+    const { Route } = await import("../signup");
+    const beforeLoad = Route.options.beforeLoad!;
+
+    await expect(
+      (beforeLoad as () => Promise<void>)(),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -1,8 +1,15 @@
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { createFileRoute, redirect, useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
 import { authClient } from "../auth-client";
 
 export const Route = createFileRoute("/login")({
+  beforeLoad: async () => {
+    const { data: session } = await authClient.getSession();
+    if (session) {
+      // eslint-disable-next-line @typescript-eslint/only-throw-error -- TanStack Router requires throwing redirect()
+      throw redirect({ to: "/app" });
+    }
+  },
   component: LoginPage,
 });
 

--- a/apps/web/src/routes/signup.tsx
+++ b/apps/web/src/routes/signup.tsx
@@ -1,8 +1,15 @@
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { createFileRoute, redirect, useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
 import { authClient } from "../auth-client";
 
 export const Route = createFileRoute("/signup")({
+  beforeLoad: async () => {
+    const { data: session } = await authClient.getSession();
+    if (session) {
+      // eslint-disable-next-line @typescript-eslint/only-throw-error -- TanStack Router requires throwing redirect()
+      throw redirect({ to: "/app" });
+    }
+  },
   component: SignupPage,
 });
 


### PR DESCRIPTION
close #138

## 概要

- ログイン済みユーザーが `/login` や `/signup` にアクセスした際、`/app` へ自動リダイレクトするガードを追加
- `/app` の既存パターン（`beforeLoad` + `authClient.getSession()`）と同じ手法を使用
- `beforeLoad` のリダイレクト動作を検証するテストを追加

## 変更内容

- `apps/web/src/routes/login.tsx`: `beforeLoad` でセッション確認、認証済みなら `/app` へリダイレクト
- `apps/web/src/routes/signup.tsx`: 同上
- `apps/web/src/routes/__tests__/auth-redirect.test.ts`: 認証済み/未認証時のリダイレクト動作テスト（4件）

## テストプラン

- [x] lint / format / typecheck パス
- [x] 全テスト（40件 Web + 19件 API）パス
- [ ] ログイン済み状態で `/login` にアクセス → `/app` にリダイレクトされることを確認
- [ ] ログイン済み状態で `/signup` にアクセス → `/app` にリダイレクトされることを確認
- [ ] 未ログイン状態で `/login`, `/signup` にアクセス → 従来通りフォームが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)