### PR TITLE
feat: カラースキーマを Dusty Indigo テーマに変更

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -8,7 +8,7 @@
       name="description"
       content="tascal はシンプルなタスク管理アプリです。カレンダー上でタスクをドラッグ&ドロップして直感的にスケジュール管理できます。"
     />
-    <meta name="theme-color" content="#2563eb" />
+    <meta name="theme-color" content="#4a4181" />
     <!-- OGP -->
     <meta property="og:title" content="tascal" />
     <meta

--- a/apps/web/src/components/Calendar.tsx
+++ b/apps/web/src/components/Calendar.tsx
@@ -157,28 +157,28 @@ export function Calendar() {
   return (
     <div className="mx-auto max-w-[1600px]">
       <div className="mb-2 flex items-center justify-between">
-        <h2 className="text-xl font-bold text-gray-900">
+        <h2 className="text-xl font-bold text-on-surface">
           {year}年{month}月
         </h2>
         <div className="flex items-center gap-2">
           <button
             type="button"
             onClick={goToToday}
-            className="rounded-md border border-gray-300 bg-white px-2 py-1 text-xs text-gray-700 hover:bg-gray-50"
+            className="rounded-md border border-border bg-white px-2 py-1 text-xs text-on-surface-secondary hover:bg-surface-hover"
           >
             今日
           </button>
           <button
             type="button"
             onClick={goToPrevMonth}
-            className="rounded-md border border-gray-300 bg-white px-2 py-1 text-xs text-gray-700 hover:bg-gray-50"
+            className="rounded-md border border-border bg-white px-2 py-1 text-xs text-on-surface-secondary hover:bg-surface-hover"
           >
             ←
           </button>
           <button
             type="button"
             onClick={goToNextMonth}
-            className="rounded-md border border-gray-300 bg-white px-2 py-1 text-xs text-gray-700 hover:bg-gray-50"
+            className="rounded-md border border-border bg-white px-2 py-1 text-xs text-on-surface-secondary hover:bg-surface-hover"
           >
             →
           </button>
@@ -186,7 +186,7 @@ export function Calendar() {
       </div>
 
       {error && (
-        <div className="mb-4 rounded-md bg-red-50 px-4 py-3 text-sm text-red-700">
+        <div className="mb-4 rounded-md bg-danger-light px-4 py-3 text-sm text-danger">
           {error}
         </div>
       )}
@@ -198,18 +198,18 @@ export function Calendar() {
         onDragCancel={handleDragCancel}
       >
         <div
-          className={`overflow-hidden rounded-lg border border-gray-200 ${isLoading ? "opacity-50" : ""}`}
+          className={`overflow-hidden rounded-lg border border-border-light ${isLoading ? "opacity-50" : ""}`}
         >
           <div className="grid grid-cols-7">
             {WEEKDAY_LABELS.map((label, i) => (
               <div
                 key={label}
-                className={`border-b border-gray-200 py-1 text-center text-sm font-medium ${
+                className={`border-b border-border-light py-1 text-center text-sm font-medium ${
                   i === 5
-                    ? "text-blue-500"
+                    ? "text-primary"
                     : i === 6
-                      ? "text-red-500"
-                      : "text-gray-600"
+                      ? "text-danger"
+                      : "text-on-surface-secondary"
                 }`}
               >
                 {label}
@@ -242,8 +242,8 @@ export function Calendar() {
             <div
               className={`flex items-center gap-1 rounded px-1 py-0.5 text-sm shadow-lg scale-105 ${
                 activeTask.status === "done"
-                  ? "bg-white text-gray-400 line-through"
-                  : "bg-blue-100 text-blue-800"
+                  ? "bg-white text-on-surface-muted line-through"
+                  : "bg-primary-light text-primary"
               }`}
             >
               <input

--- a/apps/web/src/components/CalendarDayCell.tsx
+++ b/apps/web/src/components/CalendarDayCell.tsx
@@ -66,18 +66,18 @@ export function CalendarDayCell({
         }
       }}
       aria-label={`${dateKey}にタスクを追加`}
-      className={`group relative min-h-40 cursor-pointer border-[0.5px] border-gray-200 p-1.5 ${
-        !isCurrentMonth ? "bg-gray-50" : "bg-white"
-      } ${isOver ? "bg-blue-50 ring-2 ring-blue-400 ring-inset" : isExpanded ? "z-10 shadow-lg ring-2 ring-blue-300" : ""}`}
+      className={`group relative min-h-40 cursor-pointer border-[0.5px] border-border-light p-1.5 ${
+        !isCurrentMonth ? "bg-surface" : "bg-white"
+      } ${isOver ? "bg-primary-lighter ring-2 ring-primary-muted ring-inset" : isExpanded ? "z-10 shadow-lg ring-2 ring-primary-muted" : ""}`}
     >
       <div className="mb-1 flex items-center">
         <span
           className={`inline-flex h-7 w-7 items-center justify-center rounded-full text-sm ${
             today
-              ? "bg-blue-600 font-bold text-white"
+              ? "bg-primary font-bold text-white"
               : isCurrentMonth
-                ? "text-gray-900"
-                : "text-gray-400"
+                ? "text-on-surface"
+                : "text-on-surface-muted"
           }`}
         >
           {date.getDate()}
@@ -104,7 +104,7 @@ export function CalendarDayCell({
                 e.stopPropagation();
               }
             }}
-            className="w-full cursor-pointer rounded px-1 text-left text-xs text-gray-500 hover:bg-gray-100 hover:text-gray-700"
+            className="w-full cursor-pointer rounded px-1 text-left text-xs text-on-surface-muted hover:bg-surface-hover hover:text-on-surface-secondary"
           >
             +{remainingCount} 件
           </button>
@@ -116,7 +116,7 @@ export function CalendarDayCell({
               e.stopPropagation();
               onCollapse();
             }}
-            className="w-full cursor-pointer rounded px-1 text-center text-xs text-gray-500 hover:bg-gray-100 hover:text-gray-700"
+            className="w-full cursor-pointer rounded px-1 text-center text-xs text-on-surface-muted hover:bg-surface-hover hover:text-on-surface-secondary"
           >
             折りたたむ
           </button>

--- a/apps/web/src/components/DeleteConfirmDialog.tsx
+++ b/apps/web/src/components/DeleteConfirmDialog.tsx
@@ -27,24 +27,24 @@ export function DeleteConfirmDialog({
           transition
           className="w-full max-w-sm rounded-lg bg-white p-6 shadow-xl transition duration-200 ease-out data-[closed]:scale-95 data-[closed]:opacity-0"
         >
-          <DialogTitle className="mb-2 text-lg font-bold text-gray-900">
+          <DialogTitle className="mb-2 text-lg font-bold text-on-surface">
             タスクの削除
           </DialogTitle>
-          <p className="mb-6 text-sm text-gray-600">
+          <p className="mb-6 text-sm text-on-surface-secondary">
             このタスクを削除しますか？この操作は取り消せません。
           </p>
           <div className="flex justify-end gap-2">
             <button
               type="button"
               onClick={onCancel}
-              className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm text-gray-700 hover:bg-gray-50"
+              className="rounded-md border border-border bg-white px-4 py-2 text-sm text-on-surface-secondary hover:bg-surface-hover"
             >
               キャンセル
             </button>
             <button
               type="button"
               onClick={onConfirm}
-              className="rounded-md bg-red-600 px-4 py-2 text-sm text-white hover:bg-red-700"
+              className="rounded-md bg-danger px-4 py-2 text-sm text-white hover:bg-danger-dark"
             >
               削除
             </button>

--- a/apps/web/src/components/DraggableTask.tsx
+++ b/apps/web/src/components/DraggableTask.tsx
@@ -25,10 +25,10 @@ export function DraggableTask({
       onClick={(e) => e.stopPropagation()}
       className={`flex items-center gap-1 rounded px-1 py-0 text-xs leading-tight min-h-[2.5rem] touch-none ${isDragging ? "cursor-grabbing" : "cursor-grab"} ${
         isDragging
-          ? "border border-dashed border-gray-300 bg-gray-100 text-transparent [&_input]:invisible"
+          ? "border border-dashed border-border bg-surface text-transparent [&_input]:invisible"
           : task.status === "done"
-            ? "text-gray-400 line-through"
-            : "bg-blue-100 text-blue-800"
+            ? "text-on-surface-muted line-through"
+            : "bg-primary-light text-primary"
       }`}
     >
       <input

--- a/apps/web/src/components/TaskDetailModal.tsx
+++ b/apps/web/src/components/TaskDetailModal.tsx
@@ -75,9 +75,9 @@ export function TaskDetailModal({
   return (
     <>
       <ModalWrapper open={open} onClose={onClose}>
-        <h3 className="mb-4 text-lg font-bold text-gray-900">タスクの詳細</h3>
+        <h3 className="mb-4 text-lg font-bold text-on-surface">タスクの詳細</h3>
         {error && (
-          <div className="mb-3 rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">
+          <div className="mb-3 rounded-md bg-danger-light px-3 py-2 text-sm text-danger">
             {error}
           </div>
         )}
@@ -85,23 +85,23 @@ export function TaskDetailModal({
           <div>
             <label
               htmlFor="detail-title"
-              className="mb-1 block text-sm font-medium text-gray-700"
+              className="mb-1 block text-sm font-medium text-on-surface-secondary"
             >
-              タイトル <span className="text-red-500">*</span>
+              タイトル <span className="text-danger">*</span>
             </label>
             <input
               id="detail-title"
               type="text"
               value={title}
               onChange={(e) => setTitle(e.target.value)}
-              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              className="w-full rounded-md border border-border px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
               required
             />
           </div>
           <div>
             <label
               htmlFor="detail-description"
-              className="mb-1 block text-sm font-medium text-gray-700"
+              className="mb-1 block text-sm font-medium text-on-surface-secondary"
             >
               説明
             </label>
@@ -110,13 +110,13 @@ export function TaskDetailModal({
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               rows={3}
-              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              className="w-full rounded-md border border-border px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
             />
           </div>
           <div>
             <label
               htmlFor="detail-date"
-              className="mb-1 block text-sm font-medium text-gray-700"
+              className="mb-1 block text-sm font-medium text-on-surface-secondary"
             >
               日付
             </label>
@@ -125,7 +125,7 @@ export function TaskDetailModal({
               type="date"
               value={date}
               onChange={(e) => setDate(e.target.value)}
-              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              className="w-full rounded-md border border-border px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
               required
             />
           </div>
@@ -134,7 +134,7 @@ export function TaskDetailModal({
               type="button"
               onClick={handleDelete}
               disabled={busy}
-              className="rounded-md bg-red-600 px-4 py-2 text-sm text-white hover:bg-red-700 disabled:opacity-50"
+              className="rounded-md bg-danger px-4 py-2 text-sm text-white hover:bg-danger-dark disabled:opacity-50"
             >
               {deleting ? "削除中..." : "削除"}
             </button>
@@ -142,14 +142,14 @@ export function TaskDetailModal({
               <button
                 type="button"
                 onClick={onClose}
-                className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm text-gray-700 hover:bg-gray-50"
+                className="rounded-md border border-border bg-white px-4 py-2 text-sm text-on-surface-secondary hover:bg-surface-hover"
               >
                 キャンセル
               </button>
               <button
                 type="submit"
                 disabled={busy || !title.trim()}
-                className="rounded-md bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
+                className="rounded-md bg-primary px-4 py-2 text-sm text-white hover:bg-primary-dark disabled:opacity-50"
               >
                 {saving ? "保存中..." : "保存"}
               </button>

--- a/apps/web/src/components/TaskFormModal.tsx
+++ b/apps/web/src/components/TaskFormModal.tsx
@@ -44,11 +44,11 @@ export function TaskFormModal({
 
   return (
     <ModalWrapper open={open} onClose={onClose}>
-      <h3 className="mb-4 text-lg font-bold text-gray-900">
+      <h3 className="mb-4 text-lg font-bold text-on-surface">
         タスクを追加（{date}）
       </h3>
       {error && (
-        <div className="mb-3 rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">
+        <div className="mb-3 rounded-md bg-danger-light px-3 py-2 text-sm text-danger">
           {error}
         </div>
       )}
@@ -56,16 +56,16 @@ export function TaskFormModal({
         <div>
           <label
             htmlFor="task-title"
-            className="mb-1 block text-sm font-medium text-gray-700"
+            className="mb-1 block text-sm font-medium text-on-surface-secondary"
           >
-            タイトル <span className="text-red-500">*</span>
+            タイトル <span className="text-danger">*</span>
           </label>
           <input
             id="task-title"
             type="text"
             value={title}
             onChange={(e) => setTitle(e.target.value)}
-            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="w-full rounded-md border border-border px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
             autoFocus
             required
           />
@@ -73,7 +73,7 @@ export function TaskFormModal({
         <div>
           <label
             htmlFor="task-description"
-            className="mb-1 block text-sm font-medium text-gray-700"
+            className="mb-1 block text-sm font-medium text-on-surface-secondary"
           >
             説明
           </label>
@@ -82,21 +82,21 @@ export function TaskFormModal({
             value={description}
             onChange={(e) => setDescription(e.target.value)}
             rows={3}
-            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="w-full rounded-md border border-border px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
           />
         </div>
         <div className="flex justify-end gap-2">
           <button
             type="button"
             onClick={onClose}
-            className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm text-gray-700 hover:bg-gray-50"
+            className="rounded-md border border-border bg-white px-4 py-2 text-sm text-on-surface-secondary hover:bg-surface-hover"
           >
             キャンセル
           </button>
           <button
             type="submit"
             disabled={saving || !title.trim()}
-            className="rounded-md bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
+            className="rounded-md bg-primary px-4 py-2 text-sm text-white hover:bg-primary-dark disabled:opacity-50"
           >
             {saving ? "保存中..." : "追加"}
           </button>

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1,1 +1,28 @@
 @import "tailwindcss";
+
+@theme {
+  /* Primary — Dusty Indigo */
+  --color-primary: #4a4181;
+  --color-primary-dark: #3d366d;
+  --color-primary-light: #edecf3;
+  --color-primary-lighter: #f3f2f8;
+  --color-primary-muted: #7a73a8;
+
+  /* Danger / Error */
+  --color-danger: #881337;
+  --color-danger-dark: #6e0f2d;
+  --color-danger-light: #f5e6eb;
+
+  /* Surface */
+  --color-surface: #f5f4f0;
+  --color-surface-hover: #eeedea;
+
+  /* Text */
+  --color-on-surface: #2d2a26;
+  --color-on-surface-secondary: #6b6560;
+  --color-on-surface-muted: #a09a94;
+
+  /* Border */
+  --color-border: #cbc8c0;
+  --color-border-light: #dddbd5;
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -2,15 +2,15 @@ import { createRootRoute, Link, Outlet } from "@tanstack/react-router";
 
 function NotFoundPage() {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-100 px-4">
+    <div className="flex min-h-screen items-center justify-center bg-surface px-4">
       <div className="w-full max-w-sm rounded-lg bg-white p-6 text-center shadow-xl">
-        <h1 className="mb-2 text-6xl font-bold text-gray-900">404</h1>
-        <p className="mb-6 text-sm text-gray-600">
+        <h1 className="mb-2 text-6xl font-bold text-on-surface">404</h1>
+        <p className="mb-6 text-sm text-on-surface-secondary">
           お探しのページが見つかりませんでした
         </p>
         <Link
           to="/"
-          className="inline-block rounded-md bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700"
+          className="inline-block rounded-md bg-primary px-4 py-2 text-sm text-white hover:bg-primary-dark"
         >
           トップページへ戻る
         </Link>

--- a/apps/web/src/routes/app/index.tsx
+++ b/apps/web/src/routes/app/index.tsx
@@ -16,16 +16,18 @@ function HomePage() {
   };
 
   return (
-    <div className="min-h-screen bg-gray-100">
-      <header className="border-b border-gray-200 bg-white px-4 py-1.5">
+    <div className="min-h-screen bg-surface">
+      <header className="border-b border-border-light bg-white px-4 py-1.5">
         <div className="mx-auto flex max-w-[1600px] items-center justify-between">
-          <h1 className="text-lg font-bold text-gray-900">tascal</h1>
+          <h1 className="text-lg font-bold text-on-surface">tascal</h1>
           <div className="flex items-center gap-4">
-            <span className="text-sm text-gray-600">{session?.user?.name}</span>
+            <span className="text-sm text-on-surface-secondary">
+              {session?.user?.name}
+            </span>
             <button
               type="button"
               onClick={handleSignOut}
-              className="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50"
+              className="rounded-md border border-border bg-white px-3 py-1.5 text-sm text-on-surface-secondary hover:bg-surface-hover"
             >
               ログアウト
             </button>

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -6,20 +6,20 @@ export const Route = createFileRoute("/")({
 
 function LandingPage() {
   return (
-    <div className="min-h-screen bg-white">
-      <header className="border-b border-gray-200 bg-white">
+    <div className="min-h-screen bg-surface">
+      <header className="border-b border-border-light bg-white">
         <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-3">
-          <span className="text-lg font-bold text-gray-900">tascal</span>
+          <span className="text-lg font-bold text-on-surface">tascal</span>
           <div className="flex items-center gap-3">
             <Link
               to="/login"
-              className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm text-gray-700 hover:bg-gray-50"
+              className="rounded-md border border-border bg-white px-4 py-2 text-sm text-on-surface-secondary hover:bg-surface-hover"
             >
               ログイン
             </Link>
             <Link
               to="/signup"
-              className="rounded-md bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700"
+              className="rounded-md bg-primary px-4 py-2 text-sm text-white hover:bg-primary-dark"
             >
               サインアップ
             </Link>
@@ -29,22 +29,22 @@ function LandingPage() {
 
       <main>
         <section className="px-4 py-24 text-center">
-          <h1 className="mb-4 text-4xl font-bold text-gray-900">
+          <h1 className="mb-4 text-4xl font-bold text-on-surface">
             タスク管理を、カレンダーから。
           </h1>
-          <p className="mx-auto mb-8 max-w-xl text-lg text-gray-600">
+          <p className="mx-auto mb-8 max-w-xl text-lg text-on-surface-secondary">
             カレンダービューでタスクを直感的に管理。ドラッグ&ドロップで手軽にスケジュールを調整できます。
           </p>
           <Link
             to="/signup"
-            className="inline-block rounded-md bg-blue-600 px-6 py-3 text-base font-medium text-white hover:bg-blue-700"
+            className="inline-block rounded-md bg-primary px-6 py-3 text-base font-medium text-white hover:bg-primary-dark"
           >
             無料で始める
           </Link>
         </section>
 
         <section className="px-4 pb-24">
-          <div className="mx-auto max-w-4xl overflow-hidden rounded-lg border border-gray-200 shadow-lg">
+          <div className="mx-auto max-w-4xl overflow-hidden rounded-lg border border-border-light shadow-lg">
             <img
               src="/screenshot.png"
               alt="tascal のカレンダービュー"
@@ -54,7 +54,7 @@ function LandingPage() {
         </section>
       </main>
 
-      <footer className="border-t border-gray-200 px-4 py-6 text-center text-sm text-gray-500">
+      <footer className="border-t border-border-light px-4 py-6 text-center text-sm text-on-surface-secondary">
         &copy; 2026 tascal
       </footer>
     </div>

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -31,16 +31,16 @@ function LoginPage() {
   };
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-100 px-4">
+    <div className="flex min-h-screen items-center justify-center bg-surface px-4">
       <div className="w-full max-w-sm rounded-lg bg-white p-6 shadow-xl">
-        <h1 className="mb-6 text-center text-lg font-bold text-gray-900">
+        <h1 className="mb-6 text-center text-lg font-bold text-on-surface">
           ログイン
         </h1>
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
             <label
               htmlFor="email"
-              className="mb-1 block text-sm font-medium text-gray-700"
+              className="mb-1 block text-sm font-medium text-on-surface-secondary"
             >
               メールアドレス
             </label>
@@ -50,13 +50,13 @@ function LoginPage() {
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               required
-              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              className="w-full rounded-md border border-border px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
             />
           </div>
           <div>
             <label
               htmlFor="password"
-              className="mb-1 block text-sm font-medium text-gray-700"
+              className="mb-1 block text-sm font-medium text-on-surface-secondary"
             >
               パスワード
             </label>
@@ -66,22 +66,22 @@ function LoginPage() {
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               required
-              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              className="w-full rounded-md border border-border px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
             />
           </div>
           {error && (
-            <p className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">
+            <p className="rounded-md bg-danger-light px-3 py-2 text-sm text-danger">
               {error}
             </p>
           )}
           <button
             type="submit"
-            className="w-full rounded-md bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700"
+            className="w-full rounded-md bg-primary px-4 py-2 text-sm text-white hover:bg-primary-dark"
           >
             ログイン
           </button>
         </form>
-        <p className="mt-4 text-center text-sm text-gray-600">
+        <p className="mt-4 text-center text-sm text-on-surface-secondary">
           アカウントをお持ちでない方は
           <a
             href="/signup"
@@ -89,7 +89,7 @@ function LoginPage() {
               e.preventDefault();
               void navigate({ to: "/signup" });
             }}
-            className="ml-1 text-blue-600 hover:text-blue-700 hover:underline"
+            className="ml-1 text-primary hover:text-primary-dark hover:underline"
           >
             サインアップ
           </a>

--- a/apps/web/src/routes/signup.tsx
+++ b/apps/web/src/routes/signup.tsx
@@ -33,16 +33,16 @@ function SignupPage() {
   };
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-100 px-4">
+    <div className="flex min-h-screen items-center justify-center bg-surface px-4">
       <div className="w-full max-w-sm rounded-lg bg-white p-6 shadow-xl">
-        <h1 className="mb-6 text-center text-lg font-bold text-gray-900">
+        <h1 className="mb-6 text-center text-lg font-bold text-on-surface">
           サインアップ
         </h1>
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
             <label
               htmlFor="name"
-              className="mb-1 block text-sm font-medium text-gray-700"
+              className="mb-1 block text-sm font-medium text-on-surface-secondary"
             >
               名前
             </label>
@@ -52,13 +52,13 @@ function SignupPage() {
               value={name}
               onChange={(e) => setName(e.target.value)}
               required
-              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              className="w-full rounded-md border border-border px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
             />
           </div>
           <div>
             <label
               htmlFor="email"
-              className="mb-1 block text-sm font-medium text-gray-700"
+              className="mb-1 block text-sm font-medium text-on-surface-secondary"
             >
               メールアドレス
             </label>
@@ -68,13 +68,13 @@ function SignupPage() {
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               required
-              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              className="w-full rounded-md border border-border px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
             />
           </div>
           <div>
             <label
               htmlFor="password"
-              className="mb-1 block text-sm font-medium text-gray-700"
+              className="mb-1 block text-sm font-medium text-on-surface-secondary"
             >
               パスワード
             </label>
@@ -84,22 +84,22 @@ function SignupPage() {
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               required
-              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              className="w-full rounded-md border border-border px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
             />
           </div>
           {error && (
-            <p className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">
+            <p className="rounded-md bg-danger-light px-3 py-2 text-sm text-danger">
               {error}
             </p>
           )}
           <button
             type="submit"
-            className="w-full rounded-md bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700"
+            className="w-full rounded-md bg-primary px-4 py-2 text-sm text-white hover:bg-primary-dark"
           >
             サインアップ
           </button>
         </form>
-        <p className="mt-4 text-center text-sm text-gray-600">
+        <p className="mt-4 text-center text-sm text-on-surface-secondary">
           すでにアカウントをお持ちの方は
           <a
             href="/login"
@@ -107,7 +107,7 @@ function SignupPage() {
               e.preventDefault();
               void navigate({ to: "/login" });
             }}
-            className="ml-1 text-blue-600 hover:text-blue-700 hover:underline"
+            className="ml-1 text-primary hover:text-primary-dark hover:underline"
           >
             ログイン
           </a>


### PR DESCRIPTION
close #137

## 概要

Tailwind デフォルトの blue/gray 系カラーから、低彩度・深みのある「Dusty Indigo」テーマに統一。

- `apps/web/src/index.css` に Tailwind CSS v4 の `@theme` で CSS カスタムプロパティとしてカラーパレットを定義
- 全コンポーネント（13ファイル）のハードコードされた Tailwind カラークラスを CSS 変数ベースに置換
- `apps/web/index.html` の `theme-color` メタタグを `#4a4181` に更新

## カラーパレット

| 役割 | Hex | トークン名 |
|---|---|---|
| プライマリ | `#4a4181` | `primary` |
| プライマリ（hover） | `#3d366d` | `primary-dark` |
| プライマリ（薄） | `#edecf3` | `primary-light` |
| エラー / 削除 | `#881337` | `danger` |
| テキスト（濃） | `#2d2a26` | `on-surface` |
| テキスト（薄） | `#6b6560` | `on-surface-secondary` |
| 背景 | `#f5f4f0` | `surface` |
| ボーダー | `#cbc8c0` | `border` |

## テスト計画

- [x] `pnpm lint` — pass
- [x] `pnpm format:check` — pass
- [x] `pnpm typecheck` — pass
- [x] `pnpm test` — 全55テスト pass
- [x] `pnpm knip` — pass
- [ ] ランディングページ、認証ページ、アプリ画面の目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)