### PR TITLE
feat: 利用規約・プライバシーポリシーページの追加

### DIFF
--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -9,16 +9,28 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as TermsRouteImport } from './routes/terms'
 import { Route as SignupRouteImport } from './routes/signup'
+import { Route as PrivacyRouteImport } from './routes/privacy'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as AppRouteImport } from './routes/app'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as AppIndexRouteImport } from './routes/app/index'
 import { Route as AppSettingsRouteImport } from './routes/app/settings'
 
+const TermsRoute = TermsRouteImport.update({
+  id: '/terms',
+  path: '/terms',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const SignupRoute = SignupRouteImport.update({
   id: '/signup',
   path: '/signup',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const PrivacyRoute = PrivacyRouteImport.update({
+  id: '/privacy',
+  path: '/privacy',
   getParentRoute: () => rootRouteImport,
 } as any)
 const LoginRoute = LoginRouteImport.update({
@@ -51,14 +63,18 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/app': typeof AppRouteWithChildren
   '/login': typeof LoginRoute
+  '/privacy': typeof PrivacyRoute
   '/signup': typeof SignupRoute
+  '/terms': typeof TermsRoute
   '/app/settings': typeof AppSettingsRoute
   '/app/': typeof AppIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/login': typeof LoginRoute
+  '/privacy': typeof PrivacyRoute
   '/signup': typeof SignupRoute
+  '/terms': typeof TermsRoute
   '/app/settings': typeof AppSettingsRoute
   '/app': typeof AppIndexRoute
 }
@@ -67,21 +83,40 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/app': typeof AppRouteWithChildren
   '/login': typeof LoginRoute
+  '/privacy': typeof PrivacyRoute
   '/signup': typeof SignupRoute
+  '/terms': typeof TermsRoute
   '/app/settings': typeof AppSettingsRoute
   '/app/': typeof AppIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/app' | '/login' | '/signup' | '/app/settings' | '/app/'
+  fullPaths:
+    | '/'
+    | '/app'
+    | '/login'
+    | '/privacy'
+    | '/signup'
+    | '/terms'
+    | '/app/settings'
+    | '/app/'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/login' | '/signup' | '/app/settings' | '/app'
+  to:
+    | '/'
+    | '/login'
+    | '/privacy'
+    | '/signup'
+    | '/terms'
+    | '/app/settings'
+    | '/app'
   id:
     | '__root__'
     | '/'
     | '/app'
     | '/login'
+    | '/privacy'
     | '/signup'
+    | '/terms'
     | '/app/settings'
     | '/app/'
   fileRoutesById: FileRoutesById
@@ -90,16 +125,32 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AppRoute: typeof AppRouteWithChildren
   LoginRoute: typeof LoginRoute
+  PrivacyRoute: typeof PrivacyRoute
   SignupRoute: typeof SignupRoute
+  TermsRoute: typeof TermsRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/terms': {
+      id: '/terms'
+      path: '/terms'
+      fullPath: '/terms'
+      preLoaderRoute: typeof TermsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/signup': {
       id: '/signup'
       path: '/signup'
       fullPath: '/signup'
       preLoaderRoute: typeof SignupRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/privacy': {
+      id: '/privacy'
+      path: '/privacy'
+      fullPath: '/privacy'
+      preLoaderRoute: typeof PrivacyRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/login': {
@@ -156,7 +207,9 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AppRoute: AppRouteWithChildren,
   LoginRoute: LoginRoute,
+  PrivacyRoute: PrivacyRoute,
   SignupRoute: SignupRoute,
+  TermsRoute: TermsRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -91,8 +91,26 @@ function LandingPage() {
         </section>
       </main>
 
-      <footer className="border-t border-border-light px-4 py-6 text-center text-sm text-on-surface-secondary">
-        &copy; 2026 tascal
+      <footer className="border-t border-border-light px-4 py-6">
+        <div className="mx-auto flex max-w-7xl flex-col items-center gap-2">
+          <div className="flex gap-4 text-sm">
+            <Link
+              to="/terms"
+              className="text-on-surface-secondary hover:text-on-surface hover:underline"
+            >
+              利用規約
+            </Link>
+            <Link
+              to="/privacy"
+              className="text-on-surface-secondary hover:text-on-surface hover:underline"
+            >
+              プライバシーポリシー
+            </Link>
+          </div>
+          <p className="text-sm text-on-surface-secondary">
+            &copy; 2026 tascal
+          </p>
+        </div>
       </footer>
     </div>
   );

--- a/apps/web/src/routes/privacy.tsx
+++ b/apps/web/src/routes/privacy.tsx
@@ -1,0 +1,140 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/privacy")({
+  component: PrivacyPage,
+});
+
+function PrivacyPage() {
+  return (
+    <div className="min-h-screen bg-surface">
+      <header className="border-b border-border-light bg-white">
+        <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-3">
+          <Link to="/" className="text-lg font-bold text-on-surface">
+            tascal
+          </Link>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-3xl px-4 py-12">
+        <article className="rounded-lg bg-white p-8 shadow-xl">
+          <h1 className="mb-8 text-2xl font-bold text-on-surface">
+            プライバシーポリシー
+          </h1>
+
+          <div className="space-y-6 text-sm leading-relaxed text-on-surface-secondary">
+            <p>
+              tascal（以下「本サービス」）は、ユーザーの個人情報の保護を重要と考え、個人情報の保護に関する法律を遵守し、以下のとおりプライバシーポリシー（以下「本ポリシー」）を定めます。
+            </p>
+
+            <section>
+              <h2 className="mb-2 text-base font-bold text-on-surface">
+                1. 収集する情報
+              </h2>
+              <p>
+                本サービスは、サービスの提供にあたり、以下の情報を収集します。
+              </p>
+              <ul className="mt-2 list-disc space-y-1 pl-6">
+                <li>
+                  <strong>アカウント情報:</strong>{" "}
+                  名前、メールアドレス、パスワード（ハッシュ化して保存）
+                </li>
+                <li>
+                  <strong>アクセス情報:</strong>{" "}
+                  IPアドレス、ユーザーエージェント
+                </li>
+                <li>
+                  <strong>サービス利用データ:</strong>{" "}
+                  タスク情報（タイトル、説明、日付、ステータス）、カテゴリ情報
+                </li>
+              </ul>
+            </section>
+
+            <section>
+              <h2 className="mb-2 text-base font-bold text-on-surface">
+                2. 情報の利用目的
+              </h2>
+              <p>収集した情報は、以下の目的で利用します。</p>
+              <ul className="mt-2 list-disc space-y-1 pl-6">
+                <li>本サービスの提供・運営</li>
+                <li>ユーザー認証およびセッション管理</li>
+                <li>本サービスの改善・新機能の開発</li>
+                <li>不正利用の防止およびセキュリティの確保</li>
+                <li>重要なお知らせの通知</li>
+              </ul>
+            </section>
+
+            <section>
+              <h2 className="mb-2 text-base font-bold text-on-surface">
+                3. 情報の第三者提供
+              </h2>
+              <p>
+                本サービスは、以下の場合を除き、ユーザーの個人情報を第三者に提供しません。
+              </p>
+              <ul className="mt-2 list-disc space-y-1 pl-6">
+                <li>ユーザーの同意がある場合</li>
+                <li>法令に基づく場合</li>
+                <li>
+                  人の生命、身体または財産の保護のために必要がある場合であって、本人の同意を得ることが困難であるとき
+                </li>
+              </ul>
+            </section>
+
+            <section>
+              <h2 className="mb-2 text-base font-bold text-on-surface">
+                4. 情報の管理
+              </h2>
+              <p>
+                本サービスは、ユーザーの個人情報を適切に管理し、不正アクセス、紛失、破壊、改ざんおよび漏洩の防止に努めます。パスワードはハッシュ化して保存し、通信はHTTPSにより暗号化されています。
+              </p>
+            </section>
+
+            <section>
+              <h2 className="mb-2 text-base font-bold text-on-surface">
+                5. ユーザーの権利
+              </h2>
+              <p>ユーザーは、以下の権利を有します。</p>
+              <ul className="mt-2 list-disc space-y-1 pl-6">
+                <li>自己の個人情報の開示を求めること</li>
+                <li>自己の個人情報の訂正・削除を求めること</li>
+                <li>
+                  アカウントの削除（設定画面よりいつでもアカウントを削除でき、関連するすべてのデータが削除されます）
+                </li>
+              </ul>
+            </section>
+
+            <section>
+              <h2 className="mb-2 text-base font-bold text-on-surface">
+                6. データの保存期間
+              </h2>
+              <p>
+                ユーザーのデータは、アカウントが有効な期間中保存されます。アカウントを削除した場合、関連するすべてのデータは速やかに削除されます。
+              </p>
+            </section>
+
+            <section>
+              <h2 className="mb-2 text-base font-bold text-on-surface">
+                7. プライバシーポリシーの変更
+              </h2>
+              <p>
+                本ポリシーの内容は、法令その他本ポリシーに別段の定めのある事項を除いて、ユーザーに通知することなく変更することができるものとします。変更後のプライバシーポリシーは、本サービス上に掲示した時点から効力を生じるものとします。
+              </p>
+            </section>
+
+            <section>
+              <h2 className="mb-2 text-base font-bold text-on-surface">
+                8. お問い合わせ
+              </h2>
+              <p>
+                本ポリシーに関するお問い合わせは、本サービスのGitHubリポジトリのIssueにてお願いいたします。
+              </p>
+            </section>
+
+            <p className="mt-8 text-xs text-on-surface-secondary">
+              制定日: 2026年4月14日
+            </p>
+          </div>
+        </article>
+      </main>
+    </div>
+  );
+}

--- a/apps/web/src/routes/privacy.tsx
+++ b/apps/web/src/routes/privacy.tsx
@@ -125,7 +125,15 @@ function PrivacyPage() {
                 8. お問い合わせ
               </h2>
               <p>
-                本ポリシーに関するお問い合わせは、本サービスのGitHubリポジトリのIssueにてお願いいたします。
+                本ポリシーに関するお問い合わせは、以下のメールアドレスまでお願いいたします。
+              </p>
+              <p className="mt-2">
+                <a
+                  href="mailto:hiroki.sakabe@icloud.com"
+                  className="text-primary hover:text-primary-dark hover:underline"
+                >
+                  hiroki.sakabe@icloud.com
+                </a>
               </p>
             </section>
 

--- a/apps/web/src/routes/signup.test.tsx
+++ b/apps/web/src/routes/signup.test.tsx
@@ -23,6 +23,19 @@ vi.mock("@tanstack/react-router", () => ({
   },
   redirect: vi.fn(),
   useNavigate: () => mockNavigate,
+  Link: ({
+    children,
+    to,
+    ...props
+  }: {
+    children: React.ReactNode;
+    to: string;
+    [key: string]: unknown;
+  }) => (
+    <a href={to} {...props}>
+      {children}
+    </a>
+  ),
 }));
 
 describe("SignupPage", () => {
@@ -118,6 +131,18 @@ describe("SignupPage", () => {
         screen.getByText("サインアップに失敗しました"),
       ).toBeInTheDocument();
     });
+  });
+
+  it("利用規約とプライバシーポリシーへのリンクが表示される", () => {
+    renderSignupPage();
+
+    const termsLink = screen.getByRole("link", { name: "利用規約" });
+    expect(termsLink).toHaveAttribute("href", "/terms");
+
+    const privacyLink = screen.getByRole("link", {
+      name: "プライバシーポリシー",
+    });
+    expect(privacyLink).toHaveAttribute("href", "/privacy");
   });
 
   it("ログインページへのナビゲーションリンクが動作する", async () => {

--- a/apps/web/src/routes/signup.tsx
+++ b/apps/web/src/routes/signup.tsx
@@ -1,4 +1,9 @@
-import { createFileRoute, redirect, useNavigate } from "@tanstack/react-router";
+import {
+  createFileRoute,
+  Link,
+  redirect,
+  useNavigate,
+} from "@tanstack/react-router";
 import { useState } from "react";
 import { authClient } from "../auth-client";
 
@@ -99,6 +104,23 @@ function SignupPage() {
               {error}
             </p>
           )}
+          <p className="text-xs leading-relaxed text-on-surface-secondary">
+            サインアップすることで、
+            <Link
+              to="/terms"
+              className="text-primary hover:text-primary-dark hover:underline"
+            >
+              利用規約
+            </Link>
+            および
+            <Link
+              to="/privacy"
+              className="text-primary hover:text-primary-dark hover:underline"
+            >
+              プライバシーポリシー
+            </Link>
+            に同意したものとみなされます。
+          </p>
           <button
             type="submit"
             className="w-full rounded-md bg-primary px-4 py-2 text-sm text-white hover:bg-primary-dark"

--- a/apps/web/src/routes/terms.tsx
+++ b/apps/web/src/routes/terms.tsx
@@ -1,0 +1,140 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/terms")({
+  component: TermsPage,
+});
+
+function TermsPage() {
+  return (
+    <div className="min-h-screen bg-surface">
+      <header className="border-b border-border-light bg-white">
+        <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-3">
+          <Link to="/" className="text-lg font-bold text-on-surface">
+            tascal
+          </Link>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-3xl px-4 py-12">
+        <article className="rounded-lg bg-white p-8 shadow-xl">
+          <h1 className="mb-8 text-2xl font-bold text-on-surface">利用規約</h1>
+
+          <div className="space-y-6 text-sm leading-relaxed text-on-surface-secondary">
+            <p>
+              この利用規約（以下「本規約」）は、tascal（以下「本サービス」）の利用条件を定めるものです。ユーザーの皆様には、本規約に同意のうえ、本サービスをご利用いただきます。
+            </p>
+
+            <section>
+              <h2 className="mb-2 text-base font-bold text-on-surface">
+                第1条（適用）
+              </h2>
+              <p>
+                本規約は、ユーザーと本サービス運営者との間の本サービスの利用に関わる一切の関係に適用されます。
+              </p>
+            </section>
+
+            <section>
+              <h2 className="mb-2 text-base font-bold text-on-surface">
+                第2条（利用登録）
+              </h2>
+              <p>
+                本サービスの利用を希望する方は、本規約に同意のうえ、所定の方法により利用登録を申請していただきます。利用登録の完了をもって、利用契約が成立するものとします。
+              </p>
+            </section>
+
+            <section>
+              <h2 className="mb-2 text-base font-bold text-on-surface">
+                第3条（アカウント管理）
+              </h2>
+              <p>
+                ユーザーは、自己の責任において、本サービスのアカウント（メールアドレスおよびパスワード）を適切に管理するものとします。アカウントの不正利用により生じた損害について、運営者は一切の責任を負いません。
+              </p>
+            </section>
+
+            <section>
+              <h2 className="mb-2 text-base font-bold text-on-surface">
+                第4条（禁止事項）
+              </h2>
+              <p>ユーザーは、以下の行為をしてはなりません。</p>
+              <ul className="mt-2 list-disc space-y-1 pl-6">
+                <li>法令または公序良俗に違反する行為</li>
+                <li>犯罪行為に関連する行為</li>
+                <li>
+                  本サービスのサーバーまたはネットワークの機能を破壊したり、妨害したりする行為
+                </li>
+                <li>本サービスの運営を妨害するおそれのある行為</li>
+                <li>他のユーザーに関する個人情報等を収集または蓄積する行為</li>
+                <li>不正アクセスをし、またはこれを試みる行為</li>
+                <li>他のユーザーに成りすます行為</li>
+                <li>
+                  本サービスに関連して、反社会的勢力に対して直接または間接に利益を供与する行為
+                </li>
+                <li>その他、運営者が不適切と判断する行為</li>
+              </ul>
+            </section>
+
+            <section>
+              <h2 className="mb-2 text-base font-bold text-on-surface">
+                第5条（本サービスの提供の停止等）
+              </h2>
+              <p>
+                運営者は、以下のいずれかの事由があると判断した場合、ユーザーに事前に通知することなく本サービスの全部または一部の提供を停止または中断することができるものとします。
+              </p>
+              <ul className="mt-2 list-disc space-y-1 pl-6">
+                <li>
+                  本サービスにかかるコンピュータシステムの保守点検または更新を行う場合
+                </li>
+                <li>
+                  地震、落雷、火災、停電または天災などの不可抗力により、本サービスの提供が困難となった場合
+                </li>
+                <li>コンピュータまたは通信回線等が事故により停止した場合</li>
+                <li>その他、運営者が本サービスの提供が困難と判断した場合</li>
+              </ul>
+            </section>
+
+            <section>
+              <h2 className="mb-2 text-base font-bold text-on-surface">
+                第6条（免責事項）
+              </h2>
+              <p>
+                運営者は、本サービスに事実上または法律上の瑕疵（安全性、信頼性、正確性、完全性、有効性、特定の目的への適合性、セキュリティなどに関する欠陥、エラーやバグ、権利侵害などを含みます）がないことを明示的にも黙示的にも保証しておりません。
+              </p>
+              <p className="mt-2">
+                運営者は、本サービスに起因してユーザーに生じたあらゆる損害について一切の責任を負いません。ただし、本サービスに関する運営者とユーザーとの間の契約が消費者契約法に定める消費者契約となる場合、この免責規定は適用されません。
+              </p>
+            </section>
+
+            <section>
+              <h2 className="mb-2 text-base font-bold text-on-surface">
+                第7条（サービス内容の変更等）
+              </h2>
+              <p>
+                運営者は、ユーザーに通知することなく、本サービスの内容を変更しまたは本サービスの提供を中止することができるものとし、これによってユーザーに生じた損害について一切の責任を負いません。
+              </p>
+            </section>
+
+            <section>
+              <h2 className="mb-2 text-base font-bold text-on-surface">
+                第8条（利用規約の変更）
+              </h2>
+              <p>
+                運営者は、必要と判断した場合には、ユーザーに通知することなくいつでも本規約を変更することができるものとします。変更後の利用規約は、本サービス上に掲示した時点から効力を生じるものとします。
+              </p>
+            </section>
+
+            <section>
+              <h2 className="mb-2 text-base font-bold text-on-surface">
+                第9条（準拠法・裁判管轄）
+              </h2>
+              <p>本規約の解釈にあたっては、日本法を準拠法とします。</p>
+            </section>
+
+            <p className="mt-8 text-xs text-on-surface-secondary">
+              制定日: 2026年4月14日
+            </p>
+          </div>
+        </article>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
close #184

## 概要

利用規約（`/terms`）とプライバシーポリシー（`/privacy`）のページを追加し、サインアップ画面およびランディングページから参照できるようにした。

## 変更内容

- 利用規約ページ (`apps/web/src/routes/terms.tsx`) を新規作成
- プライバシーポリシーページ (`apps/web/src/routes/privacy.tsx`) を新規作成
- サインアップ画面に「利用規約・プライバシーポリシーに同意したものとみなされます」の文言とリンクを追加
- ランディングページのフッターに利用規約・プライバシーポリシーへのリンクを追加
- サインアップ画面のテストに同意文言リンクの存在確認テストを追加

## プライバシーポリシーで開示する収集データ

DB スキーマに基づき、以下を記載:
- アカウント情報: 名前、メールアドレス、パスワード（ハッシュ化保存）
- アクセス情報: IP アドレス、ユーザーエージェント
- サービス利用データ: タスク情報、カテゴリ情報

## テスト計画

- [x] `pnpm lint` 通過
- [x] `pnpm format:check` 通過
- [x] `pnpm typecheck` 通過
- [x] `pnpm test` 通過（63 テスト全通過）
- [x] `pnpm knip` 通過
- [ ] `/terms` にアクセスして利用規約ページが表示されること
- [ ] `/privacy` にアクセスしてプライバシーポリシーページが表示されること
- [ ] サインアップ画面に同意文言とリンクが表示されること
- [ ] ランディングページのフッターからリンクでアクセスできること

🤖 Generated with [Claude Code](https://claude.com/claude-code)