### PR TITLE
feat: optimistic update 失敗時にトースト通知を表示

### DIFF
--- a/apps/web/src/components/Calendar.test.tsx
+++ b/apps/web/src/components/Calendar.test.tsx
@@ -17,9 +17,13 @@ vi.mock("../api/tasks", () => ({
   deleteTask: (...args: unknown[]) => mockDeleteTask(...args) as unknown,
 }));
 
-vi.mock("sonner", () => ({
-  toast: vi.fn(),
-}));
+vi.mock("sonner", () => {
+  const toast = vi.fn() as ReturnType<typeof vi.fn> & {
+    error: ReturnType<typeof vi.fn>;
+  };
+  toast.error = vi.fn();
+  return { toast };
+});
 
 // dnd-kit モック - onDragStart/onDragEnd/onDragCancel をキャプチャして手動発火可能にする
 let capturedOnDragStart: ((event: unknown) => void) | null = null;

--- a/apps/web/src/components/TaskDetailModal.test.tsx
+++ b/apps/web/src/components/TaskDetailModal.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { toast } from "sonner";
 import { TaskDetailModal } from "./TaskDetailModal";
 import { renderWithQueryClient } from "../test/helpers";
 
@@ -13,9 +14,13 @@ vi.mock("../api/tasks", () => ({
   createTask: vi.fn(),
 }));
 
-vi.mock("sonner", () => ({
-  toast: vi.fn(),
-}));
+vi.mock("sonner", () => {
+  const toast = vi.fn() as ReturnType<typeof vi.fn> & {
+    error: ReturnType<typeof vi.fn>;
+  };
+  toast.error = vi.fn();
+  return { toast };
+});
 
 const mockTask = {
   id: "task-1",
@@ -113,6 +118,7 @@ describe("TaskDetailModal", () => {
         screen.getByText("タスクの更新に失敗しました"),
       ).toBeInTheDocument();
     });
+    expect(toast.error).toHaveBeenCalledWith("タスクの更新に失敗しました");
     expect(defaultProps.onUpdated).not.toHaveBeenCalled();
   });
 
@@ -129,6 +135,7 @@ describe("TaskDetailModal", () => {
         screen.getByText("タスクの削除に失敗しました"),
       ).toBeInTheDocument();
     });
+    expect(toast.error).toHaveBeenCalledWith("タスクの削除に失敗しました");
     expect(defaultProps.onUpdated).not.toHaveBeenCalled();
   });
 

--- a/apps/web/src/hooks/useTasks.ts
+++ b/apps/web/src/hooks/useTasks.ts
@@ -51,6 +51,7 @@ export function useCreateTask(year: number, month: number) {
       if (context) {
         queryClient.setQueryData(key, context.previous);
       }
+      toast.error("タスクの作成に失敗しました");
     },
     onSettled: () => {
       void queryClient.invalidateQueries({ queryKey: key });
@@ -92,6 +93,7 @@ export function useUpdateTask(year: number, month: number) {
       if (context) {
         queryClient.setQueryData(key, context.previous);
       }
+      toast.error("タスクの更新に失敗しました");
     },
     onSettled: () => {
       void queryClient.invalidateQueries({ queryKey: key });
@@ -149,6 +151,7 @@ export function useDeleteTask(year: number, month: number) {
       if (context) {
         queryClient.setQueryData(key, context.previous);
       }
+      toast.error("タスクの削除に失敗しました");
     },
     onSettled: () => {
       void queryClient.invalidateQueries({ queryKey: key });


### PR DESCRIPTION
close #101

## Summary

- `useCreateTask`, `useUpdateTask`, `useDeleteTask` の `onError` で `toast.error()` によるエラー通知を追加
- 操作種別に応じたメッセージを表示（「タスクの作成/更新/削除に失敗しました」）
- sonner の既存トースト基盤を活用（新規ライブラリ追加なし）
- テストの sonner モックに `toast.error` を追加し、呼び出しを検証するアサーションを追加

## Test plan

- [x] `pnpm --filter @tascal/web run test` — 全 57 テストパス
- [x] `pnpm --filter @tascal/web run typecheck` — 型エラーなし
- [x] `pnpm --filter @tascal/web run lint` — lint エラーなし
- [x] `pnpm --filter @tascal/web run format:check` — フォーマット OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)