### PR TITLE
feat: デプロイワークフローに Docker レイヤーキャッシュを導入

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,11 +45,16 @@ jobs:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: pnpm --filter @tascal/api exec drizzle-kit migrate
 
+      - uses: docker/setup-buildx-action@v3
+
       - name: Build and push Docker image
-        run: |
-          IMAGE=${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.SERVICE_NAME }}:${{ github.sha }}
-          docker build -t $IMAGE .
-          docker push $IMAGE
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.SERVICE_NAME }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       # Cloud Run の環境変数（DATABASE_URL, BETTER_AUTH_SECRET, BETTER_AUTH_URL, TRUSTED_ORIGINS）は
       # Google Cloud コンソールまたは gcloud CLI で事前に設定してください


### PR DESCRIPTION
close #159

## Summary

- デプロイワークフローの Docker build & push を `docker/build-push-action@v6` + `docker/setup-buildx-action@v3` に置き換え
- GHA cache (`type=gha`, `mode=max`) を有効にし、中間レイヤー含む全ステージをキャッシュ対象に
- 依存変更がないデプロイでの Docker build 時間短縮を実現

## 変更内容

- `docker build` + `docker push` の手動コマンドを `docker/build-push-action` アクションに統合
- BuildKit の `cache-from` / `cache-to` で GitHub Actions キャッシュバックエンドを使用
- Dockerfile やアプリケーションコードの変更なし

## Test plan

- [ ] キャッシュなし（初回）のデプロイが正常に完了すること
- [ ] 2 回目以降のデプロイでキャッシュがヒットし、Docker build ステップの時間が短縮されること
- [ ] 依存変更時にキャッシュミスが発生しても正常にビルド・デプロイできること

🤖 Generated with [Claude Code](https://claude.com/claude-code)