### PR TITLE
feat: login/signup フォームの結合テストを追加

### DIFF
--- a/apps/web/src/routes/login.test.tsx
+++ b/apps/web/src/routes/login.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithQueryClient } from "../test/helpers";
+
+const mockSignInEmail = vi.fn();
+const mockNavigate = vi.fn();
+
+vi.mock("../auth-client", () => ({
+  authClient: {
+    signIn: {
+      email: (...args: unknown[]) => mockSignInEmail(...args) as unknown,
+    },
+  },
+}));
+
+let capturedComponent: React.ComponentType | null = null;
+
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: () => (opts: { component: React.ComponentType }) => {
+    capturedComponent = opts.component;
+    return { options: opts };
+  },
+  redirect: vi.fn(),
+  useNavigate: () => mockNavigate,
+}));
+
+describe("LoginPage", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    await import("./login");
+  });
+
+  function renderLoginPage() {
+    const Component = capturedComponent!;
+    renderWithQueryClient(<Component />);
+  }
+
+  it("フォーム入力・送信で authClient.signIn.email が正しい引数で呼ばれる", async () => {
+    mockSignInEmail.mockResolvedValue({ error: null });
+    const user = userEvent.setup();
+    renderLoginPage();
+
+    await user.type(
+      screen.getByLabelText("メールアドレス"),
+      "test@example.com",
+    );
+    await user.type(screen.getByLabelText("パスワード"), "password123");
+    await user.click(screen.getByRole("button", { name: "ログイン" }));
+
+    await waitFor(() => {
+      expect(mockSignInEmail).toHaveBeenCalledWith({
+        email: "test@example.com",
+        password: "password123",
+      });
+    });
+  });
+
+  it("ログイン成功時に /app へナビゲートする", async () => {
+    mockSignInEmail.mockResolvedValue({ error: null });
+    const user = userEvent.setup();
+    renderLoginPage();
+
+    await user.type(
+      screen.getByLabelText("メールアドレス"),
+      "test@example.com",
+    );
+    await user.type(screen.getByLabelText("パスワード"), "password123");
+    await user.click(screen.getByRole("button", { name: "ログイン" }));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith({ to: "/app" });
+    });
+  });
+
+  it("API エラー時にエラーメッセージが表示される", async () => {
+    mockSignInEmail.mockResolvedValue({
+      error: { message: "メールアドレスまたはパスワードが正しくありません" },
+    });
+    const user = userEvent.setup();
+    renderLoginPage();
+
+    await user.type(
+      screen.getByLabelText("メールアドレス"),
+      "test@example.com",
+    );
+    await user.type(screen.getByLabelText("パスワード"), "wrong");
+    await user.click(screen.getByRole("button", { name: "ログイン" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("メールアドレスまたはパスワードが正しくありません"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("エラーメッセージが無い場合デフォルトメッセージが表示される", async () => {
+    mockSignInEmail.mockResolvedValue({
+      error: { message: undefined },
+    });
+    const user = userEvent.setup();
+    renderLoginPage();
+
+    await user.type(
+      screen.getByLabelText("メールアドレス"),
+      "test@example.com",
+    );
+    await user.type(screen.getByLabelText("パスワード"), "wrong");
+    await user.click(screen.getByRole("button", { name: "ログイン" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("ログインに失敗しました")).toBeInTheDocument();
+    });
+  });
+
+  it("サインアップページへのナビゲーションリンクが動作する", async () => {
+    const user = userEvent.setup();
+    renderLoginPage();
+
+    await user.click(screen.getByText("サインアップ"));
+
+    expect(mockNavigate).toHaveBeenCalledWith({ to: "/signup" });
+  });
+});

--- a/apps/web/src/routes/signup.test.tsx
+++ b/apps/web/src/routes/signup.test.tsx
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithQueryClient } from "../test/helpers";
+
+const mockSignUpEmail = vi.fn();
+const mockNavigate = vi.fn();
+
+vi.mock("../auth-client", () => ({
+  authClient: {
+    signUp: {
+      email: (...args: unknown[]) => mockSignUpEmail(...args) as unknown,
+    },
+  },
+}));
+
+let capturedComponent: React.ComponentType | null = null;
+
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: () => (opts: { component: React.ComponentType }) => {
+    capturedComponent = opts.component;
+    return { options: opts };
+  },
+  redirect: vi.fn(),
+  useNavigate: () => mockNavigate,
+}));
+
+describe("SignupPage", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    await import("./signup");
+  });
+
+  function renderSignupPage() {
+    const Component = capturedComponent!;
+    renderWithQueryClient(<Component />);
+  }
+
+  it("フォーム入力・送信で authClient.signUp.email が正しい引数で呼ばれる", async () => {
+    mockSignUpEmail.mockResolvedValue({ error: null });
+    const user = userEvent.setup();
+    renderSignupPage();
+
+    await user.type(screen.getByLabelText("名前"), "テストユーザー");
+    await user.type(
+      screen.getByLabelText("メールアドレス"),
+      "test@example.com",
+    );
+    await user.type(screen.getByLabelText("パスワード"), "password123");
+    await user.click(screen.getByRole("button", { name: "サインアップ" }));
+
+    await waitFor(() => {
+      expect(mockSignUpEmail).toHaveBeenCalledWith({
+        name: "テストユーザー",
+        email: "test@example.com",
+        password: "password123",
+      });
+    });
+  });
+
+  it("サインアップ成功時に /app へナビゲートする", async () => {
+    mockSignUpEmail.mockResolvedValue({ error: null });
+    const user = userEvent.setup();
+    renderSignupPage();
+
+    await user.type(screen.getByLabelText("名前"), "テストユーザー");
+    await user.type(
+      screen.getByLabelText("メールアドレス"),
+      "test@example.com",
+    );
+    await user.type(screen.getByLabelText("パスワード"), "password123");
+    await user.click(screen.getByRole("button", { name: "サインアップ" }));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith({ to: "/app" });
+    });
+  });
+
+  it("API エラー時にエラーメッセージが表示される", async () => {
+    mockSignUpEmail.mockResolvedValue({
+      error: { message: "このメールアドレスは既に使用されています" },
+    });
+    const user = userEvent.setup();
+    renderSignupPage();
+
+    await user.type(screen.getByLabelText("名前"), "テストユーザー");
+    await user.type(
+      screen.getByLabelText("メールアドレス"),
+      "test@example.com",
+    );
+    await user.type(screen.getByLabelText("パスワード"), "password123");
+    await user.click(screen.getByRole("button", { name: "サインアップ" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("このメールアドレスは既に使用されています"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("エラーメッセージが無い場合デフォルトメッセージが表示される", async () => {
+    mockSignUpEmail.mockResolvedValue({
+      error: { message: undefined },
+    });
+    const user = userEvent.setup();
+    renderSignupPage();
+
+    await user.type(screen.getByLabelText("名前"), "テストユーザー");
+    await user.type(
+      screen.getByLabelText("メールアドレス"),
+      "test@example.com",
+    );
+    await user.type(screen.getByLabelText("パスワード"), "password123");
+    await user.click(screen.getByRole("button", { name: "サインアップ" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("サインアップに失敗しました"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("ログインページへのナビゲーションリンクが動作する", async () => {
+    const user = userEvent.setup();
+    renderSignupPage();
+
+    await user.click(screen.getByText("ログイン"));
+
+    expect(mockNavigate).toHaveBeenCalledWith({ to: "/login" });
+  });
+});


### PR DESCRIPTION
close #146

## 概要

- LoginPage と SignupPage の結合テストを追加
- `authClient` をモックし、フォーム入力・送信・エラー表示・ナビゲーションリンクの動作を検証
- 既存の `settings.test.tsx` と同様のパターン（`createFileRoute` モック + コンポーネントキャプチャ）で実装

## テスト内容

### LoginPage (`login.test.tsx`)
- フォーム送信で `authClient.signIn.email` が正しい引数で呼ばれる
- ログイン成功時に `/app` へナビゲートする
- API エラー時にエラーメッセージが表示される
- エラーメッセージが無い場合デフォルトメッセージが表示される
- サインアップページへのナビゲーションリンクが動作する

### SignupPage (`signup.test.tsx`)
- フォーム送信で `authClient.signUp.email` が正しい引数で呼ばれる
- サインアップ成功時に `/app` へナビゲートする
- API エラー時にエラーメッセージが表示される
- エラーメッセージが無い場合デフォルトメッセージが表示される
- ログインページへのナビゲーションリンクが動作する

## テスト計画

- [x] `pnpm test` 全テスト通過 (57 tests)
- [x] `pnpm lint` 通過
- [x] `pnpm format:check` 通過
- [x] `pnpm typecheck` 通過
- [x] `pnpm knip` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)