### PR TITLE
fix: OGP メタタグの %VITE_APP_URL% を本番 URL にハードコード

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -19,9 +19,9 @@
       content="tascal はシンプルなタスク管理アプリです。カレンダー上でタスクをドラッグ&ドロップして直感的にスケジュール管理できます。"
     />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="%VITE_APP_URL%" />
+    <meta property="og:url" content="https://tascal.dev" />
     <meta property="og:site_name" content="tascal" />
-    <meta property="og:image" content="%VITE_APP_URL%/ogp.png" />
+    <meta property="og:image" content="https://tascal.dev/ogp.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <!-- Twitter Card -->
@@ -31,7 +31,7 @@
       name="twitter:description"
       content="tascal はシンプルなタスク管理アプリです。カレンダー上でタスクをドラッグ&ドロップして直感的にスケジュール管理できます。"
     />
-    <meta name="twitter:image" content="%VITE_APP_URL%/ogp.png" />
+    <meta name="twitter:image" content="https://tascal.dev/ogp.png" />
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
close #171

## 概要

`apps/web/index.html` の OGP メタタグで `%VITE_APP_URL%` がビルド後もそのまま出力されていた問題を修正。

Vite は `index.html` 内の `%ENV_VAR%` 構文を展開しないため、OGP クローラーに未展開のプレースホルダがそのまま表示されていた。本番 URL (`https://tascal.dev`) を直接ハードコードして解決。

## 変更内容

- `og:url`: `%VITE_APP_URL%` → `https://tascal.dev`
- `og:image`: `%VITE_APP_URL%/ogp.png` → `https://tascal.dev/ogp.png`
- `twitter:image`: `%VITE_APP_URL%/ogp.png` → `https://tascal.dev/ogp.png`

## テスト計画

- [ ] OGP チェッカーでデプロイ後に `%VITE_APP_URL%` が表示されないことを確認
- [ ] `og:url`、`og:image`、`twitter:image` に正しい URL が設定されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)