### PR TITLE
feat: Hono RPC を導入し API クライアントを型安全にする

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
           node-version-file: .node-version
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      - name: Build API (type declarations)
+        run: pnpm --filter @tascal/api run build
       - name: Lint
         run: pnpm --filter @tascal/web run lint
       - name: Format check
@@ -57,6 +59,8 @@ jobs:
           node-version-file: .node-version
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      - name: Build API (type declarations)
+        run: pnpm --filter @tascal/api run build
       - name: Lint
         run: pnpm --filter tascal-cli run lint
       - name: Format check

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -115,9 +115,15 @@ app.on(["POST", "GET"], "/api/auth/**", (c) => {
   return getAuth().handler(c.req.raw);
 });
 
-app.route("/api/categories", categoriesApp);
-app.route("/api/tasks", tasksApp);
-app.route("/api/users", usersApp);
+// RPC 型推論のためチェイン形式でルートをマウント
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const routes = app
+  .route("/api/categories", categoriesApp)
+  .route("/api/tasks", tasksApp)
+  .route("/api/users", usersApp);
+
+/** @public Web・CLI の hc<AppType> で参照 */
+export type AppType = typeof routes;
 
 // SPA 静的ファイル配信（本番用）
 app.use("*", serveStatic({ root: "./public" }));

--- a/apps/api/src/routes/categories.ts
+++ b/apps/api/src/routes/categories.ts
@@ -1,7 +1,6 @@
-import { Hono, type Env } from "hono";
+import { Hono } from "hono";
 import { z } from "zod";
 import { zValidator } from "@hono/zod-validator";
-import type { Hook } from "@hono/zod-validator";
 import { eq, and, asc } from "drizzle-orm";
 import { getDb } from "../db/index.js";
 import { categories } from "../db/schema.js";
@@ -37,47 +36,29 @@ const paramIdSchema = z.object({
   id: z.string().uuid("不正なカテゴリIDです"),
 });
 
