### PR TITLE
feat: カレンダーの過去日の数字を薄く表示する

### DIFF
--- a/apps/web/src/components/CalendarDayCell.tsx
+++ b/apps/web/src/components/CalendarDayCell.tsx
@@ -1,7 +1,7 @@
 import { useDroppable } from "@dnd-kit/core";
 import type { Task } from "../types/task";
 import type { Category } from "../types/category";
-import { isToday, formatDateKey } from "../utils/calendar";
+import { isToday, isPast, formatDateKey } from "../utils/calendar";
 import { DraggableTask } from "./DraggableTask";
 
 const MAX_VISIBLE_TASKS = 4;
@@ -32,6 +32,7 @@ export function CalendarDayCell({
   onCollapse,
 }: CalendarDayCellProps) {
   const today = isToday(date);
+  const past = isCurrentMonth && isPast(date);
   const dateKey = formatDateKey(date);
   const visibleTasks = isExpanded ? tasks : tasks.slice(0, MAX_VISIBLE_TASKS);
   const remainingCount = tasks.length - MAX_VISIBLE_TASKS;
@@ -59,9 +60,11 @@ export function CalendarDayCell({
           className={`inline-flex h-7 w-7 items-center justify-center rounded-full text-sm ${
             today
               ? "bg-primary font-bold text-white"
-              : isCurrentMonth
-                ? "text-on-surface"
-                : "text-on-surface-muted"
+              : !isCurrentMonth
+                ? "text-on-surface-muted"
+                : past
+                  ? "text-on-surface-muted"
+                  : "text-on-surface"
           }`}
         >
           {date.getDate()}

--- a/apps/web/src/utils/calendar.test.ts
+++ b/apps/web/src/utils/calendar.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { getCalendarDays } from "./calendar";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { getCalendarDays, isPast } from "./calendar";
 
 describe("getCalendarDays (月曜始まり)", () => {
   it("2026年4月: 水曜始まり → 先頭2日が前月パディング", () => {
@@ -45,7 +45,7 @@ describe("getCalendarDays (月曜始まり)", () => {
     expect(days[6].isCurrentMonth).toBe(true);
   });
 
-  it("各行が月〜日の順に並ぶ", () => {
+  it("各行が月〜日の順に並ぶ (2026年4月)", () => {
     const days = getCalendarDays(2026, 4);
 
     // 各行（7日ずつ）の最初は月曜、最後は日曜
@@ -55,5 +55,40 @@ describe("getCalendarDays (月曜始まり)", () => {
       expect(firstOfRow).toBe(1); // 月曜
       expect(lastOfRow).toBe(0); // 日曜
     }
+  });
+});
+
+describe("isPast", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("昨日は過去日と判定される", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 3, 13)); // 2026-04-13
+
+    expect(isPast(new Date(2026, 3, 12))).toBe(true);
+  });
+
+  it("今日は過去日に含まれない", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 3, 13));
+
+    expect(isPast(new Date(2026, 3, 13))).toBe(false);
+  });
+
+  it("明日は過去日に含まれない", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 3, 13));
+
+    expect(isPast(new Date(2026, 3, 14))).toBe(false);
+  });
+
+  it("時刻に関係なく日付単位で比較する", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 3, 13, 0, 0, 0)); // 深夜0時
+
+    // 前日の23:59でも過去日
+    expect(isPast(new Date(2026, 3, 12, 23, 59, 59))).toBe(true);
   });
 });

--- a/apps/web/src/utils/calendar.ts
+++ b/apps/web/src/utils/calendar.ts
@@ -54,3 +54,10 @@ export function isToday(date: Date): boolean {
     date.getDate() === now.getDate()
   );
 }
+
+export function isPast(date: Date): boolean {
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const target = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  return target.getTime() < today.getTime();
+}


### PR DESCRIPTION
close #169

## 概要

- `isPast()` ユーティリティ関数を `calendar.ts` に追加（日付単位比較、今日は過去に含めない）
- `CalendarDayCell` で当月かつ過去日の日付数字に `text-on-surface-muted` を適用
- 今日（青背景）・他月（既存の薄い色）のスタイルは変更なし
- `isPast()` のユニットテストを 4 ケース追加

## テストプラン

- [x] `isPast()` のユニットテスト（昨日・今日・明日・時刻無視）が通ること
- [ ] lint / format / typecheck / knip がすべて通ること（CI で確認）
- [ ] ブラウザでカレンダーを表示し、過去日の数字が薄く、今日・未来日が通常色であることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)