### PR TITLE
docs: root README に CLI カテゴリコマンドを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,17 @@ npm install -g tascal-cli
 ```
 
 ```bash
-tascal login          # ログイン
-tascal logout         # ログアウト
-tascal list           # タスク一覧
-tascal add            # タスク作成
-tascal edit <id>      # 編集
-tascal done <id>      # 完了にする
-tascal undo <id>      # 未完了に戻す
-tascal delete <id>    # 削除
+tascal login               # ログイン
+tascal logout              # ログアウト
+tascal list                # タスク一覧
+tascal add                 # タスク作成
+tascal edit <id>           # 編集
+tascal done <id>           # 完了にする
+tascal undo <id>           # 未完了に戻す
+tascal delete <id>         # 削除
+tascal category list       # カテゴリ一覧
+tascal category add        # カテゴリ作成
+tascal category edit <id>  # カテゴリ編集
+tascal category delete <id>  # カテゴリ削除
 ```
 


### PR DESCRIPTION
## Summary

- PR #178 で追加された CLI カテゴリ管理コマンド (`tascal category list/add/edit/delete`) を root の README.md に反映
- 既存コマンド一覧のコメント位置を揃えて可読性を向上

## Test plan

- [x] README.md のフォーマットが正しいことを確認
- [x] `pnpm format:check` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)