### PR TITLE
feat: ログアウト・退会機能を設定画面に移動

### DIFF
--- a/apps/web/src/routes/__tests__/settings.test.tsx
+++ b/apps/web/src/routes/__tests__/settings.test.tsx
@@ -43,7 +43,7 @@ describe("SettingsPage アカウントセクション", () => {
     });
     mockFetchCategories.mockResolvedValue([]);
     // Import to trigger createFileRoute and capture the component
-    await import("../app/settings.tsx");
+    await import("../app/settings");
   });
 
   function renderSettingsPage() {

--- a/apps/web/src/routes/__tests__/settings.test.tsx
+++ b/apps/web/src/routes/__tests__/settings.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithQueryClient } from "../../test/helpers";
+
+const mockUseSession = vi.fn();
+const mockSignOut = vi.fn();
+const mockFetchCategories = vi.fn();
+
+vi.mock("../../auth-client", () => ({
+  authClient: {
+    useSession: () => mockUseSession() as unknown,
+    signOut: (...args: unknown[]) => mockSignOut(...args) as unknown,
+  },
+}));
+
+vi.mock("../../api/categories", () => ({
+  fetchCategories: (...args: unknown[]) =>
+    mockFetchCategories(...args) as unknown,
+}));
+
+vi.mock("../../api/users", () => ({
+  deleteAccount: vi.fn(),
+}));
+
+let capturedComponent: React.ComponentType | null = null;
+
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: () => (opts: { component: React.ComponentType }) => {
+    capturedComponent = opts.component;
+    return { options: opts };
+  },
+  Link: ({ children, ...props }: { children: React.ReactNode; to: string }) => (
+    <a {...props}>{children}</a>
+  ),
+}));
+
+describe("SettingsPage アカウントセクション", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockUseSession.mockReturnValue({
+      data: { user: { id: "1", name: "テストユーザー" }, session: {} },
+    });
+    mockFetchCategories.mockResolvedValue([]);
+    // Import to trigger createFileRoute and capture the component
+    await import("../app/settings.tsx");
+  });
+
+  function renderSettingsPage() {
+    const Component = capturedComponent!;
+    renderWithQueryClient(<Component />);
+  }
+
+  it("ログアウトボタンが表示される", () => {
+    renderSettingsPage();
+
+    expect(
+      screen.getByRole("button", { name: "ログアウト" }),
+    ).toBeInTheDocument();
+  });
+
+  it("アカウント削除ボタンが表示される", () => {
+    renderSettingsPage();
+
+    expect(
+      screen.getByRole("button", { name: "アカウント削除" }),
+    ).toBeInTheDocument();
+  });
+
+  it("アカウント削除ボタンをクリックするとモーダルが開く", async () => {
+    const user = userEvent.setup();
+    renderSettingsPage();
+
+    await user.click(screen.getByRole("button", { name: "アカウント削除" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "この操作は取り消せません。アカウントとすべてのデータが完全に削除されます。",
+        ),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/routes/app/index.tsx
+++ b/apps/web/src/routes/app/index.tsx
@@ -1,8 +1,6 @@
-import { useState } from "react";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { authClient } from "../../auth-client";
 import { Calendar } from "../../components/Calendar";
-import { DeleteAccountModal } from "../../components/DeleteAccountModal";
 
 export const Route = createFileRoute("/app/")({
   component: HomePage,
@@ -10,13 +8,6 @@ export const Route = createFileRoute("/app/")({
 
 function HomePage() {
   const { data: session } = authClient.useSession();
-  const [showDeleteModal, setShowDeleteModal] = useState(false);
-
-  const handleSignOut = () => {
-    void authClient.signOut().then(() => {
-      window.location.href = "/login";
-    });
-  };
 
   return (
     <div className="min-h-screen bg-surface">
@@ -46,30 +37,12 @@ function HomePage() {
                 <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
               </svg>
             </Link>
-            <button
-              type="button"
-              onClick={handleSignOut}
-              className="rounded-md border border-border bg-white px-3 py-1.5 text-sm text-on-surface-secondary hover:bg-surface-hover"
-            >
-              ログアウト
-            </button>
-            <button
-              type="button"
-              onClick={() => setShowDeleteModal(true)}
-              className="rounded-md border border-danger bg-white px-3 py-1.5 text-sm text-danger hover:bg-danger-light"
-            >
-              アカウント削除
-            </button>
           </div>
         </div>
       </header>
       <main className="p-4">
         <Calendar />
       </main>
-      <DeleteAccountModal
-        open={showDeleteModal}
-        onClose={() => setShowDeleteModal(false)}
-      />
     </div>
   );
 }

--- a/apps/web/src/routes/app/settings.tsx
+++ b/apps/web/src/routes/app/settings.tsx
@@ -8,6 +8,7 @@ import {
 } from "@headlessui/react";
 import { authClient } from "../../auth-client";
 import { CategoryForm } from "../../components/CategoryForm";
+import { DeleteAccountModal } from "../../components/DeleteAccountModal";
 import { CATEGORY_COLORS } from "../../constants/categoryColors";
 import {
   useCategories,
@@ -37,6 +38,7 @@ function SettingsPage() {
   const [deletingCategory, setDeletingCategory] = useState<Category | null>(
     null,
   );
+  const [showDeleteAccountModal, setShowDeleteAccountModal] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const handleCreate = (data: { name: string; color: CategoryColor }) => {
@@ -104,13 +106,6 @@ function SettingsPage() {
                 <line x1="3" y1="10" x2="21" y2="10" />
               </svg>
             </Link>
-            <button
-              type="button"
-              onClick={handleSignOut}
-              className="rounded-md border border-border bg-white px-3 py-1.5 text-sm text-on-surface-secondary hover:bg-surface-hover"
-            >
-              ログアウト
-            </button>
           </div>
         </div>
       </header>
@@ -209,7 +204,33 @@ function SettingsPage() {
             )}
           </>
         )}
+        <h2 className="mb-4 mt-8 text-xl font-bold text-on-surface">
+          アカウント
+        </h2>
+        <div className="space-y-3">
+          <button
+            type="button"
+            onClick={handleSignOut}
+            className="rounded-md border border-border bg-white px-4 py-2 text-sm text-on-surface-secondary hover:bg-surface-hover"
+          >
+            ログアウト
+          </button>
+          <div>
+            <button
+              type="button"
+              onClick={() => setShowDeleteAccountModal(true)}
+              className="rounded-md border border-danger bg-white px-4 py-2 text-sm text-danger hover:bg-danger-light"
+            >
+              アカウント削除
+            </button>
+          </div>
+        </div>
       </main>
+
+      <DeleteAccountModal
+        open={showDeleteAccountModal}
+        onClose={() => setShowDeleteAccountModal(false)}
+      />
 
       {/* 削除確認ダイアログ */}
       <Dialog


### PR DESCRIPTION
close #151

## 概要

メインページ (`/app`) に配置されていたログアウトボタンとアカウント削除ボタンを設定画面 (`/app/settings`) のアカウントセクションに移動し、UIを整理する。

## 変更内容

- `apps/web/src/routes/app/index.tsx`: ログアウトボタン、アカウント削除ボタン、DeleteAccountModal を除去
- `apps/web/src/routes/app/settings.tsx`: ヘッダーからログアウトボタンを除去し、メインコンテンツに「アカウント」セクションを新設。ログアウトボタンとアカウント削除ボタン + DeleteAccountModal を配置
- `apps/web/src/routes/__tests__/settings.test.tsx`: 設定ページのアカウントセクションのテストを追加

## テストプラン

- [ ] 設定ページにログアウトボタンが表示されること
- [ ] 設定ページにアカウント削除ボタンが表示されること
- [ ] アカウント削除ボタンクリックで確認モーダルが開くこと
- [ ] メインページにログアウト・アカウント削除ボタンが表示されないこと
- [ ] `pnpm test` が全件パスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)