### PR TITLE
fix: カレンダーセル展開時の外側クリックによる自動折りたたみを削除

### DIFF
--- a/apps/web/src/components/CalendarDayCell.tsx
+++ b/apps/web/src/components/CalendarDayCell.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useRef } from "react";
 import { useDroppable } from "@dnd-kit/core";
 import type { Task } from "../types/task";
 import type { Category } from "../types/category";
@@ -36,29 +35,11 @@ export function CalendarDayCell({
   const dateKey = formatDateKey(date);
   const visibleTasks = isExpanded ? tasks : tasks.slice(0, MAX_VISIBLE_TASKS);
   const remainingCount = tasks.length - MAX_VISIBLE_TASKS;
-  const cellRef = useRef<HTMLDivElement>(null);
-
   const { setNodeRef, isOver } = useDroppable({ id: dateKey });
-
-  useEffect(() => {
-    if (!isExpanded) return;
-    const handleClickOutside = (e: MouseEvent) => {
-      if (cellRef.current && !cellRef.current.contains(e.target as Node)) {
-        onCollapse();
-      }
-    };
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, [isExpanded, onCollapse]);
-
-  const setRefs = (node: HTMLDivElement | null) => {
-    setNodeRef(node);
-    (cellRef as React.MutableRefObject<HTMLDivElement | null>).current = node;
-  };
 
   return (
     <div
-      ref={setRefs}
+      ref={setNodeRef}
       role="button"
       tabIndex={0}
       onClick={() => onAddClick(dateKey)}


### PR DESCRIPTION
close #156

## 概要

カレンダーの日付セルで「+N件」ボタンにより展開した後、セル外をクリックすると自動的に折りたたまれてしまう問題を修正。

## 変更内容

- `CalendarDayCell.tsx` から `handleClickOutside` イベントリスナー（`useEffect`）を削除
- 不要になった `useRef`、`cellRef`、`setRefs` ヘルパーを削除
- `ref` を `setRefs` から `setNodeRef`（dnd-kit）に直接変更

## 動作

- 「+N件」で展開後、セル外をクリックしても展開状態が維持される
- 「折りたたむ」ボタンを押した場合のみ折りたたまれる

## テスト

- lint / typecheck / knip / テスト すべてパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)