### PR TITLE
feat: カテゴリ未設定タスクに枠線を追加

### DIFF
--- a/apps/web/src/components/DraggableTask.tsx
+++ b/apps/web/src/components/DraggableTask.tsx
@@ -32,10 +32,10 @@ export function DraggableTask({
         isDragging
           ? "border border-dashed border-border bg-surface text-transparent [&_input]:invisible"
           : task.status === "done"
-            ? "text-on-surface-muted line-through"
+            ? "border border-border text-on-surface-muted line-through"
             : categoryBg
               ? "text-on-surface"
-              : "bg-white text-on-surface"
+              : "border border-border bg-white text-on-surface"
       }`}
       style={
         !isDragging && task.status !== "done" && categoryBg


### PR DESCRIPTION
## Summary
- カテゴリ未設定のタスクと完了済みタスクに `border-border` の枠線を追加
- カテゴリ付きタスクは背景色で区別できるため枠線なし（従来通り）
- デザイントークン `border-border` を使用し、既存のスタイルと統一

## Test plan
- [x] lint / typecheck / test すべてパス
- [x] ローカル環境でブラウザ確認済み（カテゴリなしタスクに枠線表示、カテゴリありタスクは枠線なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)