### PR TITLE
fix: done ステータスのタスクにもカテゴリ背景色を維持する

### DIFF
--- a/apps/web/src/components/Calendar.tsx
+++ b/apps/web/src/components/Calendar.tsx
@@ -261,16 +261,14 @@ export function Calendar() {
                 <div
                   className={`flex items-center gap-1 rounded px-1 py-0.5 text-sm shadow-lg scale-105 ${
                     activeTask.status === "done"
-                      ? "bg-white text-on-surface-muted line-through"
+                      ? bgColor
+                        ? "text-on-surface/60 line-through"
+                        : "bg-white text-on-surface-muted line-through"
                       : bgColor
                         ? "text-on-surface"
                         : "bg-white text-on-surface"
                   }`}
-                  style={
-                    activeTask.status !== "done" && bgColor
-                      ? { backgroundColor: bgColor }
-                      : undefined
-                  }
+                  style={bgColor ? { backgroundColor: bgColor } : undefined}
                 >
                   <input
                     type="checkbox"

--- a/apps/web/src/components/DraggableTask.test.tsx
+++ b/apps/web/src/components/DraggableTask.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { DraggableTask } from "./DraggableTask";
+import type { Task } from "../types/task";
+import type { Category } from "../types/category";
+import { CATEGORY_COLORS } from "../constants/categoryColors";
+
+vi.mock("@dnd-kit/core", () => ({
+  useDraggable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: vi.fn(),
+    isDragging: false,
+  }),
+}));
+
+const baseTask: Task = {
+  id: "task-1",
+  title: "テストタスク",
+  description: null,
+  date: "2026-04-15",
+  status: "todo",
+  categoryId: "cat-1",
+  userId: "user-1",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+};
+
+const category: Category = {
+  id: "cat-1",
+  name: "仕事",
+  color: "blue",
+  userId: "user-1",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+};
+
+const noop = vi.fn();
+
+describe("DraggableTask", () => {
+  it("todo タスクにカテゴリ背景色が適用される", () => {
+    render(
+      <DraggableTask
+        task={baseTask}
+        category={category}
+        onTaskClick={noop}
+        onToggleStatus={noop}
+      />,
+    );
+
+    const el = screen.getByText("テストタスク").closest("div[class]")!;
+    expect(el).toHaveStyle({
+      backgroundColor: CATEGORY_COLORS.blue.bg,
+    });
+  });
+
+  it("done タスクにもカテゴリ背景色が適用される", () => {
+    const doneTask: Task = { ...baseTask, status: "done" };
+    render(
+      <DraggableTask
+        task={doneTask}
+        category={category}
+        onTaskClick={noop}
+        onToggleStatus={noop}
+      />,
+    );
+
+    const el = screen.getByText("テストタスク").closest("div[class]")!;
+    expect(el).toHaveStyle({
+      backgroundColor: CATEGORY_COLORS.blue.bg,
+    });
+    expect(el).toHaveClass("line-through");
+  });
+
+  it("カテゴリ未設定の done タスクは白背景", () => {
+    const doneTaskNoCategory: Task = {
+      ...baseTask,
+      status: "done",
+      categoryId: null,
+    };
+    render(
+      <DraggableTask
+        task={doneTaskNoCategory}
+        category={null}
+        onTaskClick={noop}
+        onToggleStatus={noop}
+      />,
+    );
+
+    const el = screen.getByText("テストタスク").closest("div[class]")!;
+    expect(el).not.toHaveStyle({ backgroundColor: CATEGORY_COLORS.blue.bg });
+    expect(el).toHaveClass("line-through");
+    expect(el).toHaveClass("border");
+  });
+});

--- a/apps/web/src/components/DraggableTask.tsx
+++ b/apps/web/src/components/DraggableTask.tsx
@@ -32,15 +32,15 @@ export function DraggableTask({
         isDragging
           ? "border border-dashed border-border bg-surface text-transparent [&_input]:invisible"
           : task.status === "done"
-            ? "border border-border text-on-surface-muted line-through"
+            ? categoryBg
+              ? "text-on-surface/60 line-through"
+              : "border border-border text-on-surface-muted line-through"
             : categoryBg
               ? "text-on-surface"
               : "border border-border bg-white text-on-surface"
       }`}
       style={
-        !isDragging && task.status !== "done" && categoryBg
-          ? { backgroundColor: categoryBg }
-          : undefined
+        !isDragging && categoryBg ? { backgroundColor: categoryBg } : undefined
       }
     >
       <input


### PR DESCRIPTION
close #185

## 概要

done ステータスのタスクでカテゴリ背景色が消えていた問題を修正。取り消し線とテキスト透明度で done を表現しつつ、カテゴリ色を保持するようにした。

## 変更内容

- `DraggableTask.tsx`: done タスクでも `categoryBg` を `backgroundColor` に適用。カテゴリ付き done タスクは `text-on-surface/60 line-through` で視覚的に区別
- `Calendar.tsx`: DragOverlay 内の同様の条件を修正
- `DraggableTask.test.tsx`: カテゴリ背景色の維持を検証するテストを追加（todo/done/カテゴリ未設定の 3 パターン）

## テスト計画

- [x] 既存テスト全件パス（136 件）
- [x] DraggableTask の背景色テスト追加（3 件）
- [x] lint / typecheck / format / knip パス
- [ ] カテゴリ付きタスクを done にしたとき背景色が維持されることを画面で確認
- [ ] カテゴリ未設定タスクを done にしたとき従来通り白背景であることを確認
- [ ] ドラッグ中にカテゴリ色が維持されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)