### PR TITLE
feat: カテゴリ機能を追加

### DIFF
--- a/apps/api/drizzle/0001_material_northstar.sql
+++ b/apps/api/drizzle/0001_material_northstar.sql
@@ -1,0 +1,13 @@
+CREATE TYPE "public"."category_color" AS ENUM('red', 'orange', 'yellow', 'green', 'teal', 'blue', 'purple', 'pink');--> statement-breakpoint
+CREATE TABLE "categories" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" varchar(255) NOT NULL,
+	"color" "category_color" NOT NULL,
+	"user_id" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "tasks" ADD COLUMN "category_id" uuid;--> statement-breakpoint
+ALTER TABLE "categories" ADD CONSTRAINT "categories_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "tasks" ADD CONSTRAINT "tasks_category_id_categories_id_fk" FOREIGN KEY ("category_id") REFERENCES "public"."categories"("id") ON DELETE set null ON UPDATE no action;

--- a/apps/api/drizzle/meta/0001_snapshot.json
+++ b/apps/api/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,490 @@
+{
+  "id": "70eea9ff-afd7-4202-8e57-a6fbcd8ad341",
+  "prevId": "e8cb0435-9d70-4880-82b2-d828d782b77c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "category_color",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "categories_user_id_users_id_fk": {
+          "name": "categories_user_id_users_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "task_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'todo'"
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tasks_category_id_categories_id_fk": {
+          "name": "tasks_category_id_categories_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "categories",
+          "columnsFrom": ["category_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "tasks_user_id_users_id_fk": {
+          "name": "tasks_user_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.category_color": {
+      "name": "category_color",
+      "schema": "public",
+      "values": [
+        "red",
+        "orange",
+        "yellow",
+        "green",
+        "teal",
+        "blue",
+        "purple",
+        "pink"
+      ]
+    },
+    "public.task_status": {
+      "name": "task_status",
+      "schema": "public",
+      "values": ["todo", "done"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1773927044150,
       "tag": "0000_bumpy_lorna_dane",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1776029805844,
+      "tag": "0001_material_northstar",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -5,6 +5,7 @@ import { cors } from "hono/cors";
 import { getAuth } from "./auth.js";
 import type { Auth } from "./auth.js";
 import { getDb } from "./db/index.js";
+import categoriesApp from "./routes/categories.js";
 import tasksApp from "./routes/tasks.js";
 
 type AuthVariables = {
@@ -57,6 +58,7 @@ app.on(["POST", "GET"], "/api/auth/**", (c) => {
   return getAuth().handler(c.req.raw);
 });
 
+app.route("/api/categories", categoriesApp);
 app.route("/api/tasks", tasksApp);
 
 // SPA 静的ファイル配信（本番用）

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -11,6 +11,17 @@ import {
 
 export const taskStatusEnum = pgEnum("task_status", ["todo", "done"]);
 
+export const categoryColorEnum = pgEnum("category_color", [
+  "red",
+  "orange",
+  "yellow",
+  "green",
+  "teal",
+  "blue",
+  "purple",
+  "pink",
+]);
+
 export const users = pgTable("users", {
   id: text("id").primaryKey(),
   name: varchar("name", { length: 255 }).notNull(),
@@ -65,12 +76,26 @@ export const verifications = pgTable("verifications", {
   updatedAt: timestamp("updated_at", { mode: "string" }).notNull().defaultNow(),
 });
 
+export const categories = pgTable("categories", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  name: varchar("name", { length: 255 }).notNull(),
+  color: categoryColorEnum("color").notNull(),
+  userId: text("user_id")
+    .notNull()
+    .references(() => users.id, { onDelete: "cascade" }),
+  createdAt: timestamp("created_at", { mode: "string" }).notNull().defaultNow(),
+  updatedAt: timestamp("updated_at", { mode: "string" }).notNull().defaultNow(),
+});
+
 export const tasks = pgTable("tasks", {
   id: uuid("id").primaryKey().defaultRandom(),
   title: varchar("title", { length: 255 }).notNull(),
   description: text("description"),
   date: date("date").notNull(),
   status: taskStatusEnum("status").notNull().default("todo"),
+  categoryId: uuid("category_id").references(() => categories.id, {
+    onDelete: "set null",
+  }),
   userId: text("user_id")
     .notNull()
     .references(() => users.id, { onDelete: "cascade" }),

--- a/apps/api/src/routes/__tests__/categories.test.ts
+++ b/apps/api/src/routes/__tests__/categories.test.ts
@@ -1,0 +1,276 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Hono } from "hono";
+import type { Auth } from "../../auth.js";
+
+type AuthVariables = {
+  user: Auth["$Infer"]["Session"]["user"] | null;
+  session: Auth["$Infer"]["Session"]["session"] | null;
+};
+
+const mockUser = {
+  id: "550e8400-e29b-41d4-a716-446655440000",
+  name: "Test User",
+  email: "test@example.com",
+  emailVerified: false,
+  image: null,
+  createdAt: new Date("2026-01-01"),
+  updatedAt: new Date("2026-01-01"),
+};
+
+const mockCategory = {
+  id: "660e8400-e29b-41d4-a716-446655440000",
+  name: "仕事",
+  color: "blue" as const,
+  userId: mockUser.id,
+  createdAt: new Date("2026-03-01"),
+  updatedAt: new Date("2026-03-01"),
+};
+
+// DB モック
+const mockSelect = vi.fn();
+const mockInsert = vi.fn();
+const mockUpdate = vi.fn();
+const mockDelete = vi.fn();
+
+vi.mock("../../db/index.js", () => ({
+  getDb: () => ({
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          orderBy: mockSelect,
+        }),
+      }),
+    }),
+    insert: () => ({
+      values: () => ({
+        returning: mockInsert,
+      }),
+    }),
+    update: () => ({
+      set: () => ({
+        where: () => ({
+          returning: mockUpdate,
+        }),
+      }),
+    }),
+    delete: () => ({
+      where: () => ({
+        returning: mockDelete,
+      }),
+    }),
+  }),
+}));
+
+vi.mock("../../db/schema.js", async () => {
+  const actual = await vi.importActual("../../db/schema.js");
+  return actual;
+});
+
+async function createTestApp(user: AuthVariables["user"] = mockUser) {
+  const categoriesApp = (await import("../categories.js")).default;
+
+  const app = new Hono<{ Variables: AuthVariables }>();
+  app.use("*", async (c, next) => {
+    c.set("user", user);
+    c.set("session", null);
+    await next();
+  });
+  app.route("/api/categories", categoriesApp);
+  return app;
+}
+
+function jsonRequest(
+  method: string,
+  path: string,
+  body?: Record<string, unknown>,
+): Request {
+  const init: RequestInit = {
+    method,
+    headers: { "Content-Type": "application/json" },
+  };
+  if (body) {
+    init.body = JSON.stringify(body);
+  }
+  return new Request(`http://localhost${path}`, init);
+}
+
+// ─── テスト ───
+
+describe("認証ミドルウェア", () => {
+  it("未認証の場合 401 を返す", async () => {
+    const app = await createTestApp(null);
+    const res = await app.request(jsonRequest("GET", "/api/categories"));
+    expect(res.status).toBe(401);
+    const json = (await res.json()) as { error: string };
+    expect(json.error).toBe("認証が必要です");
+  });
+});
+
+describe("GET /api/categories", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("カテゴリ一覧を取得できる", async () => {
+    mockSelect.mockResolvedValue([mockCategory]);
+    const app = await createTestApp();
+
+    const res = await app.request(jsonRequest("GET", "/api/categories"));
+    expect(res.status).toBe(200);
+
+    const json = (await res.json()) as (typeof mockCategory)[];
+    expect(json).toHaveLength(1);
+    expect(json[0].name).toBe("仕事");
+    expect(json[0].color).toBe("blue");
+    expect(mockSelect).toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/categories", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("カテゴリを作成できる", async () => {
+    mockInsert.mockResolvedValue([mockCategory]);
+    const app = await createTestApp();
+
+    const res = await app.request(
+      jsonRequest("POST", "/api/categories", {
+        name: "仕事",
+        color: "blue",
+      }),
+    );
+    expect(res.status).toBe(201);
+
+    const json = (await res.json()) as { name: string; color: string };
+    expect(json.name).toBe("仕事");
+    expect(json.color).toBe("blue");
+  });
+
+  it("name が空の場合 400 を返す", async () => {
+    const app = await createTestApp();
+    const res = await app.request(
+      jsonRequest("POST", "/api/categories", {
+        name: "",
+        color: "blue",
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("color が不正な場合 400 を返す", async () => {
+    const app = await createTestApp();
+    const res = await app.request(
+      jsonRequest("POST", "/api/categories", {
+        name: "テスト",
+        color: "invalid-color",
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("name が未指定の場合 400 を返す", async () => {
+    const app = await createTestApp();
+    const res = await app.request(
+      jsonRequest("POST", "/api/categories", {
+        color: "blue",
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("color が未指定の場合 400 を返す", async () => {
+    const app = await createTestApp();
+    const res = await app.request(
+      jsonRequest("POST", "/api/categories", {
+        name: "テスト",
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("PATCH /api/categories/:id", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("カテゴリを更新できる", async () => {
+    const updatedCategory = { ...mockCategory, name: "プライベート" };
+    mockUpdate.mockResolvedValue([updatedCategory]);
+    const app = await createTestApp();
+
+    const res = await app.request(
+      jsonRequest("PATCH", `/api/categories/${mockCategory.id}`, {
+        name: "プライベート",
+      }),
+    );
+    expect(res.status).toBe(200);
+
+    const json = (await res.json()) as { name: string };
+    expect(json.name).toBe("プライベート");
+  });
+
+  it("存在しないカテゴリの場合 404 を返す", async () => {
+    mockUpdate.mockResolvedValue([]);
+    const app = await createTestApp();
+
+    const res = await app.request(
+      jsonRequest(
+        "PATCH",
+        "/api/categories/770e8400-e29b-41d4-a716-446655440000",
+        { name: "テスト" },
+      ),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("不正な UUID の場合 400 を返す", async () => {
+    const app = await createTestApp();
+    const res = await app.request(
+      jsonRequest("PATCH", "/api/categories/invalid-uuid", { name: "テスト" }),
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("DELETE /api/categories/:id", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("カテゴリを削除できる", async () => {
+    mockDelete.mockResolvedValue([mockCategory]);
+    const app = await createTestApp();
+
+    const res = await app.request(
+      jsonRequest("DELETE", `/api/categories/${mockCategory.id}`),
+    );
+    expect(res.status).toBe(200);
+
+    const json = (await res.json()) as { message: string };
+    expect(json.message).toBe("カテゴリを削除しました");
+  });
+
+  it("存在しないカテゴリの場合 404 を返す", async () => {
+    mockDelete.mockResolvedValue([]);
+    const app = await createTestApp();
+
+    const res = await app.request(
+      jsonRequest(
+        "DELETE",
+        "/api/categories/770e8400-e29b-41d4-a716-446655440000",
+      ),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("不正な UUID の場合 400 を返す", async () => {
+    const app = await createTestApp();
+    const res = await app.request(
+      jsonRequest("DELETE", "/api/categories/invalid-uuid"),
+    );
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/api/src/routes/categories.ts
+++ b/apps/api/src/routes/categories.ts
@@ -1,0 +1,149 @@
+import { Hono, type Env } from "hono";
+import { z } from "zod";
+import { zValidator } from "@hono/zod-validator";
+import type { Hook } from "@hono/zod-validator";
+import { eq, and, asc } from "drizzle-orm";
+import { getDb } from "../db/index.js";
+import { categories } from "../db/schema.js";
+import type { Auth } from "../auth.js";
+
+type AuthVariables = {
+  user: Auth["$Infer"]["Session"]["user"] | null;
+  session: Auth["$Infer"]["Session"]["session"] | null;
+};
+
+const VALID_COLORS = [
+  "red",
+  "orange",
+  "yellow",
+  "green",
+  "teal",
+  "blue",
+  "purple",
+  "pink",
+] as const;
+
+const createCategorySchema = z.object({
+  name: z.string().min(1).max(255),
+  color: z.enum(VALID_COLORS),
+});
+
+const updateCategorySchema = z.object({
+  name: z.string().min(1).max(255).optional(),
+  color: z.enum(VALID_COLORS).optional(),
+});
+
+const paramIdSchema = z.object({
+  id: z.string().uuid("不正なカテゴリIDです"),
+});
+
+function validationHook(errorMessage: string): Hook<unknown, Env, string> {
+  return (result, c) => {
+    if (!result.success) {
+      return c.json({ error: errorMessage, details: result.error.issues }, 400);
+    }
+  };
+}
+
+const app = new Hono<{ Variables: AuthVariables }>();
+
+// 認証ミドルウェア
+app.use("*", async (c, next) => {
+  const user = c.get("user");
+  if (!user) {
+    return c.json({ error: "認証が必要です" }, 401);
+  }
+  await next();
+});
+
+// GET /api/categories
+app.get("/", async (c) => {
+  const user = c.get("user")!;
+
+  const result = await getDb()
+    .select()
+    .from(categories)
+    .where(eq(categories.userId, user.id))
+    .orderBy(asc(categories.createdAt));
+
+  return c.json(result);
+});
+
+// POST /api/categories
+app.post(
+  "/",
+  zValidator(
+    "json",
+    createCategorySchema,
+    validationHook("バリデーションエラー"),
+  ),
+  async (c) => {
+    const user = c.get("user")!;
+    const data = c.req.valid("json");
+
+    const [category] = await getDb()
+      .insert(categories)
+      .values({
+        name: data.name,
+        color: data.color,
+        userId: user.id,
+      })
+      .returning();
+
+    return c.json(category, 201);
+  },
+);
+
+// PATCH /api/categories/:id
+app.patch(
+  "/:id",
+  zValidator("param", paramIdSchema, validationHook("不正なカテゴリIDです")),
+  zValidator(
+    "json",
+    updateCategorySchema,
+    validationHook("バリデーションエラー"),
+  ),
+  async (c) => {
+    const user = c.get("user")!;
+    const { id } = c.req.valid("param");
+    const data = c.req.valid("json");
+
+    const [updated] = await getDb()
+      .update(categories)
+      .set({
+        ...data,
+        updatedAt: new Date().toISOString(),
+      })
+      .where(and(eq(categories.id, id), eq(categories.userId, user.id)))
+      .returning();
+
+    if (!updated) {
+      return c.json({ error: "カテゴリが見つかりません" }, 404);
+    }
+
+    return c.json(updated);
+  },
+);
+
+// DELETE /api/categories/:id
+app.delete(
+  "/:id",
+  zValidator("param", paramIdSchema, validationHook("不正なカテゴリIDです")),
+  async (c) => {
+    const user = c.get("user")!;
+    const { id } = c.req.valid("param");
+
+    const [deleted] = await getDb()
+      .delete(categories)
+      .where(and(eq(categories.id, id), eq(categories.userId, user.id)))
+      .returning();
+
+    if (!deleted) {
+      return c.json({ error: "カテゴリが見つかりません" }, 404);
+    }
+
+    return c.json({ message: "カテゴリを削除しました" });
+  },
+);
+
+export default app;

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -4,7 +4,7 @@ import { zValidator } from "@hono/zod-validator";
 import type { Hook } from "@hono/zod-validator";
 import { eq, and, gte, lt } from "drizzle-orm";
 import { getDb } from "../db/index.js";
-import { tasks } from "../db/schema.js";
+import { categories, tasks } from "../db/schema.js";
 import type { Auth } from "../auth.js";
 
 type AuthVariables = {
@@ -17,6 +17,7 @@ const createTaskSchema = z.object({
   description: z.string().nullable().optional(),
   date: z.string().date("日付はYYYY-MM-DD形式の実在する日付で指定してください"),
   status: z.enum(["todo", "done"]).optional(),
+  categoryId: z.string().uuid().nullable().optional(),
 });
 
 const updateTaskSchema = z.object({
@@ -27,6 +28,7 @@ const updateTaskSchema = z.object({
     .date("日付はYYYY-MM-DD形式の実在する日付で指定してください")
     .optional(),
   status: z.enum(["todo", "done"]).optional(),
+  categoryId: z.string().uuid().nullable().optional(),
 });
 
 const listQuerySchema = z.object({
@@ -97,6 +99,19 @@ app.post(
   async (c) => {
     const user = c.get("user")!;
     const data = c.req.valid("json");
+    const categoryId = data.categoryId ?? null;
+
+    if (categoryId) {
+      const [cat] = await getDb()
+        .select()
+        .from(categories)
+        .where(
+          and(eq(categories.id, categoryId), eq(categories.userId, user.id)),
+        );
+      if (!cat) {
+        return c.json({ error: "カテゴリが見つかりません" }, 400);
+      }
+    }
 
     const [task] = await getDb()
       .insert(tasks)
@@ -105,6 +120,7 @@ app.post(
         description: data.description ?? null,
         date: data.date,
         status: data.status ?? "todo",
+        categoryId,
         userId: user.id,
       })
       .returning();
@@ -122,6 +138,21 @@ app.patch(
     const user = c.get("user")!;
     const { id } = c.req.valid("param");
     const data = c.req.valid("json");
+
+    if (data.categoryId) {
+      const [cat] = await getDb()
+        .select()
+        .from(categories)
+        .where(
+          and(
+            eq(categories.id, data.categoryId),
+            eq(categories.userId, user.id),
+          ),
+        );
+      if (!cat) {
+        return c.json({ error: "カテゴリが見つかりません" }, 400);
+      }
+    }
 
     const [updated] = await getDb()
       .update(tasks)

--- a/apps/web/src/api/categories.ts
+++ b/apps/web/src/api/categories.ts
@@ -1,0 +1,51 @@
+import type { Category, CategoryColor } from "../types/category";
+
+export async function fetchCategories(): Promise<Category[]> {
+  const res = await fetch("/api/categories");
+  if (!res.ok) {
+    throw new Error("カテゴリの取得に失敗しました");
+  }
+  return res.json() as Promise<Category[]>;
+}
+
+export async function createCategory(data: {
+  name: string;
+  color: CategoryColor;
+}): Promise<Category> {
+  const res = await fetch("/api/categories", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) {
+    throw new Error("カテゴリの作成に失敗しました");
+  }
+  return res.json() as Promise<Category>;
+}
+
+export async function updateCategory(
+  id: string,
+  data: {
+    name?: string;
+    color?: CategoryColor;
+  },
+): Promise<Category> {
+  const res = await fetch(`/api/categories/${id}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) {
+    throw new Error("カテゴリの更新に失敗しました");
+  }
+  return res.json() as Promise<Category>;
+}
+
+export async function deleteCategory(id: string): Promise<void> {
+  const res = await fetch(`/api/categories/${id}`, {
+    method: "DELETE",
+  });
+  if (!res.ok) {
+    throw new Error("カテゴリの削除に失敗しました");
+  }
+}

--- a/apps/web/src/api/tasks.ts
+++ b/apps/web/src/api/tasks.ts
@@ -17,6 +17,7 @@ export async function createTask(data: {
   description?: string | null;
   date: string;
   status?: "todo" | "done";
+  categoryId?: string | null;
 }): Promise<Task> {
   const res = await fetch("/api/tasks", {
     method: "POST",
@@ -36,6 +37,7 @@ export async function updateTask(
     description?: string | null;
     date?: string;
     status?: "todo" | "done";
+    categoryId?: string | null;
   },
 ): Promise<Task> {
   const res = await fetch(`/api/tasks/${id}`, {

--- a/apps/web/src/components/Calendar.tsx
+++ b/apps/web/src/components/Calendar.tsx
@@ -10,7 +10,10 @@ import {
   type DropAnimation,
 } from "@dnd-kit/core";
 import type { Task } from "../types/task";
+import type { Category } from "../types/category";
+import { useCategories } from "../hooks/useCategories";
 import { useTasks, useUpdateTask } from "../hooks/useTasks";
+import { CATEGORY_COLORS } from "../constants/categoryColors";
 import { getCalendarDays, formatDateKey } from "../utils/calendar";
 import { CalendarDayCell } from "./CalendarDayCell";
 import { TaskFormModal } from "./TaskFormModal";
@@ -61,7 +64,16 @@ export function Calendar() {
     error: queryError,
   } = useTasks(year, month);
 
+  const { data: categories = [] } = useCategories();
   const updateTaskMutation = useUpdateTask(year, month);
+
+  const categoryMap = useMemo(() => {
+    const map = new Map<string, Category>();
+    for (const cat of categories) {
+      map.set(cat.id, cat);
+    }
+    return map;
+  }, [categories]);
 
   const [mutationError, setMutationError] = useState<string | null>(null);
 
@@ -226,6 +238,7 @@ export function Calendar() {
                   date={day.date}
                   isCurrentMonth={day.isCurrentMonth}
                   tasks={tasksByDate.get(key) ?? []}
+                  categoryMap={categoryMap}
                   isExpanded={expandedDate === key}
                   onAddClick={setAddDate}
                   onTaskClick={setSelectedTask}
@@ -238,23 +251,37 @@ export function Calendar() {
           </div>
         </div>
         <DragOverlay dropAnimation={dropAnimationConfig}>
-          {activeTask && (
-            <div
-              className={`flex items-center gap-1 rounded px-1 py-0.5 text-sm shadow-lg scale-105 ${
-                activeTask.status === "done"
-                  ? "bg-white text-on-surface-muted line-through"
-                  : "bg-primary-light text-primary"
-              }`}
-            >
-              <input
-                type="checkbox"
-                checked={activeTask.status === "done"}
-                readOnly
-                className="h-3.5 w-3.5 shrink-0"
-              />
-              <span className="break-all">{activeTask.title}</span>
-            </div>
-          )}
+          {activeTask &&
+            (() => {
+              const cat = activeTask.categoryId
+                ? categoryMap.get(activeTask.categoryId)
+                : null;
+              const bgColor = cat ? CATEGORY_COLORS[cat.color].bg : undefined;
+              return (
+                <div
+                  className={`flex items-center gap-1 rounded px-1 py-0.5 text-sm shadow-lg scale-105 ${
+                    activeTask.status === "done"
+                      ? "bg-white text-on-surface-muted line-through"
+                      : bgColor
+                        ? "text-on-surface"
+                        : "bg-primary-light text-primary"
+                  }`}
+                  style={
+                    activeTask.status !== "done" && bgColor
+                      ? { backgroundColor: bgColor }
+                      : undefined
+                  }
+                >
+                  <input
+                    type="checkbox"
+                    checked={activeTask.status === "done"}
+                    readOnly
+                    className="h-3.5 w-3.5 shrink-0"
+                  />
+                  <span className="break-all">{activeTask.title}</span>
+                </div>
+              );
+            })()}
         </DragOverlay>
       </DndContext>
 

--- a/apps/web/src/components/Calendar.tsx
+++ b/apps/web/src/components/Calendar.tsx
@@ -264,7 +264,7 @@ export function Calendar() {
                       ? "bg-white text-on-surface-muted line-through"
                       : bgColor
                         ? "text-on-surface"
-                        : "bg-primary-light text-primary"
+                        : "bg-white text-on-surface"
                   }`}
                   style={
                     activeTask.status !== "done" && bgColor

--- a/apps/web/src/components/CalendarDayCell.tsx
+++ b/apps/web/src/components/CalendarDayCell.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 import { useDroppable } from "@dnd-kit/core";
 import type { Task } from "../types/task";
+import type { Category } from "../types/category";
 import { isToday, formatDateKey } from "../utils/calendar";
 import { DraggableTask } from "./DraggableTask";
 
@@ -10,6 +11,7 @@ type CalendarDayCellProps = {
   date: Date;
   isCurrentMonth: boolean;
   tasks: Task[];
+  categoryMap: Map<string, Category>;
   isExpanded: boolean;
   onAddClick: (dateKey: string) => void;
   onTaskClick: (task: Task) => void;
@@ -22,6 +24,7 @@ export function CalendarDayCell({
   date,
   isCurrentMonth,
   tasks,
+  categoryMap,
   isExpanded,
   onAddClick,
   onTaskClick,
@@ -88,6 +91,11 @@ export function CalendarDayCell({
           <DraggableTask
             key={task.id}
             task={task}
+            category={
+              task.categoryId
+                ? (categoryMap.get(task.categoryId) ?? null)
+                : null
+            }
             onTaskClick={onTaskClick}
             onToggleStatus={onToggleStatus}
           />

--- a/apps/web/src/components/CategoryForm.tsx
+++ b/apps/web/src/components/CategoryForm.tsx
@@ -1,0 +1,73 @@
+import { useId, useState } from "react";
+import type { CategoryColor } from "../types/category";
+import { ColorPicker } from "./ColorPicker";
+
+type CategoryFormProps = {
+  initialName?: string;
+  initialColor?: CategoryColor;
+  onSubmit: (data: { name: string; color: CategoryColor }) => void;
+  onCancel: () => void;
+  saving: boolean;
+};
+
+export function CategoryForm({
+  initialName = "",
+  initialColor = "blue",
+  onSubmit,
+  onCancel,
+  saving,
+}: CategoryFormProps) {
+  const nameId = useId();
+  const [name, setName] = useState(initialName);
+  const [color, setColor] = useState<CategoryColor>(initialColor);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) return;
+    onSubmit({ name: name.trim(), color });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-3">
+      <div>
+        <label
+          htmlFor={nameId}
+          className="mb-1 block text-sm font-medium text-on-surface-secondary"
+        >
+          カテゴリ名
+        </label>
+        <input
+          id={nameId}
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          maxLength={255}
+          className="w-full rounded-md border border-border px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+          placeholder="例: 仕事、プライベート"
+        />
+      </div>
+      <div>
+        <span className="mb-1 block text-sm font-medium text-on-surface-secondary">
+          カラー
+        </span>
+        <ColorPicker value={color} onChange={setColor} />
+      </div>
+      <div className="flex justify-end gap-2">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded-md border border-border bg-white px-4 py-2 text-sm text-on-surface-secondary hover:bg-surface-hover"
+        >
+          キャンセル
+        </button>
+        <button
+          type="submit"
+          disabled={saving || !name.trim()}
+          className="rounded-md bg-primary px-4 py-2 text-sm text-white hover:bg-primary-dark disabled:opacity-50"
+        >
+          保存
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/apps/web/src/components/ColorPicker.tsx
+++ b/apps/web/src/components/ColorPicker.tsx
@@ -1,0 +1,33 @@
+import type { CategoryColor } from "../types/category";
+import {
+  CATEGORY_COLORS,
+  CATEGORY_COLOR_LABELS,
+} from "../constants/categoryColors";
+
+type ColorPickerProps = {
+  value: CategoryColor | null;
+  onChange: (color: CategoryColor) => void;
+};
+
+const COLOR_KEYS = Object.keys(CATEGORY_COLORS) as CategoryColor[];
+
+export function ColorPicker({ value, onChange }: ColorPickerProps) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {COLOR_KEYS.map((color) => (
+        <button
+          key={color}
+          type="button"
+          title={CATEGORY_COLOR_LABELS[color]}
+          onClick={() => onChange(color)}
+          className={`h-8 w-8 rounded-full border-2 transition-transform ${
+            value === color
+              ? "scale-110 border-on-surface"
+              : "border-transparent hover:scale-105"
+          }`}
+          style={{ backgroundColor: CATEGORY_COLORS[color].bg }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/DraggableTask.tsx
+++ b/apps/web/src/components/DraggableTask.tsx
@@ -35,7 +35,7 @@ export function DraggableTask({
             ? "text-on-surface-muted line-through"
             : categoryBg
               ? "text-on-surface"
-              : "bg-primary-light text-primary"
+              : "bg-white text-on-surface"
       }`}
       style={
         !isDragging && task.status !== "done" && categoryBg

--- a/apps/web/src/components/DraggableTask.tsx
+++ b/apps/web/src/components/DraggableTask.tsx
@@ -1,17 +1,22 @@
 import { useDraggable } from "@dnd-kit/core";
 import type { Task } from "../types/task";
+import type { Category } from "../types/category";
+import { CATEGORY_COLORS } from "../constants/categoryColors";
 
 type DraggableTaskProps = {
   task: Task;
+  category: Category | null;
   onTaskClick: (task: Task) => void;
   onToggleStatus: (task: Task) => void;
 };
 
 export function DraggableTask({
   task,
+  category,
   onTaskClick,
   onToggleStatus,
 }: DraggableTaskProps) {
+  const categoryBg = category ? CATEGORY_COLORS[category.color].bg : null;
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: task.id,
     data: { task },
@@ -28,8 +33,15 @@ export function DraggableTask({
           ? "border border-dashed border-border bg-surface text-transparent [&_input]:invisible"
           : task.status === "done"
             ? "text-on-surface-muted line-through"
-            : "bg-primary-light text-primary"
+            : categoryBg
+              ? "text-on-surface"
+              : "bg-primary-light text-primary"
       }`}
+      style={
+        !isDragging && task.status !== "done" && categoryBg
+          ? { backgroundColor: categoryBg }
+          : undefined
+      }
     >
       <input
         type="checkbox"

--- a/apps/web/src/components/TaskDetailModal.tsx
+++ b/apps/web/src/components/TaskDetailModal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import type { Task } from "../types/task";
+import { useCategories } from "../hooks/useCategories";
 import { useUpdateTask, useDeleteTask } from "../hooks/useTasks";
 import { ModalWrapper } from "./ModalWrapper";
 import { DeleteConfirmDialog } from "./DeleteConfirmDialog";
@@ -24,6 +25,7 @@ export function TaskDetailModal({
   const [title, setTitle] = useState(task.title);
   const [description, setDescription] = useState(task.description ?? "");
   const [date, setDate] = useState(task.date);
+  const [categoryId, setCategoryId] = useState<string>(task.categoryId ?? "");
   const [error, setError] = useState<string | null>(null);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
@@ -31,6 +33,7 @@ export function TaskDetailModal({
     if (!open) setShowDeleteConfirm(false);
   }, [open]);
 
+  const { data: categories = [] } = useCategories();
   const updateTaskMutation = useUpdateTask(year, month);
   const deleteTaskMutation = useDeleteTask(year, month);
 
@@ -50,6 +53,7 @@ export function TaskDetailModal({
           title: title.trim(),
           description: description.trim() || null,
           date,
+          categoryId: categoryId || null,
         },
       },
       {
@@ -129,6 +133,29 @@ export function TaskDetailModal({
               required
             />
           </div>
+          {categories.length > 0 && (
+            <div>
+              <label
+                htmlFor="detail-category"
+                className="mb-1 block text-sm font-medium text-on-surface-secondary"
+              >
+                カテゴリ
+              </label>
+              <select
+                id="detail-category"
+                value={categoryId}
+                onChange={(e) => setCategoryId(e.target.value)}
+                className="w-full rounded-md border border-border px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+              >
+                <option value="">カテゴリなし</option>
+                {categories.map((cat) => (
+                  <option key={cat.id} value={cat.id}>
+                    {cat.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
           <div className="flex justify-between">
             <button
               type="button"

--- a/apps/web/src/components/TaskFormModal.tsx
+++ b/apps/web/src/components/TaskFormModal.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useCategories } from "../hooks/useCategories";
 import { useCreateTask } from "../hooks/useTasks";
 import { ModalWrapper } from "./ModalWrapper";
 
@@ -21,7 +22,9 @@ export function TaskFormModal({
 }: TaskFormModalProps) {
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
+  const [categoryId, setCategoryId] = useState<string>("");
 
+  const { data: categories = [] } = useCategories();
   const createTaskMutation = useCreateTask(year, month);
   const saving = createTaskMutation.isPending;
   const error = createTaskMutation.error ? "タスクの作成に失敗しました" : null;
@@ -35,6 +38,7 @@ export function TaskFormModal({
         title: title.trim(),
         description: description.trim() || null,
         date,
+        categoryId: categoryId || null,
       },
       {
         onSuccess: () => onCreated(),
@@ -85,6 +89,29 @@ export function TaskFormModal({
             className="w-full rounded-md border border-border px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
           />
         </div>
+        {categories.length > 0 && (
+          <div>
+            <label
+              htmlFor="task-category"
+              className="mb-1 block text-sm font-medium text-on-surface-secondary"
+            >
+              カテゴリ
+            </label>
+            <select
+              id="task-category"
+              value={categoryId}
+              onChange={(e) => setCategoryId(e.target.value)}
+              className="w-full rounded-md border border-border px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+            >
+              <option value="">カテゴリなし</option>
+              {categories.map((cat) => (
+                <option key={cat.id} value={cat.id}>
+                  {cat.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
         <div className="flex justify-end gap-2">
           <button
             type="button"

--- a/apps/web/src/components/__tests__/TaskDetailModal.test.tsx
+++ b/apps/web/src/components/__tests__/TaskDetailModal.test.tsx
@@ -18,6 +18,7 @@ const mockTask = {
   description: "既存の説明",
   date: "2026-03-15",
   status: "todo" as const,
+  categoryId: null,
   userId: "user-1",
   createdAt: "2026-01-01T00:00:00.000Z",
   updatedAt: "2026-01-01T00:00:00.000Z",

--- a/apps/web/src/components/__tests__/TaskFormModal.test.tsx
+++ b/apps/web/src/components/__tests__/TaskFormModal.test.tsx
@@ -43,6 +43,7 @@ describe("TaskFormModal", () => {
         title: "新規タスク",
         description: "タスクの説明文",
         date: "2026-03-15",
+        categoryId: null,
       });
     });
     await waitFor(() => {
@@ -68,6 +69,7 @@ describe("TaskFormModal", () => {
         title: "タスク",
         description: null,
         date: "2026-03-15",
+        categoryId: null,
       });
     });
   });

--- a/apps/web/src/constants/categoryColors.ts
+++ b/apps/web/src/constants/categoryColors.ts
@@ -1,0 +1,23 @@
+import type { CategoryColor } from "../types/category";
+
+export const CATEGORY_COLORS: Record<CategoryColor, { bg: string }> = {
+  red: { bg: "#fde8e8" },
+  orange: { bg: "#fff1e6" },
+  yellow: { bg: "#fef9c3" },
+  green: { bg: "#dcfce7" },
+  teal: { bg: "#ccfbf1" },
+  blue: { bg: "#dbeafe" },
+  purple: { bg: "#f3e8ff" },
+  pink: { bg: "#fce7f3" },
+};
+
+export const CATEGORY_COLOR_LABELS: Record<CategoryColor, string> = {
+  red: "レッド",
+  orange: "オレンジ",
+  yellow: "イエロー",
+  green: "グリーン",
+  teal: "ティール",
+  blue: "ブルー",
+  purple: "パープル",
+  pink: "ピンク",
+};

--- a/apps/web/src/hooks/useCategories.ts
+++ b/apps/web/src/hooks/useCategories.ts
@@ -1,0 +1,59 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import type { CategoryColor } from "../types/category";
+import {
+  fetchCategories,
+  createCategory,
+  updateCategory,
+  deleteCategory,
+} from "../api/categories";
+
+const categoriesQueryKey = ["categories"] as const;
+
+export function useCategories() {
+  return useQuery({
+    queryKey: categoriesQueryKey,
+    queryFn: fetchCategories,
+  });
+}
+
+export function useCreateCategory() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: { name: string; color: CategoryColor }) =>
+      createCategory(data),
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: categoriesQueryKey });
+    },
+  });
+}
+
+export function useUpdateCategory() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      id,
+      data,
+    }: {
+      id: string;
+      data: { name?: string; color?: CategoryColor };
+    }) => updateCategory(id, data),
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: categoriesQueryKey });
+    },
+  });
+}
+
+export function useDeleteCategory() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => deleteCategory(id),
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: categoriesQueryKey });
+      // カテゴリ削除時、タスクの categoryId が null になるのでタスクキャッシュも無効化
+      void queryClient.invalidateQueries({ queryKey: ["tasks"] });
+    },
+  });
+}

--- a/apps/web/src/hooks/useTasks.ts
+++ b/apps/web/src/hooks/useTasks.ts
@@ -23,6 +23,7 @@ export function useCreateTask(year: number, month: number) {
       description?: string | null;
       date: string;
       status?: "todo" | "done";
+      categoryId?: string | null;
     }) => createTask(data),
     onMutate: async (newTask) => {
       await queryClient.cancelQueries({ queryKey: key });
@@ -36,6 +37,7 @@ export function useCreateTask(year: number, month: number) {
           description: newTask.description ?? null,
           date: newTask.date,
           status: newTask.status ?? "todo",
+          categoryId: newTask.categoryId ?? null,
           userId: "",
           createdAt: new Date().toISOString(),
           updatedAt: new Date().toISOString(),
@@ -70,6 +72,7 @@ export function useUpdateTask(year: number, month: number) {
         description?: string | null;
         date?: string;
         status?: "todo" | "done";
+        categoryId?: string | null;
       };
     }) => updateTask(id, data),
     onMutate: async ({ id, data }) => {

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as LoginRouteImport } from './routes/login'
 import { Route as AppRouteImport } from './routes/app'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as AppIndexRouteImport } from './routes/app/index'
+import { Route as AppSettingsRouteImport } from './routes/app/settings'
 
 const SignupRoute = SignupRouteImport.update({
   id: '/signup',
@@ -40,18 +41,25 @@ const AppIndexRoute = AppIndexRouteImport.update({
   path: '/',
   getParentRoute: () => AppRoute,
 } as any)
+const AppSettingsRoute = AppSettingsRouteImport.update({
+  id: '/settings',
+  path: '/settings',
+  getParentRoute: () => AppRoute,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/app': typeof AppRouteWithChildren
   '/login': typeof LoginRoute
   '/signup': typeof SignupRoute
+  '/app/settings': typeof AppSettingsRoute
   '/app/': typeof AppIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/login': typeof LoginRoute
   '/signup': typeof SignupRoute
+  '/app/settings': typeof AppSettingsRoute
   '/app': typeof AppIndexRoute
 }
 export interface FileRoutesById {
@@ -60,14 +68,22 @@ export interface FileRoutesById {
   '/app': typeof AppRouteWithChildren
   '/login': typeof LoginRoute
   '/signup': typeof SignupRoute
+  '/app/settings': typeof AppSettingsRoute
   '/app/': typeof AppIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/app' | '/login' | '/signup' | '/app/'
+  fullPaths: '/' | '/app' | '/login' | '/signup' | '/app/settings' | '/app/'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/login' | '/signup' | '/app'
-  id: '__root__' | '/' | '/app' | '/login' | '/signup' | '/app/'
+  to: '/' | '/login' | '/signup' | '/app/settings' | '/app'
+  id:
+    | '__root__'
+    | '/'
+    | '/app'
+    | '/login'
+    | '/signup'
+    | '/app/settings'
+    | '/app/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -114,14 +130,23 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppIndexRouteImport
       parentRoute: typeof AppRoute
     }
+    '/app/settings': {
+      id: '/app/settings'
+      path: '/settings'
+      fullPath: '/app/settings'
+      preLoaderRoute: typeof AppSettingsRouteImport
+      parentRoute: typeof AppRoute
+    }
   }
 }
 
 interface AppRouteChildren {
+  AppSettingsRoute: typeof AppSettingsRoute
   AppIndexRoute: typeof AppIndexRoute
 }
 
 const AppRouteChildren: AppRouteChildren = {
+  AppSettingsRoute: AppSettingsRoute,
   AppIndexRoute: AppIndexRoute,
 }
 

--- a/apps/web/src/routes/app/index.tsx
+++ b/apps/web/src/routes/app/index.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, Link } from "@tanstack/react-router";
 import { authClient } from "../../auth-client";
 import { Calendar } from "../../components/Calendar";
 
@@ -24,6 +24,25 @@ function HomePage() {
             <span className="text-sm text-on-surface-secondary">
               {session?.user?.name}
             </span>
+            <Link
+              to="/app/settings"
+              className="text-on-surface-secondary hover:text-on-surface"
+              aria-label="設定"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="h-5 w-5"
+              >
+                <circle cx="12" cy="12" r="3" />
+                <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+              </svg>
+            </Link>
             <button
               type="button"
               onClick={handleSignOut}

--- a/apps/web/src/routes/app/settings.tsx
+++ b/apps/web/src/routes/app/settings.tsx
@@ -1,0 +1,258 @@
+import { useState } from "react";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import {
+  Dialog,
+  DialogBackdrop,
+  DialogPanel,
+  DialogTitle,
+} from "@headlessui/react";
+import { authClient } from "../../auth-client";
+import { CategoryForm } from "../../components/CategoryForm";
+import { CATEGORY_COLORS } from "../../constants/categoryColors";
+import {
+  useCategories,
+  useCreateCategory,
+  useUpdateCategory,
+  useDeleteCategory,
+} from "../../hooks/useCategories";
+import type { Category, CategoryColor } from "../../types/category";
+
+export const Route = createFileRoute("/app/settings")({
+  component: SettingsPage,
+});
+
+function SettingsPage() {
+  const { data: session } = authClient.useSession();
+  const {
+    data: categories = [],
+    isLoading,
+    isError: isFetchError,
+  } = useCategories();
+  const createMutation = useCreateCategory();
+  const updateMutation = useUpdateCategory();
+  const deleteMutation = useDeleteCategory();
+
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [editingCategory, setEditingCategory] = useState<Category | null>(null);
+  const [deletingCategory, setDeletingCategory] = useState<Category | null>(
+    null,
+  );
+  const [error, setError] = useState<string | null>(null);
+
+  const handleCreate = (data: { name: string; color: CategoryColor }) => {
+    setError(null);
+    createMutation.mutate(data, {
+      onSuccess: () => setShowCreateForm(false),
+      onError: () => setError("カテゴリの作成に失敗しました"),
+    });
+  };
+
+  const handleUpdate = (data: { name: string; color: CategoryColor }) => {
+    if (!editingCategory) return;
+    setError(null);
+    updateMutation.mutate(
+      { id: editingCategory.id, data },
+      {
+        onSuccess: () => setEditingCategory(null),
+        onError: () => setError("カテゴリの更新に失敗しました"),
+      },
+    );
+  };
+
+  const handleDelete = () => {
+    if (!deletingCategory) return;
+    setError(null);
+    deleteMutation.mutate(deletingCategory.id, {
+      onSuccess: () => setDeletingCategory(null),
+      onError: () => setError("カテゴリの削除に失敗しました"),
+    });
+  };
+
+  const handleSignOut = () => {
+    void authClient.signOut().then(() => {
+      window.location.href = "/login";
+    });
+  };
+
+  return (
+    <div className="min-h-screen bg-surface">
+      <header className="border-b border-border-light bg-white px-4 py-1.5">
+        <div className="mx-auto flex max-w-[1600px] items-center justify-between">
+          <h1 className="text-lg font-bold text-on-surface">tascal</h1>
+          <div className="flex items-center gap-4">
+            <span className="text-sm text-on-surface-secondary">
+              {session?.user?.name}
+            </span>
+            <Link
+              to="/app"
+              className="text-on-surface-secondary hover:text-on-surface"
+              aria-label="カレンダーに戻る"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="h-5 w-5"
+              >
+                <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+                <line x1="16" y1="2" x2="16" y2="6" />
+                <line x1="8" y1="2" x2="8" y2="6" />
+                <line x1="3" y1="10" x2="21" y2="10" />
+              </svg>
+            </Link>
+            <button
+              type="button"
+              onClick={handleSignOut}
+              className="rounded-md border border-border bg-white px-3 py-1.5 text-sm text-on-surface-secondary hover:bg-surface-hover"
+            >
+              ログアウト
+            </button>
+          </div>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-2xl p-4">
+        <h2 className="mb-4 text-xl font-bold text-on-surface">カテゴリ管理</h2>
+
+        {error && (
+          <div className="mb-4 rounded-md bg-danger-light px-3 py-2 text-sm text-danger">
+            {error}
+          </div>
+        )}
+
+        {isLoading ? (
+          <p className="text-sm text-on-surface-secondary">読み込み中...</p>
+        ) : isFetchError ? (
+          <div className="rounded-md bg-danger-light px-3 py-2 text-sm text-danger">
+            カテゴリの取得に失敗しました。ページを再読み込みしてください。
+          </div>
+        ) : (
+          <>
+            {categories.length === 0 && !showCreateForm && (
+              <p className="mb-4 text-sm text-on-surface-secondary">
+                カテゴリがまだありません。作成してタスクを色分けしましょう。
+              </p>
+            )}
+
+            <ul className="mb-4 space-y-2">
+              {categories.map((category) =>
+                editingCategory?.id === category.id ? (
+                  <li
+                    key={category.id}
+                    className="rounded-lg border border-border bg-white p-4"
+                  >
+                    <CategoryForm
+                      initialName={category.name}
+                      initialColor={category.color}
+                      onSubmit={handleUpdate}
+                      onCancel={() => setEditingCategory(null)}
+                      saving={updateMutation.isPending}
+                    />
+                  </li>
+                ) : (
+                  <li
+                    key={category.id}
+                    className="flex items-center justify-between rounded-lg border border-border bg-white px-4 py-3"
+                  >
+                    <div className="flex items-center gap-3">
+                      <span
+                        className="inline-block h-5 w-5 shrink-0 rounded-full"
+                        style={{
+                          backgroundColor: CATEGORY_COLORS[category.color].bg,
+                        }}
+                      />
+                      <span className="text-sm text-on-surface">
+                        {category.name}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <button
+                        type="button"
+                        onClick={() => setEditingCategory(category)}
+                        className="rounded-md border border-border bg-white px-3 py-1 text-xs text-on-surface-secondary hover:bg-surface-hover"
+                      >
+                        編集
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setDeletingCategory(category)}
+                        className="rounded-md border border-border bg-white px-3 py-1 text-xs text-danger hover:bg-danger-light"
+                      >
+                        削除
+                      </button>
+                    </div>
+                  </li>
+                ),
+              )}
+            </ul>
+
+            {showCreateForm ? (
+              <div className="rounded-lg border border-border bg-white p-4">
+                <CategoryForm
+                  onSubmit={handleCreate}
+                  onCancel={() => setShowCreateForm(false)}
+                  saving={createMutation.isPending}
+                />
+              </div>
+            ) : (
+              <button
+                type="button"
+                onClick={() => setShowCreateForm(true)}
+                className="rounded-md bg-primary px-4 py-2 text-sm text-white hover:bg-primary-dark"
+              >
+                カテゴリを追加
+              </button>
+            )}
+          </>
+        )}
+      </main>
+
+      {/* 削除確認ダイアログ */}
+      <Dialog
+        open={!!deletingCategory}
+        onClose={() => setDeletingCategory(null)}
+        className="relative z-50"
+      >
+        <DialogBackdrop
+          transition
+          className="fixed inset-0 bg-black/50 transition-opacity duration-200 ease-out data-[closed]:opacity-0"
+        />
+        <div className="fixed inset-0 flex items-center justify-center">
+          <DialogPanel
+            transition
+            className="w-full max-w-sm rounded-lg bg-white p-6 shadow-xl transition duration-200 ease-out data-[closed]:scale-95 data-[closed]:opacity-0"
+          >
+            <DialogTitle className="mb-2 text-lg font-bold text-on-surface">
+              カテゴリの削除
+            </DialogTitle>
+            <p className="mb-6 text-sm text-on-surface-secondary">
+              「{deletingCategory?.name}
+              」を削除しますか？このカテゴリが設定されたタスクはカテゴリなしになります。
+            </p>
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setDeletingCategory(null)}
+                className="rounded-md border border-border bg-white px-4 py-2 text-sm text-on-surface-secondary hover:bg-surface-hover"
+              >
+                キャンセル
+              </button>
+              <button
+                type="button"
+                onClick={handleDelete}
+                disabled={deleteMutation.isPending}
+                className="rounded-md bg-danger px-4 py-2 text-sm text-white hover:bg-danger-dark disabled:opacity-50"
+              >
+                削除
+              </button>
+            </div>
+          </DialogPanel>
+        </div>
+      </Dialog>
+    </div>
+  );
+}

--- a/apps/web/src/types/category.ts
+++ b/apps/web/src/types/category.ts
@@ -1,0 +1,18 @@
+export type CategoryColor =
+  | "red"
+  | "orange"
+  | "yellow"
+  | "green"
+  | "teal"
+  | "blue"
+  | "purple"
+  | "pink";
+
+export type Category = {
+  id: string;
+  name: string;
+  color: CategoryColor;
+  userId: string;
+  createdAt: string;
+  updatedAt: string;
+};

--- a/apps/web/src/types/task.ts
+++ b/apps/web/src/types/task.ts
@@ -4,6 +4,7 @@ export type Task = {
   description: string | null;
   date: string;
   status: "todo" | "done";
+  categoryId: string | null;
   userId: string;
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
close #11

## Summary

タスクにカテゴリを付与し、カレンダー上でカテゴリの色によりタスクを視覚的に区別できるようにする機能を追加。

### 変更内容

**API (apps/api)**
- `categories` テーブル追加 (id, name, color, userId) + `tasks` テーブルに `categoryId` (nullable FK, onDelete: set null) 追加
- カテゴリ CRUD API (`/api/categories`) — GET (一覧), POST (作成), PATCH (更新), DELETE (削除)
- タスク作成/更新時に `categoryId` を受け付け、所有者バリデーション付き
- Drizzle マイグレーション生成済み
- カテゴリ API テスト追加

**Web (apps/web)**
- 設定ページ `/app/settings` — カテゴリの一覧・作成・編集・削除が可能
- カレンダー画面ヘッダーに歯車アイコンを追加し、設定ページへ遷移
- タスク作成/編集フォームにカテゴリ選択ドロップダウンを追加
- カレンダー上でカテゴリの色が背景色として反映（8色プリセット: red, orange, yellow, green, teal, blue, purple, pink）
- カテゴリ未設定のタスクは既存のプライマリ色で表示

### プリセットカラー

| Key | 背景色 |
|-----|--------|
| red | #fde8e8 |
| orange | #fff1e6 |
| yellow | #fef9c3 |
| green | #dcfce7 |
| teal | #ccfbf1 |
| blue | #dbeafe |
| purple | #f3e8ff |
| pink | #fce7f3 |

文字色は全て既存の `text-on-surface` (#2d2a26) で統一。

## Test plan

- [x] `pnpm lint` 通過
- [x] `pnpm format:check` 通過
- [x] `pnpm typecheck` 通過
- [x] `pnpm test` 通過 (API 64 tests, Web 40 tests)
- [x] `pnpm knip` 通過
- [x] `pnpm build` 通過
- [ ] 設定ページでカテゴリの作成・編集・削除が動作する
- [ ] タスク作成/編集時にカテゴリを選択/解除できる
- [ ] カレンダー上でカテゴリの色が背景色として反映される
- [ ] カテゴリ未設定のタスクは既存のプライマリ色で表示される
- [ ] カテゴリ削除時にタスクのカテゴリが自動解除される

🤖 Generated with [Claude Code](https://claude.com/claude-code)