### PR TITLE
feat: 退会機能（アカウント削除）の実装

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -6,6 +6,7 @@ import { getAuth } from "./auth.js";
 import type { Auth } from "./auth.js";
 import { getDb } from "./db/index.js";
 import tasksApp from "./routes/tasks.js";
+import usersApp from "./routes/users.js";
 
 type AuthVariables = {
   user: Auth["$Infer"]["Session"]["user"] | null;
@@ -58,6 +59,7 @@ app.on(["POST", "GET"], "/api/auth/**", (c) => {
 });
 
 app.route("/api/tasks", tasksApp);
+app.route("/api/users", usersApp);
 
 // SPA 静的ファイル配信（本番用）
 app.use("*", serveStatic({ root: "./public" }));

--- a/apps/api/src/routes/__tests__/users.test.ts
+++ b/apps/api/src/routes/__tests__/users.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Hono } from "hono";
+import type { Auth } from "../../auth.js";
+
+type AuthVariables = {
+  user: Auth["$Infer"]["Session"]["user"] | null;
+  session: Auth["$Infer"]["Session"]["session"] | null;
+};
+
+const mockUser = {
+  id: "550e8400-e29b-41d4-a716-446655440000",
+  name: "Test User",
+  email: "test@example.com",
+  emailVerified: false,
+  image: null,
+  createdAt: new Date("2026-01-01"),
+  updatedAt: new Date("2026-01-01"),
+};
+
+const mockDelete = vi.fn();
+
+vi.mock("../../db/index.js", () => ({
+  getDb: () => ({
+    delete: () => ({
+      where: () => ({
+        returning: mockDelete,
+      }),
+    }),
+  }),
+}));
+
+vi.mock("../../db/schema.js", async () => {
+  const actual = await vi.importActual("../../db/schema.js");
+  return actual;
+});
+
+async function createTestApp(user: AuthVariables["user"] = mockUser) {
+  const usersApp = (await import("../users.js")).default;
+
+  const app = new Hono<{ Variables: AuthVariables }>();
+  app.use("*", async (c, next) => {
+    c.set("user", user);
+    c.set("session", null);
+    await next();
+  });
+  app.route("/api/users", usersApp);
+  return app;
+}
+
+describe("DELETE /api/users/me", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("未認証の場合 401 を返す", async () => {
+    const app = await createTestApp(null);
+    const res = await app.request(
+      new Request("http://localhost/api/users/me", { method: "DELETE" }),
+    );
+    expect(res.status).toBe(401);
+    const json = (await res.json()) as { error: string };
+    expect(json.error).toBe("認証が必要です");
+  });
+
+  it("アカウントを削除できる", async () => {
+    mockDelete.mockResolvedValue([mockUser]);
+    const app = await createTestApp();
+
+    const res = await app.request(
+      new Request("http://localhost/api/users/me", { method: "DELETE" }),
+    );
+    expect(res.status).toBe(200);
+
+    const json = (await res.json()) as { message: string };
+    expect(json.message).toBe("アカウントを削除しました");
+    expect(mockDelete).toHaveBeenCalled();
+  });
+
+  it("ユーザーが見つからない場合 404 を返す", async () => {
+    mockDelete.mockResolvedValue([]);
+    const app = await createTestApp();
+
+    const res = await app.request(
+      new Request("http://localhost/api/users/me", { method: "DELETE" }),
+    );
+    expect(res.status).toBe(404);
+
+    const json = (await res.json()) as { error: string };
+    expect(json.error).toBe("ユーザーが見つかりません");
+  });
+});

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,0 +1,39 @@
+import { Hono } from "hono";
+import { eq } from "drizzle-orm";
+import { getDb } from "../db/index.js";
+import { users } from "../db/schema.js";
+import type { Auth } from "../auth.js";
+
+type AuthVariables = {
+  user: Auth["$Infer"]["Session"]["user"] | null;
+  session: Auth["$Infer"]["Session"]["session"] | null;
+};
+
+const app = new Hono<{ Variables: AuthVariables }>();
+
+// 認証ミドルウェア
+app.use("*", async (c, next) => {
+  const user = c.get("user");
+  if (!user) {
+    return c.json({ error: "認証が必要です" }, 401);
+  }
+  await next();
+});
+
+// DELETE /api/users/me
+app.delete("/me", async (c) => {
+  const user = c.get("user")!;
+
+  const [deleted] = await getDb()
+    .delete(users)
+    .where(eq(users.id, user.id))
+    .returning();
+
+  if (!deleted) {
+    return c.json({ error: "ユーザーが見つかりません" }, 404);
+  }
+
+  return c.json({ message: "アカウントを削除しました" });
+});
+
+export default app;

