### PR TITLE
feat: デプロイ時にDBマイグレーションを自動実行する

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+
       - id: auth
         uses: google-github-actions/auth@v2
         with:
@@ -31,6 +37,14 @@ jobs:
       - name: Configure Docker for Artifact Registry
         run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --quiet
 
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run database migrations
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: pnpm --filter @tascal/api exec drizzle-kit migrate
+
       - name: Build and push Docker image
         run: |
           IMAGE=${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.SERVICE_NAME }}:${{ github.sha }}
@@ -39,6 +53,7 @@ jobs:
 
       # Cloud Run の環境変数（DATABASE_URL, BETTER_AUTH_SECRET, BETTER_AUTH_URL, TRUSTED_ORIGINS）は
       # Google Cloud コンソールまたは gcloud CLI で事前に設定してください
+      # GitHub Secrets にも DATABASE_URL の設定が必要です（マイグレーション実行用）
       - name: Deploy to Cloud Run
         run: |
           IMAGE=${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.SERVICE_NAME }}:${{ github.sha }}


### PR DESCRIPTION
close #152

## 概要

- デプロイワークフロー（deploy.yml）に `drizzle-kit migrate` ステップを追加し、Cloud Run デプロイ前にDBマイグレーションを自動実行する
- マイグレーション失敗時は後続のビルド・デプロイが中断される（安全側に倒す）
- プレビュー環境（preview.yml）と同じ方式で実行

## 変更内容

- pnpm / Node.js セットアップステップを追加
- `pnpm install --frozen-lockfile` で依存インストール
- `drizzle-kit migrate` をデプロイ前に実行（`DATABASE_URL` は GitHub Secrets から取得）
- 運用コメントに `DATABASE_URL` Secret の必要性を追記

## 前提条件

- GitHub Secrets に `DATABASE_URL`（本番DB接続文字列）の設定が必要

## テスト計画

- [ ] GitHub Secrets に `DATABASE_URL` が設定されていることを確認
- [ ] main マージ後、デプロイワークフローでマイグレーションステップが成功することを確認
- [ ] ローカル開発（`pnpm dev`）に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)