### PR TITLE
feat: ヘッダータイトル「tascal」を /app へのリンクにする

### DIFF
--- a/apps/web/src/routes/app/index.tsx
+++ b/apps/web/src/routes/app/index.tsx
@@ -13,7 +13,11 @@ function HomePage() {
     <div className="min-h-screen bg-surface">
       <header className="border-b border-border-light bg-white px-4 py-1.5">
         <div className="mx-auto flex max-w-[1600px] items-center justify-between">
-          <h1 className="text-lg font-bold text-on-surface">tascal</h1>
+          <h1 className="text-lg font-bold text-on-surface">
+            <Link to="/app" className="no-underline text-inherit">
+              tascal
+            </Link>
+          </h1>
           <div className="flex items-center gap-4">
             <span className="text-sm text-on-surface-secondary">
               {session?.user?.name}

--- a/apps/web/src/routes/app/settings.tsx
+++ b/apps/web/src/routes/app/settings.tsx
@@ -80,7 +80,11 @@ function SettingsPage() {
     <div className="min-h-screen bg-surface">
       <header className="border-b border-border-light bg-white px-4 py-1.5">
         <div className="mx-auto flex max-w-[1600px] items-center justify-between">
-          <h1 className="text-lg font-bold text-on-surface">tascal</h1>
+          <h1 className="text-lg font-bold text-on-surface">
+            <Link to="/app" className="no-underline text-inherit">
+              tascal
+            </Link>
+          </h1>
           <div className="flex items-center gap-4">
             <span className="text-sm text-on-surface-secondary">
               {session?.user?.name}

--- a/apps/web/src/routes/settings.test.tsx
+++ b/apps/web/src/routes/settings.test.tsx
@@ -30,8 +30,17 @@ vi.mock("@tanstack/react-router", () => ({
     capturedComponent = opts.component;
     return { options: opts };
   },
-  Link: ({ children, ...props }: { children: React.ReactNode; to: string }) => (
-    <a {...props}>{children}</a>
+  Link: ({
+    children,
+    to,
+    ...props
+  }: {
+    children: React.ReactNode;
+    to: string;
+  }) => (
+    <a href={to} {...props}>
+      {children}
+    </a>
   ),
 }));
 
@@ -50,6 +59,14 @@ describe("SettingsPage アカウントセクション", () => {
     const Component = capturedComponent!;
     renderWithQueryClient(<Component />);
   }
+
+  it("タイトル「tascal」が /app へのリンクになっている", () => {
+    renderSettingsPage();
+
+    const link = screen.getByRole("link", { name: "tascal" });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", "/app");
+  });
 
   it("ログアウトボタンが表示される", () => {
     renderSettingsPage();


### PR DESCRIPTION
close #175

## 概要

- ヘッダー左上の「tascal」タイトルを TanStack Router の `Link` コンポーネントで `/app` へのリンクに変更
- `app/index.tsx` と `app/settings.tsx` の両方に適用
- settings テストに Link mock の改善とタイトルリンクの検証テストを追加

## 変更ファイル

- `apps/web/src/routes/app/index.tsx` — `<h1>` 内に `<Link to="/app">` を追加
- `apps/web/src/routes/app/settings.tsx` — 同上
- `apps/web/src/routes/settings.test.tsx` — Link mock を `to` → `href` 変換に改善、タイトルリンクのテスト追加

## テスト計画

- [x] 既存テスト全パス (62/62)
- [x] タイトルリンクのテスト追加・通過
- [x] lint / format / typecheck / knip 全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)