### PR TITLE
feat: ランディングページに CLI 紹介セクションを追加

### DIFF
--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -52,6 +52,43 @@ function LandingPage() {
             />
           </div>
         </section>
+
+        <section className="bg-white px-4 py-24">
+          <div className="mx-auto max-w-3xl text-center">
+            <h2 className="mb-4 text-3xl font-bold text-on-surface">
+              ターミナルからも、タスク管理。
+            </h2>
+            <p className="mb-10 text-lg text-on-surface-secondary">
+              CLI ツールを使えば、ターミナルから直接タスクを操作できます。
+            </p>
+
+            <div className="mx-auto max-w-xl overflow-hidden rounded-lg border border-border-light bg-gray-900 text-left shadow-lg">
+              <div className="flex items-center gap-1.5 border-b border-gray-700 px-4 py-2.5">
+                <span className="h-3 w-3 rounded-full bg-red-500" />
+                <span className="h-3 w-3 rounded-full bg-yellow-500" />
+                <span className="h-3 w-3 rounded-full bg-green-500" />
+                <span className="ml-2 text-xs text-gray-400">Terminal</span>
+              </div>
+              <div className="space-y-3 p-5 font-mono text-sm leading-relaxed text-gray-300">
+                <p>
+                  <span className="text-green-400">$</span> npm install -g
+                  tascal-cli
+                </p>
+                <p>
+                  <span className="text-green-400">$</span> tascal add --title
+                  &quot;レビュー対応&quot; --date 2026-04-14
+                </p>
+                <p>
+                  <span className="text-green-400">$</span> tascal list
+                </p>
+                <p>
+                  <span className="text-green-400">$</span> tascal done
+                  &lt;task-id&gt;
+                </p>
+              </div>
+            </div>
+          </div>
+        </section>
       </main>
 
       <footer className="border-t border-border-light px-4 py-6 text-center text-sm text-on-surface-secondary">


### PR DESCRIPTION
close #176

## 概要

- ランディングページのスクリーンショットセクションとフッターの間に CLI 紹介セクションを追加
- ターミナル風 UI で `npm install -g tascal-cli` のインストールコマンドと主要コマンド例（add, list, done）を表示
- 既存のデザイントーン（Tailwind CSS クラス、カラーパレット）と一貫性のあるスタイリング

## テストプラン

- [x] lint / format / typecheck / knip 通過
- [x] 全テスト通過（API 37, Web 61, CLI 34）
- [x] Codex レビュー実施済み（critical 指摘なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)