--- a/apps/web/src/api/users.ts
+++ b/apps/web/src/api/users.ts
@@ -1,0 +1,8 @@
+export async function deleteAccount(): Promise<void> {
+  const res = await fetch("/api/users/me", {
+    method: "DELETE",
+  });
+  if (!res.ok) {
+    throw new Error("アカウントの削除に失敗しました");
+  }
+}

--- a/apps/web/src/components/DeleteAccountModal.tsx
+++ b/apps/web/src/components/DeleteAccountModal.tsx
@@ -1,0 +1,56 @@
+import { useState } from "react";
+import { DialogTitle } from "@headlessui/react";
+import { ModalWrapper } from "./ModalWrapper";
+import { deleteAccount } from "../api/users";
+
+type DeleteAccountModalProps = {
+  open: boolean;
+  onClose: () => void;
+};
+
+export function DeleteAccountModal({ open, onClose }: DeleteAccountModalProps) {
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleDelete = async () => {
+    setIsDeleting(true);
+    setError(null);
+    try {
+      await deleteAccount();
+      window.location.href = "/login";
+    } catch {
+      setError("アカウントの削除に失敗しました");
+      setIsDeleting(false);
+    }
+  };
+
+  return (
+    <ModalWrapper open={open} onClose={onClose}>
+      <DialogTitle className="text-lg font-bold text-on-surface">
+        アカウント削除
+      </DialogTitle>
+      <p className="mt-2 text-sm text-on-surface-secondary">
+        この操作は取り消せません。アカウントとすべてのデータが完全に削除されます。
+      </p>
+      {error && <p className="mt-2 text-sm text-danger">{error}</p>}
+      <div className="mt-6 flex justify-end gap-3">
+        <button
+          type="button"
+          onClick={onClose}
+          disabled={isDeleting}
+          className="rounded-md border border-border bg-white px-4 py-2 text-sm text-on-surface-secondary hover:bg-surface-hover disabled:opacity-50"
+        >
+          キャンセル
+        </button>
+        <button
+          type="button"
+          onClick={() => void handleDelete()}
+          disabled={isDeleting}
+          className="rounded-md bg-danger px-4 py-2 text-sm text-white hover:bg-danger-dark disabled:opacity-50"
+        >
+          {isDeleting ? "削除中..." : "削除する"}
+        </button>
+      </div>
+    </ModalWrapper>
+  );
+}

