### PR TITLE
feat: タスクアイテムのソート機能

### DIFF
--- a/apps/api/src/routes/tasks.test.ts
+++ b/apps/api/src/routes/tasks.test.ts
@@ -38,7 +38,9 @@ vi.mock("../db/index.js", () => ({
   getDb: () => ({
     select: () => ({
       from: () => ({
-        where: mockSelect,
+        where: () => ({
+          orderBy: mockSelect,
+        }),
       }),
     }),
     insert: () => ({

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -2,7 +2,7 @@ import { Hono, type Env } from "hono";
 import { z } from "zod";
 import { zValidator } from "@hono/zod-validator";
 import type { Hook } from "@hono/zod-validator";
-import { eq, and, gte, lt } from "drizzle-orm";
+import { eq, and, gte, lt, asc } from "drizzle-orm";
 import { getDb } from "../db/index.js";
 import { categories, tasks } from "../db/schema.js";
 import type { Auth } from "../auth.js";
@@ -86,7 +86,8 @@ app.get(
           gte(tasks.date, startDate),
           lt(tasks.date, endDate),
         ),
-      );
+      )
+      .orderBy(asc(tasks.status), asc(tasks.createdAt));
 
     return c.json(result);
   },


### PR DESCRIPTION
close #142

## 概要
- API の GET /api/tasks クエリに `ORDER BY status ASC, created_at ASC` を追加
- 同一日のタスクがステータス順（todo → done）、作成日時順（古い順）で表示されるようになる
- フロントエンド側の変更は不要（API の返却順をそのまま表示）

## 変更内容
- `apps/api/src/routes/tasks.ts`: `asc` インポート追加、`.orderBy(asc(tasks.status), asc(tasks.createdAt))` をクエリに追加
- `apps/api/src/routes/tasks.test.ts`: DB モックのチェーンに `orderBy` を追加

## テスト計画
- [x] 既存の API テストが全て通ること
- [x] lint / format / typecheck / knip が全て通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)