### PR TITLE
テストファイルをソースファイルと同階層にコロケーション

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,8 +38,8 @@ tascal (task + calendar) — カレンダービューがメインのタスク管
 
 個別 app でのテスト実行：
 ```bash
-pnpm --filter @tascal/api exec vitest run src/routes/__tests__/tasks.test.ts  # 単一テスト
-pnpm --filter @tascal/web exec vitest run src/components/__tests__/Calendar.test.tsx
+pnpm --filter @tascal/api exec vitest run src/routes/tasks.test.ts  # 単一テスト
+pnpm --filter @tascal/web exec vitest run src/components/Calendar.test.tsx
 ```
 
 ウォッチモード: `pnpm --filter @tascal/api run test:watch`

--- a/apps/api/src/routes/categories.test.ts
+++ b/apps/api/src/routes/categories.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Hono } from "hono";
-import type { Auth } from "../../auth.js";
+import type { Auth } from "../auth.js";
 
 type AuthVariables = {
   user: Auth["$Infer"]["Session"]["user"] | null;
@@ -32,7 +32,7 @@ const mockInsert = vi.fn();
 const mockUpdate = vi.fn();
 const mockDelete = vi.fn();
 
-vi.mock("../../db/index.js", () => ({
+vi.mock("../db/index.js", () => ({
   getDb: () => ({
     select: () => ({
       from: () => ({
@@ -61,13 +61,13 @@ vi.mock("../../db/index.js", () => ({
   }),
 }));
 
-vi.mock("../../db/schema.js", async () => {
-  const actual = await vi.importActual("../../db/schema.js");
+vi.mock("../db/schema.js", async () => {
+  const actual = await vi.importActual("../db/schema.js");
   return actual;
 });
 
 async function createTestApp(user: AuthVariables["user"] = mockUser) {
-  const categoriesApp = (await import("../categories.js")).default;
+  const categoriesApp = (await import("./categories.js")).default;
 
   const app = new Hono<{ Variables: AuthVariables }>();
   app.use("*", async (c, next) => {

--- a/apps/api/src/routes/healthz.test.ts
+++ b/apps/api/src/routes/healthz.test.ts
@@ -2,20 +2,20 @@ import { describe, it, expect, vi } from "vitest";
 
 const mockExecute = vi.fn();
 
-vi.mock("../../db/index.js", () => ({
+vi.mock("../db/index.js", () => ({
   getDb: () => ({
     execute: mockExecute,
   }),
 }));
 
-vi.mock("../../auth.js", () => ({
+vi.mock("../auth.js", () => ({
   getAuth: () => ({
     api: { getSession: vi.fn().mockResolvedValue(null) },
     handler: vi.fn(),
   }),
 }));
 
-const { default: app } = await import("../../app.js");
+const { default: app } = await import("../app.js");
 
 describe("GET /healthz", () => {
   it("DB 接続成功時に 200 と { status: 'ok' } を返す", async () => {

--- a/apps/api/src/routes/tasks.test.ts
+++ b/apps/api/src/routes/tasks.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Hono } from "hono";
-import type { Auth } from "../../auth.js";
+import type { Auth } from "../auth.js";
 
 type AuthVariables = {
   user: Auth["$Infer"]["Session"]["user"] | null;
@@ -34,7 +34,7 @@ const mockInsert = vi.fn();
 const mockUpdate = vi.fn();
 const mockDelete = vi.fn();
 
-vi.mock("../../db/index.js", () => ({
+vi.mock("../db/index.js", () => ({
   getDb: () => ({
     select: () => ({
       from: () => ({
@@ -61,8 +61,8 @@ vi.mock("../../db/index.js", () => ({
   }),
 }));
 
-vi.mock("../../db/schema.js", async () => {
-  const actual = await vi.importActual("../../db/schema.js");
+vi.mock("../db/schema.js", async () => {
+  const actual = await vi.importActual("../db/schema.js");
   return actual;
 });
 
@@ -71,7 +71,7 @@ vi.mock("../../db/schema.js", async () => {
  * 認証済みユーザーを Variables にセットした状態で tasks ルートをマウントする。
  */
 async function createTestApp(user: AuthVariables["user"] = mockUser) {
-  const tasksApp = (await import("../tasks.js")).default;
+  const tasksApp = (await import("./tasks.js")).default;
 
   const app = new Hono<{ Variables: AuthVariables }>();
   app.use("*", async (c, next) => {

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Hono } from "hono";
-import type { Auth } from "../../auth.js";
+import type { Auth } from "../auth.js";
 
 type AuthVariables = {
   user: Auth["$Infer"]["Session"]["user"] | null;
@@ -19,7 +19,7 @@ const mockUser = {
 
 const mockDelete = vi.fn();
 
-vi.mock("../../db/index.js", () => ({
+vi.mock("../db/index.js", () => ({
   getDb: () => ({
     delete: () => ({
       where: () => ({
@@ -29,13 +29,13 @@ vi.mock("../../db/index.js", () => ({
   }),
 }));
 
-vi.mock("../../db/schema.js", async () => {
-  const actual = await vi.importActual("../../db/schema.js");
+vi.mock("../db/schema.js", async () => {
+  const actual = await vi.importActual("../db/schema.js");
   return actual;
 });
 
 async function createTestApp(user: AuthVariables["user"] = mockUser) {
-  const usersApp = (await import("../users.js")).default;
+  const usersApp = (await import("./users.js")).default;
 
   const app = new Hono<{ Variables: AuthVariables }>();
   app.use("*", async (c, next) => {

--- a/apps/web/src/components/Calendar.test.tsx
+++ b/apps/web/src/components/Calendar.test.tsx
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { Calendar } from "../Calendar";
-import { renderWithQueryClient } from "../../test/helpers";
+import { Calendar } from "./Calendar";
+import { renderWithQueryClient } from "../test/helpers";
 
 // API モック
 const mockFetchTasks = vi.fn();
@@ -10,7 +10,7 @@ const mockCreateTask = vi.fn();
 const mockUpdateTask = vi.fn();
 const mockDeleteTask = vi.fn();
 
-vi.mock("../../api/tasks", () => ({
+vi.mock("../api/tasks", () => ({
   fetchTasks: (...args: unknown[]) => mockFetchTasks(...args) as unknown,
   createTask: (...args: unknown[]) => mockCreateTask(...args) as unknown,
   updateTask: (...args: unknown[]) => mockUpdateTask(...args) as unknown,

--- a/apps/web/src/components/DeleteAccountModal.test.tsx
+++ b/apps/web/src/components/DeleteAccountModal.test.tsx
@@ -1,12 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { DeleteAccountModal } from "../DeleteAccountModal";
-import { renderWithQueryClient } from "../../test/helpers";
+import { DeleteAccountModal } from "./DeleteAccountModal";
+import { renderWithQueryClient } from "../test/helpers";
 
 const mockDeleteAccount = vi.fn();
 
-vi.mock("../../api/users", () => ({
+vi.mock("../api/users", () => ({
   deleteAccount: (...args: unknown[]) => mockDeleteAccount(...args) as unknown,
 }));
 

--- a/apps/web/src/components/TaskDetailModal.test.tsx
+++ b/apps/web/src/components/TaskDetailModal.test.tsx
@@ -1,13 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { TaskDetailModal } from "../TaskDetailModal";
-import { renderWithQueryClient } from "../../test/helpers";
+import { TaskDetailModal } from "./TaskDetailModal";
+import { renderWithQueryClient } from "../test/helpers";
 
 const mockUpdateTask = vi.fn();
 const mockDeleteTask = vi.fn();
 
-vi.mock("../../api/tasks", () => ({
+vi.mock("../api/tasks", () => ({
   updateTask: (...args: unknown[]) => mockUpdateTask(...args) as unknown,
   deleteTask: (...args: unknown[]) => mockDeleteTask(...args) as unknown,
 }));

--- a/apps/web/src/components/TaskFormModal.test.tsx
+++ b/apps/web/src/components/TaskFormModal.test.tsx
@@ -1,12 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { TaskFormModal } from "../TaskFormModal";
-import { renderWithQueryClient } from "../../test/helpers";
+import { TaskFormModal } from "./TaskFormModal";
+import { renderWithQueryClient } from "../test/helpers";
 
 const mockCreateTask = vi.fn();
 
-vi.mock("../../api/tasks", () => ({
+vi.mock("../api/tasks", () => ({
   createTask: (...args: unknown[]) => mockCreateTask(...args) as unknown,
 }));
 

--- a/apps/web/src/routes/auth-redirect.test.ts
+++ b/apps/web/src/routes/auth-redirect.test.ts
@@ -3,7 +3,7 @@ import { isRedirect } from "@tanstack/react-router";
 
 const mockGetSession = vi.fn();
 
-vi.mock("../../auth-client", () => ({
+vi.mock("../auth-client", () => ({
   authClient: {
     getSession: (...args: unknown[]) => mockGetSession(...args) as unknown,
   },
@@ -20,7 +20,7 @@ describe("/login beforeLoad", () => {
       data: { user: { id: "1" }, session: {} },
     });
 
-    const { Route } = await import("../login");
+    const { Route } = await import("./login");
     const beforeLoad = Route.options.beforeLoad!;
 
     try {
@@ -35,7 +35,7 @@ describe("/login beforeLoad", () => {
   it("未ログインの場合リダイレクトしない", async () => {
     mockGetSession.mockResolvedValue({ data: null });
 
-    const { Route } = await import("../login");
+    const { Route } = await import("./login");
     const beforeLoad = Route.options.beforeLoad!;
 
     await expect(
@@ -55,7 +55,7 @@ describe("/signup beforeLoad", () => {
       data: { user: { id: "1" }, session: {} },
     });
 
-    const { Route } = await import("../signup");
+    const { Route } = await import("./signup");
     const beforeLoad = Route.options.beforeLoad!;
 
     try {
@@ -70,7 +70,7 @@ describe("/signup beforeLoad", () => {
   it("未ログインの場合リダイレクトしない", async () => {
     mockGetSession.mockResolvedValue({ data: null });
 
-    const { Route } = await import("../signup");
+    const { Route } = await import("./signup");
     const beforeLoad = Route.options.beforeLoad!;
 
     await expect(

--- a/apps/web/src/routes/settings.test.tsx
+++ b/apps/web/src/routes/settings.test.tsx
@@ -1,25 +1,25 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { renderWithQueryClient } from "../../test/helpers";
+import { renderWithQueryClient } from "../test/helpers";
 
 const mockUseSession = vi.fn();
 const mockSignOut = vi.fn();
 const mockFetchCategories = vi.fn();
 
-vi.mock("../../auth-client", () => ({
+vi.mock("../auth-client", () => ({
   authClient: {
     useSession: () => mockUseSession() as unknown,
     signOut: (...args: unknown[]) => mockSignOut(...args) as unknown,
   },
 }));
 
-vi.mock("../../api/categories", () => ({
+vi.mock("../api/categories", () => ({
   fetchCategories: (...args: unknown[]) =>
     mockFetchCategories(...args) as unknown,
 }));
 
-vi.mock("../../api/users", () => ({
+vi.mock("../api/users", () => ({
   deleteAccount: vi.fn(),
 }));
 
@@ -43,7 +43,7 @@ describe("SettingsPage アカウントセクション", () => {
     });
     mockFetchCategories.mockResolvedValue([]);
     // Import to trigger createFileRoute and capture the component
-    await import("../app/settings");
+    await import("./app/settings");
   });
 
   function renderSettingsPage() {

--- a/apps/web/src/utils/calendar.test.ts
+++ b/apps/web/src/utils/calendar.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { getCalendarDays } from "../calendar";
+import { getCalendarDays } from "./calendar";
 
 describe("getCalendarDays (月曜始まり)", () => {
   it("2026年4月: 水曜始まり → 先頭2日が前月パディング", () => {


### PR DESCRIPTION
close #148

## 概要

テストファイルを `__tests__/` ディレクトリから対応するソースファイルと同じディレクトリに移動（コロケーション）し、ソースとテストの対応関係を把握しやすくした。

## 変更内容

- API・Web の全テストファイル（11ファイル）を `__tests__/` から親ディレクトリへ移動
- 移動に伴うインポートパスの修正（`../../` → `../` 等）
- AGENTS.md のテスト実行例パスを新配置に合わせて更新

## テスト計画

- [x] `pnpm test` — 全テスト（API 35件 + Web 48件）パス
- [x] `pnpm lint` — パス
- [x] `pnpm typecheck` — パス
- [x] `pnpm format:check` — パス
- [x] `pnpm knip` — パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)