-function validationHook(errorMessage: string): Hook<unknown, Env, string> {
-  return (result, c) => {
-    if (!result.success) {
-      return c.json({ error: errorMessage, details: result.error.issues }, 400);
+const app = new Hono<{ Variables: AuthVariables }>()
+  // 認証ミドルウェア
+  .use("*", async (c, next) => {
+    const user = c.get("user");
+    if (!user) {
+      return c.json({ error: "認証が必要です" }, 401);
     }
-  };
-}
+    await next();
+  })
+  // GET /api/categories
+  .get("/", async (c) => {
+    const user = c.get("user")!;
 
-const app = new Hono<{ Variables: AuthVariables }>();
+    const result = await getDb()
+      .select()
+      .from(categories)
+      .where(eq(categories.userId, user.id))
+      .orderBy(asc(categories.createdAt));
 
-// 認証ミドルウェア
-app.use("*", async (c, next) => {
-  const user = c.get("user");
-  if (!user) {
-    return c.json({ error: "認証が必要です" }, 401);
-  }
-  await next();
-});
-
-// GET /api/categories
-app.get("/", async (c) => {
-  const user = c.get("user")!;
-
-  const result = await getDb()
-    .select()
-    .from(categories)
-    .where(eq(categories.userId, user.id))
-    .orderBy(asc(categories.createdAt));
-
-  return c.json(result);
-});
-
-// POST /api/categories
-app.post(
-  "/",
-  zValidator(
-    "json",
-    createCategorySchema,
-    validationHook("バリデーションエラー"),
-  ),
-  async (c) => {
+    return c.json(result);
+  })
+  // POST /api/categories
+  .post("/", zValidator("json", createCategorySchema), async (c) => {
     const user = c.get("user")!;
     const data = c.req.valid("json");
 
@@ -91,45 +72,35 @@ app.post(
       .returning();
 
     return c.json(category, 201);
-  },
-);
+  })
+  // PATCH /api/categories/:id
+  .patch(
+    "/:id",
+    zValidator("param", paramIdSchema),
+    zValidator("json", updateCategorySchema),
+    async (c) => {
+      const user = c.get("user")!;
+      const { id } = c.req.valid("param");
+      const data = c.req.valid("json");
 
-// PATCH /api/categories/:id
-app.patch(
-  "/:id",
-  zValidator("param", paramIdSchema, validationHook("不正なカテゴリIDです")),
-  zValidator(
-    "json",
-    updateCategorySchema,
-    validationHook("バリデーションエラー"),
-  ),
-  async (c) => {
-    const user = c.get("user")!;
-    const { id } = c.req.valid("param");
-    const data = c.req.valid("json");
+      const [updated] = await getDb()
+        .update(categories)
+        .set({
+          ...data,
+          updatedAt: new Date().toISOString(),
+        })
+        .where(and(eq(categories.id, id), eq(categories.userId, user.id)))
+        .returning();
 
-    const [updated] = await getDb()
-      .update(categories)
-      .set({
-        ...data,
-        updatedAt: new Date().toISOString(),
-      })
-      .where(and(eq(categories.id, id), eq(categories.userId, user.id)))
-      .returning();
+      if (!updated) {
+        return c.json({ error: "カテゴリが見つかりません" }, 404);
+      }
 
-    if (!updated) {
-      return c.json({ error: "カテゴリが見つかりません" }, 404);
-    }
-
-    return c.json(updated);
-  },
-);
-
-// DELETE /api/categories/:id
-app.delete(
-  "/:id",
-  zValidator("param", paramIdSchema, validationHook("不正なカテゴリIDです")),
-  async (c) => {
+      return c.json(updated);
+    },
+  )
+  // DELETE /api/categories/:id
+  .delete("/:id", zValidator("param", paramIdSchema), async (c) => {
     const user = c.get("user")!;
     const { id } = c.req.valid("param");
 
@@ -143,7 +114,6 @@ app.delete(
     }
 
     return c.json({ message: "カテゴリを削除しました" });
-  },
-);
+  });
 
 export default app;

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -1,7 +1,6 @@
-import { Hono, type Env } from "hono";
+import { Hono } from "hono";
 import { z } from "zod";
 import { zValidator } from "@hono/zod-validator";
-import type { Hook } from "@hono/zod-validator";
 import { eq, and, gte, lt, asc } from "drizzle-orm";
 import { getDb } from "../db/index.js";
 import { categories, tasks } from "../db/schema.js";
@@ -40,35 +39,17 @@ const paramIdSchema = z.object({
   id: z.string().uuid("不正なタスクIDです"),
 });
 
-// バリデーションエラー時に既存形式 { error, details } で返す共通 hook
-function validationHook(errorMessage: string): Hook<unknown, Env, string> {
-  return (result, c) => {
-    if (!result.success) {
-      return c.json({ error: errorMessage, details: result.error.issues }, 400);
+const app = new Hono<{ Variables: AuthVariables }>()
+  // 認証ミドルウェア
+  .use("*", async (c, next) => {
+    const user = c.get("user");
+    if (!user) {
+      return c.json({ error: "認証が必要です" }, 401);
     }
-  };
-}
-
-const app = new Hono<{ Variables: AuthVariables }>();
-
-// 認証ミドルウェア
-app.use("*", async (c, next) => {
-  const user = c.get("user");
-  if (!user) {
-    return c.json({ error: "認証が必要です" }, 401);
-  }
-  await next();
-});
-
-// GET /api/tasks?year=YYYY&month=MM
-app.get(
-  "/",
-  zValidator(
-    "query",
-    listQuerySchema,
-    validationHook("year と month のクエリパラメータが必要です"),
-  ),
-  async (c) => {
+    await next();
+  })
+  // GET /api/tasks?year=YYYY&month=MM
+  .get("/", zValidator("query", listQuerySchema), async (c) => {
     const user = c.get("user")!;
     const { year, month } = c.req.valid("query");
 
@@ -90,14 +71,9 @@ app.get(
       .orderBy(asc(tasks.status), asc(tasks.createdAt));
 
     return c.json(result);
-  },
-);
-
-// POST /api/tasks
-app.post(
-  "/",
-  zValidator("json", createTaskSchema, validationHook("バリデーションエラー")),
-  async (c) => {
+  })
+  // POST /api/tasks
+  .post("/", zValidator("json", createTaskSchema), async (c) => {
     const user = c.get("user")!;
     const data = c.req.valid("json");
     const categoryId = data.categoryId ?? null;
@@ -127,56 +103,50 @@ app.post(
       .returning();
 
     return c.json(task, 201);
-  },
-);
+  })
+  // PATCH /api/tasks/:id
+  .patch(
+    "/:id",
+    zValidator("param", paramIdSchema),
+    zValidator("json", updateTaskSchema),
+    async (c) => {
+      const user = c.get("user")!;
+      const { id } = c.req.valid("param");
+      const data = c.req.valid("json");
 
-// PATCH /api/tasks/:id
-app.patch(
-  "/:id",
-  zValidator("param", paramIdSchema, validationHook("不正なタスクIDです")),
-  zValidator("json", updateTaskSchema, validationHook("バリデーションエラー")),
-  async (c) => {
-    const user = c.get("user")!;
-    const { id } = c.req.valid("param");
-    const data = c.req.valid("json");
-
-    if (data.categoryId) {
-      const [cat] = await getDb()
-        .select()
-        .from(categories)
-        .where(
-          and(
-            eq(categories.id, data.categoryId),
-            eq(categories.userId, user.id),
-          ),
-        );
-      if (!cat) {
-        return c.json({ error: "カテゴリが見つかりません" }, 400);
+      if (data.categoryId) {
+        const [cat] = await getDb()
+          .select()
+          .from(categories)
+          .where(
+            and(
+              eq(categories.id, data.categoryId),
+              eq(categories.userId, user.id),
+            ),
+          );
+        if (!cat) {
+          return c.json({ error: "カテゴリが見つかりません" }, 400);
+        }
       }
-    }
 
-    const [updated] = await getDb()
-      .update(tasks)
-      .set({
-        ...data,
-        updatedAt: new Date().toISOString(),
-      })
-      .where(and(eq(tasks.id, id), eq(tasks.userId, user.id)))
-      .returning();
+      const [updated] = await getDb()
+        .update(tasks)
+        .set({
+          ...data,
+          updatedAt: new Date().toISOString(),
+        })
+        .where(and(eq(tasks.id, id), eq(tasks.userId, user.id)))
+        .returning();
 
-    if (!updated) {
-      return c.json({ error: "タスクが見つかりません" }, 404);
-    }
+      if (!updated) {
+        return c.json({ error: "タスクが見つかりません" }, 404);
+      }
 
-    return c.json(updated);
-  },
-);
-
-// DELETE /api/tasks/:id
-app.delete(
-  "/:id",
-  zValidator("param", paramIdSchema, validationHook("不正なタスクIDです")),
-  async (c) => {
+      return c.json(updated);
+    },
+  )
+  // DELETE /api/tasks/:id
+  .delete("/:id", zValidator("param", paramIdSchema), async (c) => {
     const user = c.get("user")!;
     const { id } = c.req.valid("param");
 
@@ -190,7 +160,6 @@ app.delete(
     }
 
     return c.json({ message: "タスクを削除しました" });
-  },
-);
+  });
 
 export default app;

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -9,31 +9,29 @@ type AuthVariables = {
   session: Auth["$Infer"]["Session"]["session"] | null;
 };
 
-const app = new Hono<{ Variables: AuthVariables }>();
+const app = new Hono<{ Variables: AuthVariables }>()
+  // 認証ミドルウェア
+  .use("*", async (c, next) => {
+    const user = c.get("user");
+    if (!user) {
+      return c.json({ error: "認証が必要です" }, 401);
+    }
+    await next();
+  })
+  // DELETE /api/users/me
+  .delete("/me", async (c) => {
+    const user = c.get("user")!;
 
-// 認証ミドルウェア
-app.use("*", async (c, next) => {
-  const user = c.get("user");
-  if (!user) {
-    return c.json({ error: "認証が必要です" }, 401);
-  }
-  await next();
-});
+    const [deleted] = await getDb()
+      .delete(users)
+      .where(eq(users.id, user.id))
+      .returning();
 
-// DELETE /api/users/me
-app.delete("/me", async (c) => {
-  const user = c.get("user")!;
+    if (!deleted) {
+      return c.json({ error: "ユーザーが見つかりません" }, 404);
+    }
 
-  const [deleted] = await getDb()
-    .delete(users)
-    .where(eq(users.id, user.id))
-    .returning();
-
-  if (!deleted) {
-    return c.json({ error: "ユーザーが見つかりません" }, 404);
-  }
-
-  return c.json({ message: "アカウントを削除しました" });
-});
+    return c.json({ message: "アカウントを削除しました" });
+  });
 
 export default app;

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -39,9 +39,11 @@
   "dependencies": {
     "@clack/prompts": "^1.2.0",
     "citty": "^0.1.6",
-    "consola": "^3.4.2"
+    "consola": "^3.4.2",
+    "hono": "^4.12.12"
   },
   "devDependencies": {
+    "@tascal/api": "workspace:*",
     "@types/node": "^22.15.3",
     "vitest": "^4.1.4"
   }

--- a/apps/cli/src/api.test.ts
+++ b/apps/cli/src/api.test.ts
@@ -9,9 +9,13 @@ vi.mock("./config.js", () => ({
   getApiUrl: vi.fn(),
 }));
 
+vi.mock("hono/client", () => ({
+  hc: vi.fn(() => ({})),
+}));
+
 import { consola } from "consola";
 import { readConfig, getApiUrl } from "./config.js";
-import { requireAuth, apiRequest, handleApiError } from "./api.js";
+import { requireAuthClient, handleApiError } from "./api.js";
 
 const mockedReadConfig = vi.mocked(readConfig);
 const mockedGetApiUrl = vi.mocked(getApiUrl);
@@ -26,83 +30,25 @@ beforeEach(() => {
 
 afterAll(() => {
   mockedProcessExit.mockRestore();
-  vi.unstubAllGlobals();
 });
 
-describe("requireAuth", () => {
-  it("トークンがある場合、apiUrl と token を返す", async () => {
+describe("requireAuthClient", () => {
+  it("トークンがある場合、クライアントを返す", async () => {
     mockedReadConfig.mockResolvedValue({ token: "test-token" });
     mockedGetApiUrl.mockReturnValue("http://localhost:3000");
 
-    const ctx = await requireAuth();
+    const client = await requireAuthClient();
 
-    expect(ctx).toEqual({
-      apiUrl: "http://localhost:3000",
-      token: "test-token",
-    });
+    expect(client).toBeDefined();
   });
 
   it("トークンがない場合、process.exit(1) が呼ばれる", async () => {
     mockedReadConfig.mockResolvedValue({});
 
-    await requireAuth();
+    await requireAuthClient();
 
     expect(consola.error).toHaveBeenCalledWith(
       expect.stringContaining("ログインしていません"),
-    );
-    expect(mockedProcessExit).toHaveBeenCalledWith(1);
-  });
-});
-
-describe("apiRequest", () => {
-  const ctx = { apiUrl: "http://localhost:3000", token: "test-token" };
-
-  beforeEach(() => {
-    vi.stubGlobal("fetch", vi.fn());
-  });
-
-  it("Authorization ヘッダー付きでリクエストを送信する", async () => {
-    const mockResponse = new Response(JSON.stringify({ ok: true }), {
-      status: 200,
-    });
-    vi.mocked(fetch).mockResolvedValue(mockResponse);
-
-    const res = await apiRequest(ctx, "GET", "/api/tasks");
-
-    expect(fetch).toHaveBeenCalledWith("http://localhost:3000/api/tasks", {
-      method: "GET",
-      headers: { Authorization: "Bearer test-token" },
-      body: undefined,
-    });
-    expect(res.status).toBe(200);
-  });
-
-  it("body がある場合、Content-Type ヘッダーを付与する", async () => {
-    const mockResponse = new Response(JSON.stringify({ ok: true }), {
-      status: 200,
-    });
-    vi.mocked(fetch).mockResolvedValue(mockResponse);
-
-    await apiRequest(ctx, "POST", "/api/tasks", { title: "test" });
-
-    expect(fetch).toHaveBeenCalledWith("http://localhost:3000/api/tasks", {
-      method: "POST",
-      headers: {
-        Authorization: "Bearer test-token",
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ title: "test" }),
-    });
-  });
-
-  it("401 レスポンス時に process.exit(1) が呼ばれる", async () => {
-    const mockResponse = new Response("Unauthorized", { status: 401 });
-    vi.mocked(fetch).mockResolvedValue(mockResponse);
-
-    await apiRequest(ctx, "GET", "/api/tasks");
-
-    expect(consola.error).toHaveBeenCalledWith(
-      expect.stringContaining("認証エラー"),
     );
     expect(mockedProcessExit).toHaveBeenCalledWith(1);
   });

--- a/apps/cli/src/api.ts
+++ b/apps/cli/src/api.ts
@@ -1,12 +1,11 @@
+import { hc } from "hono/client";
+import type { AppType } from "@tascal/api/src/app.js";
 import { consola } from "consola";
 import { readConfig, getApiUrl } from "./config.js";
 
-interface ApiContext {
-  apiUrl: string;
-  token: string;
-}
+type ApiClient = ReturnType<typeof hc<AppType>>;
 
-export async function requireAuth(): Promise<ApiContext> {
+export async function requireAuthClient(): Promise<ApiClient> {
   const config = await readConfig();
   const token = config.token;
 
@@ -15,37 +14,23 @@ export async function requireAuth(): Promise<ApiContext> {
     process.exit(1);
   }
 
-  return { apiUrl: getApiUrl(config), token };
-}
+  const apiUrl = getApiUrl(config);
 
-export async function apiRequest(
-  ctx: ApiContext,
-  method: string,
-  path: string,
-  body?: unknown,
-): Promise<Response> {
-  const headers: Record<string, string> = {
-    Authorization: `Bearer ${ctx.token}`,
-  };
-
-  if (body !== undefined) {
-    headers["Content-Type"] = "application/json";
-  }
-
-  const res = await fetch(`${ctx.apiUrl}${path}`, {
-    method,
-    headers,
-    body: body !== undefined ? JSON.stringify(body) : undefined,
+  return hc<AppType>(apiUrl, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+    fetch: async (input: RequestInfo | URL, init?: RequestInit) => {
+      const res = await fetch(input, init);
+      if (res.status === 401) {
+        consola.error(
+          "認証エラー: セッションが無効です。`tascal login` で再ログインしてください。",
+        );
+        process.exit(1);
+      }
+      return res;
+    },
   });
-
-  if (res.status === 401) {
-    consola.error(
-      "認証エラー: セッションが無効です。`tascal login` で再ログインしてください。",
-    );
-    process.exit(1);
-  }
-
-  return res;
 }
 
 export async function handleApiError(

--- a/apps/cli/src/commands/add.test.ts
+++ b/apps/cli/src/commands/add.test.ts
@@ -5,28 +5,23 @@ vi.mock("consola", () => ({
 }));
 
 vi.mock("../api.js", () => ({
-  requireAuth: vi.fn(),
-  apiRequest: vi.fn(),
+  requireAuthClient: vi.fn(),
   handleApiError: vi.fn(),
 }));
 
 import { consola } from "consola";
-import { requireAuth, apiRequest } from "../api.js";
+import { requireAuthClient } from "../api.js";
 import command from "./add.js";
 
-const mockedRequireAuth = vi.mocked(requireAuth);
-const mockedApiRequest = vi.mocked(apiRequest);
+const mockedRequireAuthClient = vi.mocked(requireAuthClient);
 
 beforeEach(() => {
   vi.resetAllMocks();
 });
 
-const ctx = { apiUrl: "http://localhost:3000", token: "test-token" };
-
 describe("add", () => {
   it("カテゴリ付きでタスクを作成する", async () => {
-    mockedRequireAuth.mockResolvedValue(ctx);
-    mockedApiRequest.mockResolvedValue(
+    const mockPost = vi.fn().mockResolvedValue(
       new Response(
         JSON.stringify({
           id: "task-1",
@@ -36,6 +31,8 @@ describe("add", () => {
         { status: 201 },
       ),
     );
+    const mockClient = { api: { tasks: { $post: mockPost } } };
+    mockedRequireAuthClient.mockResolvedValue(mockClient as never);
 
     await command.run!({
       args: {
@@ -49,10 +46,12 @@ describe("add", () => {
       cmd: command,
     });
 
-    expect(mockedApiRequest).toHaveBeenCalledWith(ctx, "POST", "/api/tasks", {
-      title: "テスト",
-      date: "2026-04-13",
-      categoryId: "cat-1",
+    expect(mockPost).toHaveBeenCalledWith({
+      json: {
+        title: "テスト",
+        date: "2026-04-13",
+        categoryId: "cat-1",
+      },
     });
     expect(consola.success).toHaveBeenCalledWith(
       expect.stringContaining("テスト"),
@@ -60,8 +59,7 @@ describe("add", () => {
   });
 
   it("カテゴリなしでタスクを作成する", async () => {
-    mockedRequireAuth.mockResolvedValue(ctx);
-    mockedApiRequest.mockResolvedValue(
+    const mockPost = vi.fn().mockResolvedValue(
       new Response(
         JSON.stringify({
           id: "task-1",
@@ -71,6 +69,8 @@ describe("add", () => {
         { status: 201 },
       ),
     );
+    const mockClient = { api: { tasks: { $post: mockPost } } };
+    mockedRequireAuthClient.mockResolvedValue(mockClient as never);
 
     await command.run!({
       args: {
@@ -84,9 +84,11 @@ describe("add", () => {
       cmd: command,
     });
 
-    expect(mockedApiRequest).toHaveBeenCalledWith(ctx, "POST", "/api/tasks", {
-      title: "テスト",
-      date: "2026-04-13",
+    expect(mockPost).toHaveBeenCalledWith({
+      json: {
+        title: "テスト",
+        date: "2026-04-13",
+      },
     });
   });
 });

--- a/apps/cli/src/commands/add.ts
+++ b/apps/cli/src/commands/add.ts
@@ -1,12 +1,6 @@
 import { defineCommand } from "citty";
 import { consola } from "consola";
-import { requireAuth, apiRequest, handleApiError } from "../api.js";
-
-interface Task {
-  id: string;
-  title: string;
-  date: string;
-}
+import { requireAuthClient, handleApiError } from "../api.js";
 
 export default defineCommand({
   meta: {
@@ -34,28 +28,33 @@ export default defineCommand({
     },
   },
   async run({ args }) {
-    const ctx = await requireAuth();
+    const client = await requireAuthClient();
 
-    const body: Record<string, string> = {
+    const json: {
+      title: string;
+      date: string;
+      description?: string;
+      categoryId?: string;
+    } = {
       title: args.title,
       date: args.date,
     };
 
     if (args.description) {
-      body.description = args.description;
+      json.description = args.description;
     }
 
     if (args.category) {
-      body.categoryId = args.category;
+      json.categoryId = args.category;
     }
 
-    const res = await apiRequest(ctx, "POST", "/api/tasks", body);
+    const res = await client.api.tasks.$post({ json });
 
     if (!res.ok) {
       await handleApiError(res, "タスクの作成に失敗しました。");
     }
 
-    const task = (await res.json()) as Task;
+    const task = (await res.json()) as { id: string; title: string };
     consola.success(`タスクを作成しました: ${task.title} (${task.id})`);
   },
 });

--- a/apps/cli/src/commands/category/add.test.ts
+++ b/apps/cli/src/commands/category/add.test.ts
@@ -5,34 +5,33 @@ vi.mock("consola", () => ({
 }));
 
 vi.mock("../../api.js", () => ({
-  requireAuth: vi.fn(),
-  apiRequest: vi.fn(),
+  requireAuthClient: vi.fn(),
   handleApiError: vi.fn(),
 }));
 
 import { consola } from "consola";
-import { requireAuth, apiRequest, handleApiError } from "../../api.js";
+import { requireAuthClient, handleApiError } from "../../api.js";
 import command from "./add.js";
 
-const mockedRequireAuth = vi.mocked(requireAuth);
-const mockedApiRequest = vi.mocked(apiRequest);
+const mockedRequireAuthClient = vi.mocked(requireAuthClient);
 const mockedHandleApiError = vi.mocked(handleApiError);
 
 beforeEach(() => {
   vi.resetAllMocks();
 });
 
-const ctx = { apiUrl: "http://localhost:3000", token: "test-token" };
-
 describe("category add", () => {
   it("カテゴリを作成する", async () => {
-    mockedRequireAuth.mockResolvedValue(ctx);
-    mockedApiRequest.mockResolvedValue(
-      new Response(
-        JSON.stringify({ id: "cat-1", name: "仕事", color: "blue" }),
-        { status: 201 },
-      ),
-    );
+    const mockPost = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(
+          JSON.stringify({ id: "cat-1", name: "仕事", color: "blue" }),
+          { status: 201 },
+        ),
+      );
+    const mockClient = { api: { categories: { $post: mockPost } } };
+    mockedRequireAuthClient.mockResolvedValue(mockClient as never);
 
     await command.run!({
       args: { _: [], name: "仕事", color: "blue" },
@@ -40,28 +39,26 @@ describe("category add", () => {
       cmd: command,
     });
 
-    expect(mockedApiRequest).toHaveBeenCalledWith(
-      ctx,
-      "POST",
-      "/api/categories",
-      {
+    expect(mockPost).toHaveBeenCalledWith({
+      json: {
         name: "仕事",
         color: "blue",
       },
-    );
+    });
     expect(consola.success).toHaveBeenCalledWith(
       expect.stringContaining("仕事"),
     );
   });
 
   it("API エラー時にエラーハンドリングする", async () => {
-    mockedRequireAuth.mockResolvedValue(ctx);
-    mockedApiRequest.mockResolvedValue(
+    const mockPost = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ error: "error" }), {
         status: 400,
         headers: { "Content-Type": "application/json" },
       }),
     );
+    const mockClient = { api: { categories: { $post: mockPost } } };
+    mockedRequireAuthClient.mockResolvedValue(mockClient as never);
     mockedHandleApiError.mockRejectedValue(new Error("exit"));
 
     await expect(

--- a/apps/cli/src/commands/category/add.ts
+++ b/apps/cli/src/commands/category/add.ts
@@ -1,12 +1,6 @@
 import { defineCommand } from "citty";
 import { consola } from "consola";
-import { requireAuth, apiRequest, handleApiError } from "../../api.js";
-
-interface Category {
-  id: string;
-  name: string;
-  color: string;
-}
+import { requireAuthClient, handleApiError } from "../../api.js";
 
 export default defineCommand({
   meta: {
@@ -26,18 +20,28 @@ export default defineCommand({
     },
   },
   async run({ args }) {
-    const ctx = await requireAuth();
+    const client = await requireAuthClient();
 
-    const res = await apiRequest(ctx, "POST", "/api/categories", {
-      name: args.name,
-      color: args.color,
+    const res = await client.api.categories.$post({
+      json: {
+        name: args.name,
+        color: args.color as
+          | "red"
+          | "orange"
+          | "yellow"
+          | "green"
+          | "teal"
+          | "blue"
+          | "purple"
+          | "pink",
+      },
     });
 
     if (!res.ok) {
       await handleApiError(res, "カテゴリの作成に失敗しました。");
     }
 
-    const category = (await res.json()) as Category;
+    const category = (await res.json()) as { id: string; name: string };
     consola.success(
       `カテゴリを作成しました: ${category.name} (${category.id})`,
     );

--- a/apps/cli/src/commands/category/delete.test.ts
+++ b/apps/cli/src/commands/category/delete.test.ts
@@ -5,33 +5,32 @@ vi.mock("consola", () => ({
 }));
 
 vi.mock("../../api.js", () => ({
-  requireAuth: vi.fn(),
-  apiRequest: vi.fn(),
+  requireAuthClient: vi.fn(),
   handleApiError: vi.fn(),
 }));
 
 import { consola } from "consola";
-import { requireAuth, apiRequest, handleApiError } from "../../api.js";
+import { requireAuthClient, handleApiError } from "../../api.js";
 import command from "./delete.js";
 
-const mockedRequireAuth = vi.mocked(requireAuth);
-const mockedApiRequest = vi.mocked(apiRequest);
+const mockedRequireAuthClient = vi.mocked(requireAuthClient);
 const mockedHandleApiError = vi.mocked(handleApiError);
 
 beforeEach(() => {
   vi.resetAllMocks();
 });
 
-const ctx = { apiUrl: "http://localhost:3000", token: "test-token" };
-
 describe("category delete", () => {
   it("カテゴリを削除する", async () => {
-    mockedRequireAuth.mockResolvedValue(ctx);
-    mockedApiRequest.mockResolvedValue(
+    const mockDelete = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ message: "カテゴリを削除しました" }), {
         status: 200,
       }),
     );
+    const mockClient = {
+      api: { categories: { ":id": { $delete: mockDelete } } },
+    };
+    mockedRequireAuthClient.mockResolvedValue(mockClient as never);
 
     await command.run!({
       args: { _: [], id: "cat-1" },
@@ -39,22 +38,21 @@ describe("category delete", () => {
       cmd: command,
     });
 
-    expect(mockedApiRequest).toHaveBeenCalledWith(
-      ctx,
-      "DELETE",
-      "/api/categories/cat-1",
-    );
+    expect(mockDelete).toHaveBeenCalledWith({ param: { id: "cat-1" } });
     expect(consola.success).toHaveBeenCalledWith("カテゴリを削除しました。");
   });
 
   it("API エラー時にエラーハンドリングする", async () => {
-    mockedRequireAuth.mockResolvedValue(ctx);
-    mockedApiRequest.mockResolvedValue(
+    const mockDelete = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ error: "error" }), {
         status: 404,
         headers: { "Content-Type": "application/json" },
       }),
     );
+    const mockClient = {
+      api: { categories: { ":id": { $delete: mockDelete } } },
+    };
+    mockedRequireAuthClient.mockResolvedValue(mockClient as never);
     mockedHandleApiError.mockRejectedValue(new Error("exit"));
 
     await expect(

--- a/apps/cli/src/commands/category/delete.ts
+++ b/apps/cli/src/commands/category/delete.ts
@@ -1,6 +1,6 @@
 import { defineCommand } from "citty";
 import { consola } from "consola";
-import { requireAuth, apiRequest, handleApiError } from "../../api.js";
+import { requireAuthClient, handleApiError } from "../../api.js";
 
 export default defineCommand({
   meta: {
@@ -15,9 +15,11 @@ export default defineCommand({
     },
   },
   async run({ args }) {
-    const ctx = await requireAuth();
+    const client = await requireAuthClient();
 
-    const res = await apiRequest(ctx, "DELETE", `/api/categories/${args.id}`);
+    const res = await client.api.categories[":id"].$delete({
+      param: { id: args.id },
+    });
 
     if (!res.ok) {
       await handleApiError(res, "カテゴリの削除に失敗しました。");

--- a/apps/cli/src/commands/category/edit.test.ts
+++ b/apps/cli/src/commands/category/edit.test.ts
@@ -5,17 +5,15 @@ vi.mock("consola", () => ({
 }));
 
 vi.mock("../../api.js", () => ({
-  requireAuth: vi.fn(),
-  apiRequest: vi.fn(),
+  requireAuthClient: vi.fn(),
   handleApiError: vi.fn(),
 }));
 
 import { consola } from "consola";
-import { requireAuth, apiRequest, handleApiError } from "../../api.js";
+import { requireAuthClient, handleApiError } from "../../api.js";
 import command from "./edit.js";
 
-const mockedRequireAuth = vi.mocked(requireAuth);
-const mockedApiRequest = vi.mocked(apiRequest);
+const mockedRequireAuthClient = vi.mocked(requireAuthClient);
 const mockedHandleApiError = vi.mocked(handleApiError);
 const mockedProcessExit = vi
   .spyOn(process, "exit")
@@ -30,17 +28,20 @@ afterAll(() => {
   mockedProcessExit.mockRestore();
 });
 
-const ctx = { apiUrl: "http://localhost:3000", token: "test-token" };
-
 describe("category edit", () => {
   it("カテゴリを更新する", async () => {
-    mockedRequireAuth.mockResolvedValue(ctx);
-    mockedApiRequest.mockResolvedValue(
-      new Response(
-        JSON.stringify({ id: "cat-1", name: "更新後", color: "red" }),
-        { status: 200 },
-      ),
-    );
+    const mockPatch = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(
+          JSON.stringify({ id: "cat-1", name: "更新後", color: "red" }),
+          { status: 200 },
+        ),
+      );
+    const mockClient = {
+      api: { categories: { ":id": { $patch: mockPatch } } },
+    };
+    mockedRequireAuthClient.mockResolvedValue(mockClient as never);
 
     await command.run!({
       args: { _: [], id: "cat-1", name: "更新後", color: "red" },
@@ -48,24 +49,30 @@ describe("category edit", () => {
       cmd: command,
     });
 
-    expect(mockedApiRequest).toHaveBeenCalledWith(
-      ctx,
-      "PATCH",
-      "/api/categories/cat-1",
-      { name: "更新後", color: "red" },
-    );
+    expect(mockPatch).toHaveBeenCalledWith({
+      param: { id: "cat-1" },
+      json: { name: "更新後", color: "red" },
+    });
     expect(consola.success).toHaveBeenCalledWith(
       expect.stringContaining("更新後"),
     );
   });
 
   it("更新項目が指定されていない場合、エラーを表示する", async () => {
-    mockedRequireAuth.mockResolvedValue(ctx);
-    mockedApiRequest.mockResolvedValue(
-      new Response(JSON.stringify({ id: "cat-1", name: "n", color: "red" }), {
-        status: 200,
-      }),
-    );
+    const mockClient = {
+      api: {
+        categories: {
+          ":id": {
+            $patch: vi
+              .fn()
+              .mockResolvedValue(
+                new Response(JSON.stringify({}), { status: 200 }),
+              ),
+          },
+        },
+      },
+    };
+    mockedRequireAuthClient.mockResolvedValue(mockClient as never);
 
     await command.run!({
       args: { _: [], id: "cat-1", name: "", color: "" },
@@ -80,13 +87,16 @@ describe("category edit", () => {
   });
 
   it("API エラー時にエラーハンドリングする", async () => {
-    mockedRequireAuth.mockResolvedValue(ctx);
-    mockedApiRequest.mockResolvedValue(
+    const mockPatch = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ error: "error" }), {
         status: 404,
         headers: { "Content-Type": "application/json" },
       }),
     );
+    const mockClient = {
+      api: { categories: { ":id": { $patch: mockPatch } } },
+    };
+    mockedRequireAuthClient.mockResolvedValue(mockClient as never);
     mockedHandleApiError.mockRejectedValue(new Error("exit"));
 
     await expect(

--- a/apps/cli/src/commands/category/edit.ts
+++ b/apps/cli/src/commands/category/edit.ts
@@ -1,12 +1,6 @@
 import { defineCommand } from "citty";
 import { consola } from "consola";
-import { requireAuth, apiRequest, handleApiError } from "../../api.js";
-
-interface Category {
-  id: string;
-  name: string;
-  color: string;
-}
+import { requireAuthClient, handleApiError } from "../../api.js";
 
 export default defineCommand({
   meta: {
@@ -29,29 +23,47 @@ export default defineCommand({
     },
   },
   async run({ args }) {
-    const ctx = await requireAuth();
+    const client = await requireAuthClient();
 
-    const body: Record<string, string> = {};
-    if (args.name) body.name = args.name;
-    if (args.color) body.color = args.color;
+    const json: {
+      name?: string;
+      color?:
+        | "red"
+        | "orange"
+        | "yellow"
+        | "green"
+        | "teal"
+        | "blue"
+        | "purple"
+        | "pink";
+    } = {};
+    if (args.name) json.name = args.name;
+    if (args.color)
+      json.color = args.color as
+        | "red"
+        | "orange"
+        | "yellow"
+        | "green"
+        | "teal"
+        | "blue"
+        | "purple"
+        | "pink";
 
-    if (Object.keys(body).length === 0) {
+    if (Object.keys(json).length === 0) {
       consola.error("更新する項目を指定してください (--name, --color)。");
       process.exit(1);
     }
 
-    const res = await apiRequest(
-      ctx,
-      "PATCH",
-      `/api/categories/${args.id}`,
-      body,
-    );
+    const res = await client.api.categories[":id"].$patch({
+      param: { id: args.id },
+      json,
+    });
 
     if (!res.ok) {
       await handleApiError(res, "カテゴリの更新に失敗しました。");
     }
 
-    const category = (await res.json()) as Category;
+    const category = (await res.json()) as { id: string; name: string };
     consola.success(
       `カテゴリを更新しました: ${category.name} (${category.id})`,
     );

--- a/apps/cli/src/commands/category/list.test.ts
+++ b/apps/cli/src/commands/category/list.test.ts
@@ -5,17 +5,15 @@ vi.mock("consola", () => ({
 }));
 
 vi.mock("../../api.js", () => ({
-  requireAuth: vi.fn(),
-  apiRequest: vi.fn(),
+  requireAuthClient: vi.fn(),
   handleApiError: vi.fn(),
 }));
 
 import { consola } from "consola";
-import { requireAuth, apiRequest, handleApiError } from "../../api.js";
+import { requireAuthClient, handleApiError } from "../../api.js";
 import command from "./list.js";
 
-const mockedRequireAuth = vi.mocked(requireAuth);
-const mockedApiRequest = vi.mocked(apiRequest);
+const mockedRequireAuthClient = vi.mocked(requireAuthClient);
 const mockedHandleApiError = vi.mocked(handleApiError);
 const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
@@ -28,20 +26,24 @@ afterAll(() => {
   consoleSpy.mockRestore();
 });
 
-const ctx = { apiUrl: "http://localhost:3000", token: "test-token" };
-
 describe("category list", () => {
   it("カテゴリ一覧を表示する", async () => {
-    mockedRequireAuth.mockResolvedValue(ctx);
-    mockedApiRequest.mockResolvedValue(
-      new Response(
-        JSON.stringify([
-          { id: "cat-1", name: "仕事", color: "blue" },
-          { id: "cat-2", name: "個人", color: "green" },
-        ]),
-        { status: 200 },
-      ),
-    );
+    const mockClient = {
+      api: {
+        categories: {
+          $get: vi.fn().mockResolvedValue(
+            new Response(
+              JSON.stringify([
+                { id: "cat-1", name: "仕事", color: "blue" },
+                { id: "cat-2", name: "個人", color: "green" },
+              ]),
+              { status: 200 },
+            ),
+          ),
+        },
+      },
+    };
+    mockedRequireAuthClient.mockResolvedValue(mockClient as never);
 
     await command.run!({ args: { _: [] }, rawArgs: [], cmd: command });
 
@@ -51,10 +53,18 @@ describe("category list", () => {
   });
 
   it("カテゴリがない場合、メッセージを表示する", async () => {
-    mockedRequireAuth.mockResolvedValue(ctx);
-    mockedApiRequest.mockResolvedValue(
-      new Response(JSON.stringify([]), { status: 200 }),
-    );
+    const mockClient = {
+      api: {
+        categories: {
+          $get: vi
+            .fn()
+            .mockResolvedValue(
+              new Response(JSON.stringify([]), { status: 200 }),
+            ),
+        },
+      },
+    };
+    mockedRequireAuthClient.mockResolvedValue(mockClient as never);
 
     await command.run!({ args: { _: [] }, rawArgs: [], cmd: command });
 
@@ -64,13 +74,19 @@ describe("category list", () => {
   });
 
   it("API エラー時にエラーハンドリングする", async () => {
-    mockedRequireAuth.mockResolvedValue(ctx);
-    mockedApiRequest.mockResolvedValue(
-      new Response(JSON.stringify({ error: "error" }), {
-        status: 500,
-        headers: { "Content-Type": "application/json" },
-      }),
-    );
+    const mockClient = {
+      api: {
+        categories: {
+          $get: vi.fn().mockResolvedValue(
+            new Response(JSON.stringify({ error: "error" }), {
+              status: 500,
+              headers: { "Content-Type": "application/json" },
+            }),
+          ),
+        },
+      },
+    };
+    mockedRequireAuthClient.mockResolvedValue(mockClient as never);
     mockedHandleApiError.mockRejectedValue(new Error("exit"));
 
     await expect(

--- a/apps/cli/src/commands/category/list.ts
+++ b/apps/cli/src/commands/category/list.ts
@@ -1,12 +1,6 @@
 import { defineCommand } from "citty";
 import { consola } from "consola";
-import { requireAuth, apiRequest, handleApiError } from "../../api.js";
-
-interface Category {
-  id: string;
-  name: string;
-  color: string;
-}
+import { requireAuthClient, handleApiError } from "../../api.js";
 
 export default defineCommand({
   meta: {
@@ -14,15 +8,15 @@ export default defineCommand({
     description: "カテゴリ一覧を表示する",
   },
   async run() {
-    const ctx = await requireAuth();
+    const client = await requireAuthClient();
 
-    const res = await apiRequest(ctx, "GET", "/api/categories");
+    const res = await client.api.categories.$get();
 
     if (!res.ok) {
       await handleApiError(res, "カテゴリの取得に失敗しました。");
     }
 
-    const categories = (await res.json()) as Category[];
+    const categories = await res.json();
 
     if (categories.length === 0) {
       consola.info("カテゴリはありません。");

--- a/apps/cli/src/commands/delete.ts
+++ b/apps/cli/src/commands/delete.ts
@@ -1,6 +1,6 @@
 import { defineCommand } from "citty";
 import { consola } from "consola";
-import { requireAuth, apiRequest, handleApiError } from "../api.js";
+import { requireAuthClient, handleApiError } from "../api.js";
 
 export default defineCommand({
   meta: {
@@ -15,9 +15,11 @@ export default defineCommand({
     },
   },
   async run({ args }) {
-    const ctx = await requireAuth();
+    const client = await requireAuthClient();
 
-    const res = await apiRequest(ctx, "DELETE", `/api/tasks/${args.id}`);
+    const res = await client.api.tasks[":id"].$delete({
+      param: { id: args.id },
+    });
 
     if (!res.ok) {
       await handleApiError(res, "タスクの削除に失敗しました。");

--- a/apps/cli/src/commands/done.ts
+++ b/apps/cli/src/commands/done.ts
@@ -1,11 +1,6 @@
 import { defineCommand } from "citty";
 import { consola } from "consola";
-import { requireAuth, apiRequest, handleApiError } from "../api.js";
-
-interface Task {
-  id: string;
-  title: string;
-}
+import { requireAuthClient, handleApiError } from "../api.js";
 
 export default defineCommand({
   meta: {
@@ -20,17 +15,18 @@ export default defineCommand({
     },
   },
   async run({ args }) {
-    const ctx = await requireAuth();
+    const client = await requireAuthClient();
 
-    const res = await apiRequest(ctx, "PATCH", `/api/tasks/${args.id}`, {
-      status: "done",
+    const res = await client.api.tasks[":id"].$patch({
+      param: { id: args.id },
+      json: { status: "done" },
     });
 
     if (!res.ok) {
       await handleApiError(res, "タスクの更新に失敗しました。");
     }
 
-    const task = (await res.json()) as Task;
+    const task = (await res.json()) as { id: string; title: string };
     consola.success(`タスクを完了にしました: ${task.title}`);
   },
 });

--- a/apps/cli/src/commands/edit.test.ts
+++ b/apps/cli/src/commands/edit.test.ts
@@ -5,17 +5,15 @@ vi.mock("consola", () => ({
 }));
 
 vi.mock("../api.js", () => ({
-  requireAuth: vi.fn(),
-  apiRequest: vi.fn(),
+  requireAuthClient: vi.fn(),
   handleApiError: vi.fn(),
 }));
 
 import { consola } from "consola";
-import { requireAuth, apiRequest } from "../api.js";
+import { requireAuthClient } from "../api.js";
 import command from "./edit.js";
 
-const mockedRequireAuth = vi.mocked(requireAuth);
-const mockedApiRequest = vi.mocked(apiRequest);
+const mockedRequireAuthClient = vi.mocked(requireAuthClient);
 const mockedProcessExit = vi
   .spyOn(process, "exit")
   .mockImplementation(() => undefined as never);
@@ -29,8 +27,6 @@ afterAll(() => {
   mockedProcessExit.mockRestore();
 });
 
-const ctx = { apiUrl: "http://localhost:3000", token: "test-token" };
-
 // citty の ParsedArgs 型が全フィールド必須のため、テスト用にキャスト
 const run = command.run! as (ctx: {
   args: Record<string, unknown>;
@@ -40,8 +36,7 @@ const run = command.run! as (ctx: {
 
 describe("edit", () => {
   it("カテゴリ付きでタスクを更新する", async () => {
-    mockedRequireAuth.mockResolvedValue(ctx);
-    mockedApiRequest.mockResolvedValue(
+    const mockPatch = vi.fn().mockResolvedValue(
       new Response(
         JSON.stringify({
           id: "task-1",
@@ -51,6 +46,8 @@ describe("edit", () => {
         { status: 200 },
       ),
     );
+    const mockClient = { api: { tasks: { ":id": { $patch: mockPatch } } } };
+    mockedRequireAuthClient.mockResolvedValue(mockClient as never);
 
     await run({
       args: { _: [], id: "task-1", category: "cat-1" },
@@ -58,24 +55,23 @@ describe("edit", () => {
       cmd: command,
     });
 
-    expect(mockedApiRequest).toHaveBeenCalledWith(
-      ctx,
-      "PATCH",
-      "/api/tasks/task-1",
-      { categoryId: "cat-1" },
-    );
+    expect(mockPatch).toHaveBeenCalledWith({
+      param: { id: "task-1" },
+      json: { categoryId: "cat-1" },
+    });
     expect(consola.success).toHaveBeenCalledWith(
       expect.stringContaining("テスト"),
     );
   });
 
   it("更新項目が指定されていない場合、エラーメッセージに --category を含む", async () => {
-    mockedRequireAuth.mockResolvedValue(ctx);
-    mockedApiRequest.mockResolvedValue(
-      new Response(JSON.stringify({ id: "task-1", title: "t", date: "d" }), {
-        status: 200,
-      }),
-    );
+    const mockPatch = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+    const mockClient = {
+      api: { tasks: { ":id": { $patch: mockPatch } } },
+    };
+    mockedRequireAuthClient.mockResolvedValue(mockClient as never);
 
     await run({
       args: { _: [], id: "task-1" },

--- a/apps/cli/src/commands/edit.ts
+++ b/apps/cli/src/commands/edit.ts
@@ -1,12 +1,6 @@
 import { defineCommand } from "citty";
 import { consola } from "consola";
-import { requireAuth, apiRequest, handleApiError } from "../api.js";
-
-interface Task {
-  id: string;
-  title: string;
-  date: string;
-}
+import { requireAuthClient, handleApiError } from "../api.js";
 
 export default defineCommand({
   meta: {
@@ -37,28 +31,31 @@ export default defineCommand({
     },
   },
   async run({ args }) {
-    const ctx = await requireAuth();
+    const client = await requireAuthClient();
 
-    const body: Record<string, string> = {};
-    if (args.title) body.title = args.title;
-    if (args.date) body.date = args.date;
-    if (args.description !== undefined) body.description = args.description;
-    if (args.category) body.categoryId = args.category;
+    const json: Record<string, string> = {};
+    if (args.title) json.title = args.title;
+    if (args.date) json.date = args.date;
+    if (args.description !== undefined) json.description = args.description;
+    if (args.category) json.categoryId = args.category;
 
-    if (Object.keys(body).length === 0) {
+    if (Object.keys(json).length === 0) {
       consola.error(
         "更新する項目を指定してください (--title, --date, --description, --category)。",
       );
       process.exit(1);
     }
 
-    const res = await apiRequest(ctx, "PATCH", `/api/tasks/${args.id}`, body);
+    const res = await client.api.tasks[":id"].$patch({
+      param: { id: args.id },
+      json,
+    });
 
     if (!res.ok) {
       await handleApiError(res, "タスクの更新に失敗しました。");
     }
 
-    const task = (await res.json()) as Task;
+    const task = (await res.json()) as { id: string; title: string };
     consola.success(`タスクを更新しました: ${task.title} (${task.id})`);
   },
 });

--- a/apps/cli/src/commands/list.test.ts
+++ b/apps/cli/src/commands/list.test.ts
@@ -5,17 +5,15 @@ vi.mock("consola", () => ({
 }));
 
 vi.mock("../api.js", () => ({
-  requireAuth: vi.fn(),
-  apiRequest: vi.fn(),
+  requireAuthClient: vi.fn(),
   handleApiError: vi.fn(),
 }));
 
 import { consola } from "consola";
-import { requireAuth, apiRequest, handleApiError } from "../api.js";
+import { requireAuthClient, handleApiError } from "../api.js";
 import command from "./list.js";
 
-const mockedRequireAuth = vi.mocked(requireAuth);
-const mockedApiRequest = vi.mocked(apiRequest);
+const mockedRequireAuthClient = vi.mocked(requireAuthClient);
 const mockedHandleApiError = vi.mocked(handleApiError);
 const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
@@ -28,43 +26,51 @@ afterAll(() => {
   consoleSpy.mockRestore();
 });
 
-const ctx = { apiUrl: "http://localhost:3000", token: "test-token" };
+function createMockClient(
+  tasksResponse: Response,
+  categoriesResponse: Response,
+) {
+  return {
+    api: {
+      tasks: {
+        $get: vi.fn().mockResolvedValue(tasksResponse),
+      },
+      categories: {
+        $get: vi.fn().mockResolvedValue(categoriesResponse),
+      },
+    },
+  };
+}
 
 describe("list", () => {
   it("タスク一覧にカテゴリ名を表示する", async () => {
-    mockedRequireAuth.mockResolvedValue(ctx);
-    mockedApiRequest.mockImplementation((_ctx, _method, path) => {
-      if (path.startsWith("/api/tasks")) {
-        return Promise.resolve(
-          new Response(
-            JSON.stringify([
-              {
-                id: "task-1",
-                title: "タスク1",
-                description: null,
-                date: "2026-04-13",
-                status: "todo",
-                categoryId: "cat-1",
-              },
-              {
-                id: "task-2",
-                title: "タスク2",
-                description: null,
-                date: "2026-04-14",
-                status: "done",
-                categoryId: null,
-              },
-            ]),
-            { status: 200 },
-          ),
-        );
-      }
-      return Promise.resolve(
-        new Response(JSON.stringify([{ id: "cat-1", name: "仕事" }]), {
-          status: 200,
-        }),
-      );
-    });
+    const mockClient = createMockClient(
+      new Response(
+        JSON.stringify([
+          {
+            id: "task-1",
+            title: "タスク1",
+            description: null,
+            date: "2026-04-13",
+            status: "todo",
+            categoryId: "cat-1",
+          },
+          {
+            id: "task-2",
+            title: "タスク2",
+            description: null,
+            date: "2026-04-14",
+            status: "done",
+            categoryId: null,
+          },
+        ]),
+        { status: 200 },
+      ),
+      new Response(JSON.stringify([{ id: "cat-1", name: "仕事" }]), {
+        status: 200,
+      }),
+    );
+    mockedRequireAuthClient.mockResolvedValue(mockClient as never);
 
     await command.run!({
       args: { _: [], year: "2026", month: "4" },
@@ -82,27 +88,23 @@ describe("list", () => {
   });
 
   it("カテゴリなしのタスクにはカテゴリラベルを表示しない", async () => {
-    mockedRequireAuth.mockResolvedValue(ctx);
-    mockedApiRequest.mockImplementation((_ctx, _method, path) => {
-      if (path.startsWith("/api/tasks")) {
-        return Promise.resolve(
-          new Response(
-            JSON.stringify([
-              {
-                id: "task-1",
-                title: "タスク1",
-                description: null,
-                date: "2026-04-13",
-                status: "todo",
-                categoryId: null,
-              },
-            ]),
-            { status: 200 },
-          ),
-        );
-      }
-      return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }));
-    });
+    const mockClient = createMockClient(
+      new Response(
+        JSON.stringify([
+          {
+            id: "task-1",
+            title: "タスク1",
+            description: null,
+            date: "2026-04-13",
+            status: "todo",
+            categoryId: null,
+          },
+        ]),
+        { status: 200 },
+      ),
+      new Response(JSON.stringify([]), { status: 200 }),
+    );
+    mockedRequireAuthClient.mockResolvedValue(mockClient as never);
 
     await command.run!({
       args: { _: [], year: "2026", month: "4" },
@@ -120,15 +122,11 @@ describe("list", () => {
   });
 
   it("タスクがない場合、メッセージを表示する", async () => {
-    mockedRequireAuth.mockResolvedValue(ctx);
-    mockedApiRequest.mockImplementation((_ctx, _method, path) => {
-      if (path.startsWith("/api/tasks")) {
-        return Promise.resolve(
-          new Response(JSON.stringify([]), { status: 200 }),
-        );
-      }
-      return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }));
-    });
+    const mockClient = createMockClient(
+      new Response(JSON.stringify([]), { status: 200 }),
+      new Response(JSON.stringify([]), { status: 200 }),
+    );
+    mockedRequireAuthClient.mockResolvedValue(mockClient as never);
 
     await command.run!({
       args: { _: [], year: "2026", month: "4" },
@@ -142,18 +140,14 @@ describe("list", () => {
   });
 
   it("タスク API エラー時にエラーハンドリングする", async () => {
-    mockedRequireAuth.mockResolvedValue(ctx);
-    mockedApiRequest.mockImplementation((_ctx, _method, path) => {
-      if (path.startsWith("/api/tasks")) {
-        return Promise.resolve(
-          new Response(JSON.stringify({ error: "error" }), {
-            status: 500,
-            headers: { "Content-Type": "application/json" },
-          }),
-        );
-      }
-      return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }));
-    });
+    const mockClient = createMockClient(
+      new Response(JSON.stringify({ error: "error" }), {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      }),
+      new Response(JSON.stringify([]), { status: 200 }),
+    );
+    mockedRequireAuthClient.mockResolvedValue(mockClient as never);
     mockedHandleApiError.mockRejectedValue(new Error("exit"));
 
     await expect(

--- a/apps/cli/src/commands/list.ts
+++ b/apps/cli/src/commands/list.ts
@@ -1,20 +1,6 @@
 import { defineCommand } from "citty";
 import { consola } from "consola";
-import { requireAuth, apiRequest, handleApiError } from "../api.js";
-
-interface Task {
-  id: string;
-  title: string;
-  description: string | null;
-  date: string;
-  status: "todo" | "done";
-  categoryId: string | null;
-}
-
-interface Category {
-  id: string;
-  name: string;
-}
+import { requireAuthClient, handleApiError } from "../api.js";
 
 export default defineCommand({
   meta: {
@@ -32,25 +18,27 @@ export default defineCommand({
     },
   },
   async run({ args }) {
-    const ctx = await requireAuth();
+    const client = await requireAuthClient();
 
     const now = new Date();
     const year = args.year ? Number(args.year) : now.getFullYear();
     const month = args.month ? Number(args.month) : now.getMonth() + 1;
 
     const [tasksRes, categoriesRes] = await Promise.all([
-      apiRequest(ctx, "GET", `/api/tasks?year=${year}&month=${month}`),
-      apiRequest(ctx, "GET", "/api/categories"),
+      client.api.tasks.$get({
+        query: { year: String(year), month: String(month) },
+      }),
+      client.api.categories.$get(),
     ]);
 
     if (!tasksRes.ok) {
       await handleApiError(tasksRes, "タスクの取得に失敗しました。");
     }
 
-    const tasks = (await tasksRes.json()) as Task[];
-    let categories: Category[] = [];
+    const tasks = await tasksRes.json();
+    let categories: { id: string; name: string }[] = [];
     if (categoriesRes.ok) {
-      categories = (await categoriesRes.json()) as Category[];
+      categories = await categoriesRes.json();
     }
     const categoryMap = new Map(categories.map((c) => [c.id, c.name]));
 
@@ -61,7 +49,7 @@ export default defineCommand({
 
     consola.info(`${year}年${month}月のタスク (${tasks.length}件):\n`);
 
-    const sorted = tasks.sort(
+    const sorted = [...tasks].sort(
       (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
     );
 

--- a/apps/cli/src/commands/undo.ts
+++ b/apps/cli/src/commands/undo.ts
@@ -1,11 +1,6 @@
 import { defineCommand } from "citty";
 import { consola } from "consola";
-import { requireAuth, apiRequest, handleApiError } from "../api.js";
-
-interface Task {
-  id: string;
-  title: string;
-}
+import { requireAuthClient, handleApiError } from "../api.js";
 
 export default defineCommand({
   meta: {
@@ -20,17 +15,18 @@ export default defineCommand({
     },
   },
   async run({ args }) {
-    const ctx = await requireAuth();
+    const client = await requireAuthClient();
 
-    const res = await apiRequest(ctx, "PATCH", `/api/tasks/${args.id}`, {
-      status: "todo",
+    const res = await client.api.tasks[":id"].$patch({
+      param: { id: args.id },
+      json: { status: "todo" },
     });
 
     if (!res.ok) {
       await handleApiError(res, "タスクの更新に失敗しました。");
     }
 
-    const task = (await res.json()) as Task;
+    const task = (await res.json()) as { id: string; title: string };
     consola.success(`タスクを未完了に戻しました: ${task.title}`);
   },
 });

--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -5,5 +5,6 @@
     "noEmit": false,
     "composite": true
   },
+  "references": [{ "path": "../api" }],
   "include": ["src", "vitest.config.ts"]
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,6 +20,7 @@
     "@tanstack/react-query": "^5.97.0",
     "@tanstack/react-router": "^1.167.3",
     "better-auth": "^1.5.5",
+    "hono": "^4.12.12",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "sonner": "^2.0.7"
@@ -27,6 +28,7 @@
   "devDependencies": {
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-plugin": "^1.166.12",
+    "@tascal/api": "workspace:*",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/apps/web/src/api/categories.ts
+++ b/apps/web/src/api/categories.ts
@@ -1,50 +1,51 @@
-import type { Category, CategoryColor } from "../types/category";
+import type { InferResponseType } from "hono/client";
+import { client } from "./client";
+
+type Category = InferResponseType<
+  typeof client.api.categories.$get,
+  200
+>[number];
+
+export type { Category };
 
 export async function fetchCategories(): Promise<Category[]> {
-  const res = await fetch("/api/categories");
+  const res = await client.api.categories.$get();
   if (!res.ok) {
     throw new Error("カテゴリの取得に失敗しました");
   }
-  return res.json() as Promise<Category[]>;
+  return res.json();
 }
 
 export async function createCategory(data: {
   name: string;
-  color: CategoryColor;
+  color: Category["color"];
 }): Promise<Category> {
-  const res = await fetch("/api/categories", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(data),
-  });
+  const res = await client.api.categories.$post({ json: data });
   if (!res.ok) {
     throw new Error("カテゴリの作成に失敗しました");
   }
-  return res.json() as Promise<Category>;
+  return res.json();
 }
 
 export async function updateCategory(
   id: string,
   data: {
     name?: string;
-    color?: CategoryColor;
+    color?: Category["color"];
   },
 ): Promise<Category> {
-  const res = await fetch(`/api/categories/${id}`, {
-    method: "PATCH",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(data),
+  const res = await client.api.categories[":id"].$patch({
+    param: { id },
+    json: data,
   });
   if (!res.ok) {
     throw new Error("カテゴリの更新に失敗しました");
   }
-  return res.json() as Promise<Category>;
+  return res.json();
 }
 
 export async function deleteCategory(id: string): Promise<void> {
-  const res = await fetch(`/api/categories/${id}`, {
-    method: "DELETE",
-  });
+  const res = await client.api.categories[":id"].$delete({ param: { id } });
   if (!res.ok) {
     throw new Error("カテゴリの削除に失敗しました");
   }

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -1,0 +1,4 @@
+import { hc } from "hono/client";
+import type { AppType } from "@tascal/api/src/app.js";
+
+export const client = hc<AppType>("");

--- a/apps/web/src/api/tasks.ts
+++ b/apps/web/src/api/tasks.ts
@@ -1,15 +1,23 @@
-import type { Task } from "../types/task";
+import type { InferResponseType } from "hono/client";
+import { client } from "./client";
+
+type Task = InferResponseType<typeof client.api.tasks.$get, 200>[number];
+
+export type { Task };
 
 export async function fetchTasks(
   year: number,
   month: number,
   signal?: AbortSignal,
 ): Promise<Task[]> {
-  const res = await fetch(`/api/tasks?year=${year}&month=${month}`, { signal });
+  const res = await client.api.tasks.$get(
+    { query: { year: String(year), month: String(month) } },
+    { init: { signal } },
+  );
   if (!res.ok) {
     throw new Error("タスクの取得に失敗しました");
   }
-  return res.json() as Promise<Task[]>;
+  return res.json();
 }
 
 export async function createTask(data: {
@@ -19,15 +27,11 @@ export async function createTask(data: {
   status?: "todo" | "done";
   categoryId?: string | null;
 }): Promise<Task> {
-  const res = await fetch("/api/tasks", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(data),
-  });
+  const res = await client.api.tasks.$post({ json: data });
   if (!res.ok) {
     throw new Error("タスクの作成に失敗しました");
   }
-  return res.json() as Promise<Task>;
+  return res.json();
 }
 
 export async function updateTask(
@@ -40,21 +44,18 @@ export async function updateTask(
     categoryId?: string | null;
   },
 ): Promise<Task> {
-  const res = await fetch(`/api/tasks/${id}`, {
-    method: "PATCH",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(data),
+  const res = await client.api.tasks[":id"].$patch({
+    param: { id },
+    json: data,
   });
   if (!res.ok) {
     throw new Error("タスクの更新に失敗しました");
   }
-  return res.json() as Promise<Task>;
+  return res.json();
 }
 
 export async function deleteTask(id: string): Promise<void> {
-  const res = await fetch(`/api/tasks/${id}`, {
-    method: "DELETE",
-  });
+  const res = await client.api.tasks[":id"].$delete({ param: { id } });
   if (!res.ok) {
     throw new Error("タスクの削除に失敗しました");
   }

--- a/apps/web/src/types/category.ts
+++ b/apps/web/src/types/category.ts
@@ -1,18 +1,4 @@
-export type CategoryColor =
-  | "red"
-  | "orange"
-  | "yellow"
-  | "green"
-  | "teal"
-  | "blue"
-  | "purple"
-  | "pink";
+import type { Category } from "../api/categories";
 
-export type Category = {
-  id: string;
-  name: string;
-  color: CategoryColor;
-  userId: string;
-  createdAt: string;
-  updatedAt: string;
-};
+export type { Category };
+export type CategoryColor = Category["color"];

--- a/apps/web/src/types/task.ts
+++ b/apps/web/src/types/task.ts
@@ -1,11 +1,1 @@
-export type Task = {
-  id: string;
-  title: string;
-  description: string | null;
-  date: string;
-  status: "todo" | "done";
-  categoryId: string | null;
-  userId: string;
-  createdAt: string;
-  updatedAt: string;
-};
+export type { Task } from "../api/tasks";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,7 +93,13 @@ importers:
       consola:
         specifier: ^3.4.2
         version: 3.4.2
+      hono:
+        specifier: ^4.12.12
+        version: 4.12.12
     devDependencies:
+      '@tascal/api':
+        specifier: workspace:*
+        version: link:../api
       '@types/node':
         specifier: ^22.15.3
         version: 22.19.17
@@ -118,6 +124,9 @@ importers:
       better-auth:
         specifier: ^1.5.5
         version: 1.6.2(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.16)(pg@8.20.0))(pg@8.20.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)))
+      hono:
+        specifier: ^4.12.12
+        version: 4.12.12
       react:
         specifier: ^19.1.0
         version: 19.2.5
@@ -134,6 +143,9 @@ importers:
       '@tanstack/router-plugin':
         specifier: ^1.166.12
         version: 1.167.18(@tanstack/react-router@1.168.18(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@tascal/api':
+        specifier: workspace:*
+        version: link:../api
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1


### PR DESCRIPTION
close #150

## Summary

- API ルートをチェイン形式に変更し `AppType` をエクスポート
- `validationHook` を廃止し Hono 標準のバリデーションに統一
- Web の API クライアントを `hc<AppType>` ベースに置き換え（`InferResponseType` で型自動導出）
- CLI の API クライアントを `hc<AppType>` ベースに置き換え（Bearer トークン認証は `hc` の `fetch` オプションで対応）
- Web/CLI の手動型定義（`Task`, `Category`, `CategoryColor`）を API ルート定義からの自動導出に変更

## 変更の詳細

### API (`apps/api`)
- `tasks.ts`, `categories.ts`, `users.ts`: ルート定義をチェイン形式（`.get().post().patch().delete()`）に変更
- `validationHook` を削除し、`zValidator` のデフォルトバリデーションエラーに統一
- `app.ts`: `.route()` をチェインし `AppType` を型エクスポート

### Web (`apps/web`)
- `hono` と `@tascal/api` を依存に追加
- `api/client.ts` を新規作成（`hc<AppType>("")` のシングルトン）
- `api/tasks.ts`, `api/categories.ts` を `hc` ベースに書き換え
- `types/task.ts`, `types/category.ts` を API クライアントからの re-export に変更

### CLI (`apps/cli`)
- `hono` と `@tascal/api` を依存に追加、`tsconfig.json` にプロジェクトリファレンス追加
- `api.ts`: `requireAuth` + `apiRequest` を `requireAuthClient`（`hc` クライアントファクトリ）に置き換え
- 全コマンド（list, add, edit, delete, done, undo, category/*）を RPC クライアント API に対応
- テストファイルを新しいモックパターン（モッククライアントオブジェクト）に更新

## Test plan

- [x] `pnpm typecheck` — 全 app 通過
- [x] `pnpm lint` — 全 app 通過
- [x] `pnpm format:check` — 全 app 通過
- [x] `pnpm test` — API 74件、Web 66件、CLI 31件 すべて通過
- [x] `pnpm knip` — 全 app 通過
- [ ] CI が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)