--- a/apps/web/src/components/__tests__/DeleteAccountModal.test.tsx
+++ b/apps/web/src/components/__tests__/DeleteAccountModal.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { DeleteAccountModal } from "../DeleteAccountModal";
+import { renderWithQueryClient } from "../../test/helpers";
+
+const mockDeleteAccount = vi.fn();
+
+vi.mock("../../api/users", () => ({
+  deleteAccount: (...args: unknown[]) => mockDeleteAccount(...args) as unknown,
+}));
+
+describe("DeleteAccountModal", () => {
+  const defaultProps = {
+    open: true,
+    onClose: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("確認メッセージが表示される", () => {
+    renderWithQueryClient(<DeleteAccountModal {...defaultProps} />);
+
+    expect(screen.getByText("アカウント削除")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "この操作は取り消せません。アカウントとすべてのデータが完全に削除されます。",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("キャンセルボタンで閉じる", async () => {
+    const user = userEvent.setup();
+    renderWithQueryClient(<DeleteAccountModal {...defaultProps} />);
+
+    await user.click(screen.getByText("キャンセル"));
+    expect(defaultProps.onClose).toHaveBeenCalled();
+  });
+
+  it("削除ボタンで API を呼び出す", async () => {
+    mockDeleteAccount.mockResolvedValue(undefined);
+
+    const user = userEvent.setup();
+    renderWithQueryClient(<DeleteAccountModal {...defaultProps} />);
+
+    await user.click(screen.getByText("削除する"));
+
+    await waitFor(() => {
+      expect(mockDeleteAccount).toHaveBeenCalled();
+    });
+  });
+
+  it("削除に失敗した場合エラーメッセージを表示する", async () => {
+    mockDeleteAccount.mockRejectedValue(new Error("失敗"));
+    const user = userEvent.setup();
+    renderWithQueryClient(<DeleteAccountModal {...defaultProps} />);
+
+    await user.click(screen.getByText("削除する"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("アカウントの削除に失敗しました"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("open が false の場合モーダルが表示されない", () => {
+    renderWithQueryClient(
+      <DeleteAccountModal {...defaultProps} open={false} />,
+    );
+
+    expect(screen.queryByText("アカウント削除")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/routes/app/index.tsx
+++ b/apps/web/src/routes/app/index.tsx
@@ -1,6 +1,8 @@
+import { useState } from "react";
 import { createFileRoute } from "@tanstack/react-router";
 import { authClient } from "../../auth-client";
 import { Calendar } from "../../components/Calendar";
+import { DeleteAccountModal } from "../../components/DeleteAccountModal";
 
 export const Route = createFileRoute("/app/")({
   component: HomePage,
@@ -8,6 +10,7 @@ export const Route = createFileRoute("/app/")({
 
 function HomePage() {
   const { data: session } = authClient.useSession();
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
 
   const handleSignOut = () => {
     void authClient.signOut().then(() => {
@@ -31,12 +34,23 @@ function HomePage() {
             >
               ログアウト
             </button>
+            <button
+              type="button"
+              onClick={() => setShowDeleteModal(true)}
+              className="rounded-md border border-danger bg-white px-3 py-1.5 text-sm text-danger hover:bg-danger-light"
+            >
+              アカウント削除
+            </button>
           </div>
         </div>
       </header>
       <main className="p-4">
         <Calendar />
       </main>
+      <DeleteAccountModal
+        open={showDeleteModal}
+        onClose={() => setShowDeleteModal(false)}
+      />
     </div>
   );
 }


### PR DESCRIPTION
close #42

## Summary

- API に `DELETE /api/users/me` エンドポイントを追加（認証必須、cascade により関連データ自動削除）
- Web のヘッダーに「アカウント削除」ボタンを追加し、確認ダイアログ表示後に削除を実行
- 削除完了後、ログイン画面にリダイレクト
- API・Web 双方にテストを追加

## 変更ファイル

### API
- `apps/api/src/routes/users.ts` — 新規。ユーザー削除エンドポイント
- `apps/api/src/routes/__tests__/users.test.ts` — 新規。ユーザー削除のテスト
- `apps/api/src/app.ts` — users ルートのマウント追加

### Web
- `apps/web/src/api/users.ts` — 新規。アカウント削除 API クライアント
- `apps/web/src/components/DeleteAccountModal.tsx` — 新規。確認ダイアログコンポーネント
- `apps/web/src/components/__tests__/DeleteAccountModal.test.tsx` — 新規。確認ダイアログのテスト
- `apps/web/src/routes/app/index.tsx` — ヘッダーにアカウント削除ボタンを追加

## Test plan

- [x] API テスト通過（未認証 401、正常削除 200、ユーザー不在 404）
- [x] Web テスト通過（確認メッセージ表示、キャンセル、削除 API 呼び出し、エラー表示、非表示時の非レンダリング）
- [x] lint / format / typecheck / knip 全通過
- [ ] 手動テスト: ブラウザでアカウント削除フロー確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)