### PR TITLE
feat: 日付なしタスク（未スケジュールタスク）機能の追加

### DIFF
--- a/apps/api/drizzle/0002_nullable_task_date.sql
+++ b/apps/api/drizzle/0002_nullable_task_date.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "tasks" ALTER COLUMN "date" DROP NOT NULL;

--- a/apps/api/drizzle/meta/0002_snapshot.json
+++ b/apps/api/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,490 @@
+{
+  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "prevId": "70eea9ff-afd7-4202-8e57-a6fbcd8ad341",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "category_color",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "categories_user_id_users_id_fk": {
+          "name": "categories_user_id_users_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "task_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'todo'"
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tasks_category_id_categories_id_fk": {
+          "name": "tasks_category_id_categories_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "categories",
+          "columnsFrom": ["category_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "tasks_user_id_users_id_fk": {
+          "name": "tasks_user_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.category_color": {
+      "name": "category_color",
+      "schema": "public",
+      "values": [
+        "red",
+        "orange",
+        "yellow",
+        "green",
+        "teal",
+        "blue",
+        "purple",
+        "pink"
+      ]
+    },
+    "public.task_status": {
+      "name": "task_status",
+      "schema": "public",
+      "values": ["todo", "done"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1776029805844,
       "tag": "0001_material_northstar",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1776130000000,
+      "tag": "0002_nullable_task_date",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -91,7 +91,7 @@ export const tasks = pgTable("tasks", {
   id: uuid("id").primaryKey().defaultRandom(),
   title: varchar("title", { length: 255 }).notNull(),
   description: text("description"),
-  date: date("date").notNull(),
+  date: date("date"),
   status: taskStatusEnum("status").notNull().default("todo"),
   categoryId: uuid("category_id").references(() => categories.id, {
     onDelete: "set null",

--- a/apps/api/src/routes/tasks.test.ts
+++ b/apps/api/src/routes/tasks.test.ts
@@ -28,6 +28,17 @@ const mockTask = {
   updatedAt: new Date("2026-03-01"),
 };
 
+const mockUnscheduledTask = {
+  id: "770e8400-e29b-41d4-a716-446655440001",
+  title: "未スケジュールタスク",
+  description: null,
+  date: null,
+  status: "todo" as const,
+  userId: mockUser.id,
+  createdAt: new Date("2026-03-01"),
+  updatedAt: new Date("2026-03-01"),
+};
+
 // DB モック
 const mockSelect = vi.fn();
 const mockInsert = vi.fn();
@@ -318,5 +329,81 @@ describe("DELETE /api/tasks/:id", () => {
       jsonRequest("DELETE", "/api/tasks/invalid-uuid"),
     );
     expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /api/tasks/unscheduled", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("未スケジュールタスク一覧を取得できる", async () => {
+    mockSelect.mockResolvedValue([mockUnscheduledTask]);
+    const app = await createTestApp();
+
+    const res = await app.request(jsonRequest("GET", "/api/tasks/unscheduled"));
+    expect(res.status).toBe(200);
+
+    const json = (await res.json()) as (typeof mockUnscheduledTask)[];
+    expect(json).toHaveLength(1);
+    expect(json[0].title).toBe("未スケジュールタスク");
+    expect(json[0].date).toBeNull();
+  });
+});
+
+describe("POST /api/tasks (未スケジュール)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("date なしでタスクを作成できる", async () => {
+    mockInsert.mockResolvedValue([mockUnscheduledTask]);
+    const app = await createTestApp();
+
+    const res = await app.request(
+      jsonRequest("POST", "/api/tasks", {
+        title: "未スケジュールタスク",
+      }),
+    );
+    expect(res.status).toBe(201);
+
+    const json = (await res.json()) as { title: string; date: string | null };
+    expect(json.title).toBe("未スケジュールタスク");
+    expect(json.date).toBeNull();
+  });
+
+  it("date を null で指定してタスクを作成できる", async () => {
+    mockInsert.mockResolvedValue([mockUnscheduledTask]);
+    const app = await createTestApp();
+
+    const res = await app.request(
+      jsonRequest("POST", "/api/tasks", {
+        title: "未スケジュールタスク",
+        date: null,
+      }),
+    );
+    expect(res.status).toBe(201);
+  });
+});
+
+describe("PATCH /api/tasks/:id (未スケジュール)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("date を null に更新して未スケジュールに戻せる", async () => {
+    const updatedTask = { ...mockTask, date: null };
+    mockUpdate.mockResolvedValue([updatedTask]);
+    const app = await createTestApp();
+
+    const res = await app.request(
+      jsonRequest("PATCH", `/api/tasks/${mockTask.id}`, {
+        date: null,
+      }),
+    );
+    expect(res.status).toBe(200);
+
+    const json = (await res.json()) as { date: string | null };
+    expect(json.date).toBeNull();
   });
 });

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import { z } from "zod";
 import { zValidator } from "@hono/zod-validator";
-import { eq, and, gte, lt, asc } from "drizzle-orm";
+import { eq, and, gte, lt, asc, isNull } from "drizzle-orm";
 import { getDb } from "../db/index.js";
 import { categories, tasks } from "../db/schema.js";
 import type { Auth } from "../auth.js";
@@ -14,7 +14,11 @@ type AuthVariables = {
 const createTaskSchema = z.object({
   title: z.string().min(1).max(255),
   description: z.string().nullable().optional(),
-  date: z.string().date("日付はYYYY-MM-DD形式の実在する日付で指定してください"),
+  date: z
+    .string()
+    .date("日付はYYYY-MM-DD形式の実在する日付で指定してください")
+    .nullable()
+    .optional(),
   status: z.enum(["todo", "done"]).optional(),
   categoryId: z.string().uuid().nullable().optional(),
 });
@@ -25,6 +29,7 @@ const updateTaskSchema = z.object({
   date: z
     .string()
     .date("日付はYYYY-MM-DD形式の実在する日付で指定してください")
+    .nullable()
     .optional(),
   status: z.enum(["todo", "done"]).optional(),
   categoryId: z.string().uuid().nullable().optional(),
@@ -72,6 +77,18 @@ const app = new Hono<{ Variables: AuthVariables }>()
 
     return c.json(result);
   })
+  // GET /api/tasks/unscheduled
+  .get("/unscheduled", async (c) => {
+    const user = c.get("user")!;
+
+    const result = await getDb()
+      .select()
+      .from(tasks)
+      .where(and(eq(tasks.userId, user.id), isNull(tasks.date)))
+      .orderBy(asc(tasks.status), asc(tasks.createdAt));
+
+    return c.json(result);
+  })
   // POST /api/tasks
   .post("/", zValidator("json", createTaskSchema), async (c) => {
     const user = c.get("user")!;
@@ -95,7 +112,7 @@ const app = new Hono<{ Variables: AuthVariables }>()
       .values({
         title: data.title,
         description: data.description ?? null,
-        date: data.date,
+        date: data.date ?? null,
         status: data.status ?? "todo",
         categoryId,
         userId: user.id,

--- a/apps/cli/src/commands/add.test.ts
+++ b/apps/cli/src/commands/add.test.ts
@@ -91,4 +91,40 @@ describe("add", () => {
       },
     });
   });
+
+  it("date 省略で未スケジュールタスクを作成する", async () => {
+    const mockPost = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: "task-1",
+          title: "未スケジュール",
+          date: null,
+        }),
+        { status: 201 },
+      ),
+    );
+    const mockClient = { api: { tasks: { $post: mockPost } } };
+    mockedRequireAuthClient.mockResolvedValue(mockClient as never);
+
+    await command.run!({
+      args: {
+        _: [],
+        title: "未スケジュール",
+        date: undefined as unknown as string,
+        description: "",
+        category: "",
+      },
+      rawArgs: [],
+      cmd: command,
+    });
+
+    expect(mockPost).toHaveBeenCalledWith({
+      json: {
+        title: "未スケジュール",
+      },
+    });
+    expect(consola.success).toHaveBeenCalledWith(
+      expect.stringContaining("未スケジュール"),
+    );
+  });
 });

--- a/apps/cli/src/commands/add.ts
+++ b/apps/cli/src/commands/add.ts
@@ -15,8 +15,7 @@ export default defineCommand({
     },
     date: {
       type: "string",
-      description: "日付 (YYYY-MM-DD)",
-      required: true,
+      description: "日付 (YYYY-MM-DD)。省略時は未スケジュールタスクとして作成",
     },
     description: {
       type: "string",
@@ -32,13 +31,16 @@ export default defineCommand({
 
     const json: {
       title: string;
-      date: string;
+      date?: string;
       description?: string;
       categoryId?: string;
     } = {
       title: args.title,
-      date: args.date,
     };
+
+    if (args.date) {
+      json.date = args.date;
+    }
 
     if (args.description) {
       json.description = args.description;

--- a/apps/cli/src/commands/list.ts
+++ b/apps/cli/src/commands/list.ts
@@ -49,9 +49,12 @@ export default defineCommand({
 
     consola.info(`${year}年${month}月のタスク (${tasks.length}件):\n`);
 
-    const sorted = [...tasks].sort(
-      (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
-    );
+    const sorted = [...tasks].sort((a, b) => {
+      if (!a.date && !b.date) return 0;
+      if (!a.date) return 1;
+      if (!b.date) return -1;
+      return new Date(a.date).getTime() - new Date(b.date).getTime();
+    });
 
     for (const task of sorted) {
       const status = task.status === "done" ? "✔" : "○";
@@ -59,8 +62,9 @@ export default defineCommand({
         ? categoryMap.get(task.categoryId)
         : null;
       const categoryLabel = categoryName ? ` [${categoryName}]` : "";
+      const dateLabel = task.date ?? "未定";
       console.log(
-        `  ${status} [${task.date}] ${task.title}${categoryLabel} (${task.id})`,
+        `  ${status} [${dateLabel}] ${task.title}${categoryLabel} (${task.id})`,
       );
       if (task.description) {
         console.log(`    ${task.description}`);

--- a/apps/web/src/api/tasks.ts
+++ b/apps/web/src/api/tasks.ts
@@ -20,10 +20,20 @@ export async function fetchTasks(
   return res.json();
 }
 
+export async function fetchUnscheduledTasks(
+  signal?: AbortSignal,
+): Promise<Task[]> {
+  const res = await client.api.tasks.unscheduled.$get({}, { init: { signal } });
+  if (!res.ok) {
+    throw new Error("未スケジュールタスクの取得に失敗しました");
+  }
+  return res.json();
+}
+
 export async function createTask(data: {
   title: string;
   description?: string | null;
-  date: string;
+  date?: string | null;
   status?: "todo" | "done";
   categoryId?: string | null;
 }): Promise<Task> {
@@ -39,7 +49,7 @@ export async function updateTask(
   data: {
     title?: string;
     description?: string | null;
-    date?: string;
+    date?: string | null;
     status?: "todo" | "done";
     categoryId?: string | null;
   },

--- a/apps/web/src/components/Calendar.test.tsx
+++ b/apps/web/src/components/Calendar.test.tsx
@@ -551,9 +551,23 @@ describe("Calendar", () => {
     });
   });
 
-  it("未スケジュールタスクサイドバーが表示される", async () => {
+  it("トグルボタンで未スケジュールタスクサイドバーを表示できる", async () => {
     mockFetchUnscheduledTasks.mockResolvedValue([mockUnscheduledTask]);
+
+    const user = userEvent.setup();
     renderWithQueryClient(<Calendar />);
+
+    // 初期状態ではサイドバーは非表示
+    await waitFor(() => {
+      expect(
+        screen.queryByText("未スケジュールタスク"),
+      ).not.toBeInTheDocument();
+    });
+
+    // トグルボタンをクリックして表示
+    await user.click(
+      screen.getByRole("button", { name: "未スケジュールタスク" }),
+    );
 
     await waitFor(() => {
       expect(screen.getByText("未スケジュール")).toBeInTheDocument();
@@ -561,7 +575,7 @@ describe("Calendar", () => {
     });
   });
 
-  it("未スケジュールタスクの件数バッジが表示される", async () => {
+  it("未スケジュールタスクがある場合、トグルボタンに件数バッジが表示される", async () => {
     mockFetchUnscheduledTasks.mockResolvedValue([
       mockUnscheduledTask,
       { ...mockUnscheduledTask, id: "unscheduled-task-2", title: "タスク2" },
@@ -569,9 +583,10 @@ describe("Calendar", () => {
     renderWithQueryClient(<Calendar />);
 
     await waitFor(() => {
-      const toggle = screen.getByText("未スケジュール");
-      const wrapper = toggle.closest("span");
-      const badge = wrapper?.querySelector(".rounded-full");
+      const toggleButton = screen.getByRole("button", {
+        name: "未スケジュールタスク",
+      });
+      const badge = toggleButton.querySelector(".rounded-full");
       expect(badge?.textContent).toBe("2");
     });
   });
@@ -582,24 +597,24 @@ describe("Calendar", () => {
     const user = userEvent.setup();
     renderWithQueryClient(<Calendar />);
 
+    const toggleButton = screen.getByRole("button", {
+      name: "未スケジュールタスク",
+    });
+
+    // 開く
+    await user.click(toggleButton);
+
     await waitFor(() => {
       expect(screen.getByText("未スケジュールタスク")).toBeInTheDocument();
     });
 
-    // トグルボタンをクリックして閉じる
-    await user.click(screen.getByText("未スケジュール"));
+    // 閉じる
+    await user.click(toggleButton);
 
     await waitFor(() => {
       expect(
         screen.queryByText("未スケジュールタスク"),
       ).not.toBeInTheDocument();
-    });
-
-    // 再度クリックして開く
-    await user.click(screen.getByText("未スケジュール"));
-
-    await waitFor(() => {
-      expect(screen.getByText("未スケジュールタスク")).toBeInTheDocument();
     });
   });
 
@@ -632,8 +647,13 @@ describe("Calendar", () => {
     const user = userEvent.setup();
     renderWithQueryClient(<Calendar />);
 
+    // サイドバーを開く
+    await user.click(
+      screen.getByRole("button", { name: "未スケジュールタスク" }),
+    );
+
     await waitFor(() => {
-      expect(screen.getByText("未スケジュール")).toBeInTheDocument();
+      expect(screen.getByText("+ タスクを追加")).toBeInTheDocument();
     });
 
     await user.click(screen.getByText("+ タスクを追加"));

--- a/apps/web/src/components/Calendar.test.tsx
+++ b/apps/web/src/components/Calendar.test.tsx
@@ -551,28 +551,35 @@ describe("Calendar", () => {
     });
   });
 
-  it("トグルボタンで未スケジュールタスクサイドバーを表示できる", async () => {
+  it("トグルボタンで未スケジュールタスクサイドバーを開閉できる", async () => {
     mockFetchUnscheduledTasks.mockResolvedValue([mockUnscheduledTask]);
 
     const user = userEvent.setup();
     renderWithQueryClient(<Calendar />);
 
-    // 初期状態ではサイドバーは非表示
     await waitFor(() => {
-      expect(
-        screen.queryByText("未スケジュールタスク"),
-      ).not.toBeInTheDocument();
+      expect(screen.getByText("未スケジュールタスク")).toBeInTheDocument();
     });
 
-    // トグルボタンをクリックして表示
+    // 初期状態ではサイドバーは閉じている（width: 0px）
+    const sidebarWrapper = screen
+      .getByText("未スケジュール")
+      .closest("[style]") as HTMLElement;
+    expect(sidebarWrapper.style.width).toBe("0px");
+
+    // トグルボタンをクリックして開く
     await user.click(
       screen.getByRole("button", { name: "未スケジュールタスク" }),
     );
 
-    await waitFor(() => {
-      expect(screen.getByText("未スケジュール")).toBeInTheDocument();
-      expect(screen.getByText("未スケジュールタスク")).toBeInTheDocument();
-    });
+    expect(sidebarWrapper.style.width).toBe("16rem");
+
+    // 再度クリックして閉じる
+    await user.click(
+      screen.getByRole("button", { name: "未スケジュールタスク" }),
+    );
+
+    expect(sidebarWrapper.style.width).toBe("0px");
   });
 
   it("未スケジュールタスクがある場合、トグルボタンに件数バッジが表示される", async () => {
@@ -588,33 +595,6 @@ describe("Calendar", () => {
       });
       const badge = toggleButton.querySelector(".rounded-full");
       expect(badge?.textContent).toBe("2");
-    });
-  });
-
-  it("サイドバーのトグルで開閉できる", async () => {
-    mockFetchUnscheduledTasks.mockResolvedValue([mockUnscheduledTask]);
-
-    const user = userEvent.setup();
-    renderWithQueryClient(<Calendar />);
-
-    const toggleButton = screen.getByRole("button", {
-      name: "未スケジュールタスク",
-    });
-
-    // 開く
-    await user.click(toggleButton);
-
-    await waitFor(() => {
-      expect(screen.getByText("未スケジュールタスク")).toBeInTheDocument();
-    });
-
-    // 閉じる
-    await user.click(toggleButton);
-
-    await waitFor(() => {
-      expect(
-        screen.queryByText("未スケジュールタスク"),
-      ).not.toBeInTheDocument();
     });
   });
 

--- a/apps/web/src/components/Calendar.test.tsx
+++ b/apps/web/src/components/Calendar.test.tsx
@@ -6,12 +6,15 @@ import { renderWithQueryClient } from "../test/helpers";
 
 // API モック
 const mockFetchTasks = vi.fn();
+const mockFetchUnscheduledTasks = vi.fn();
 const mockCreateTask = vi.fn();
 const mockUpdateTask = vi.fn();
 const mockDeleteTask = vi.fn();
 
 vi.mock("../api/tasks", () => ({
   fetchTasks: (...args: unknown[]) => mockFetchTasks(...args) as unknown,
+  fetchUnscheduledTasks: (...args: unknown[]) =>
+    mockFetchUnscheduledTasks(...args) as unknown,
   createTask: (...args: unknown[]) => mockCreateTask(...args) as unknown,
   updateTask: (...args: unknown[]) => mockUpdateTask(...args) as unknown,
   deleteTask: (...args: unknown[]) => mockDeleteTask(...args) as unknown,
@@ -76,10 +79,23 @@ const mockTask = {
   updatedAt: "2026-01-01T00:00:00.000Z",
 };
 
+const mockUnscheduledTask = {
+  id: "unscheduled-task-1",
+  title: "未スケジュールタスク",
+  description: null,
+  date: null,
+  status: "todo" as const,
+  userId: "user-1",
+  categoryId: null,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+};
+
 describe("Calendar", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockFetchTasks.mockResolvedValue([]);
+    mockFetchUnscheduledTasks.mockResolvedValue([]);
   });
 
   it("年月ヘッダーと曜日ラベルが表示される", async () => {
@@ -204,7 +220,7 @@ describe("Calendar", () => {
     );
 
     // モーダルが表示される
-    expect(screen.getByText(/タスクを追加/)).toBeInTheDocument();
+    expect(screen.getByText(/タスクを追加（/)).toBeInTheDocument();
 
     // タイトルを入力して送信
     const titleInput = screen.getByLabelText(/タイトル/);
@@ -290,12 +306,12 @@ describe("Calendar", () => {
     await user.click(
       screen.getByRole("button", { name: `${dateKey}にタスクを追加` }),
     );
-    expect(screen.getByText(/タスクを追加/)).toBeInTheDocument();
+    expect(screen.getByText(/タスクを追加（/)).toBeInTheDocument();
 
     await user.click(screen.getByText("キャンセル"));
 
     await waitFor(() => {
-      expect(screen.queryByText(/タスクを追加/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/タスクを追加（/)).not.toBeInTheDocument();
     });
   });
 
@@ -532,6 +548,100 @@ describe("Calendar", () => {
       expect(mockUpdateTask).toHaveBeenCalledWith(mockTask.id, {
         status: "done",
       });
+    });
+  });
+
+  it("未スケジュールタスクサイドバーが表示される", async () => {
+    mockFetchUnscheduledTasks.mockResolvedValue([mockUnscheduledTask]);
+    renderWithQueryClient(<Calendar />);
+
+    await waitFor(() => {
+      expect(screen.getByText("未スケジュール")).toBeInTheDocument();
+      expect(screen.getByText("未スケジュールタスク")).toBeInTheDocument();
+    });
+  });
+
+  it("未スケジュールタスクの件数バッジが表示される", async () => {
+    mockFetchUnscheduledTasks.mockResolvedValue([
+      mockUnscheduledTask,
+      { ...mockUnscheduledTask, id: "unscheduled-task-2", title: "タスク2" },
+    ]);
+    renderWithQueryClient(<Calendar />);
+
+    await waitFor(() => {
+      const toggle = screen.getByText("未スケジュール");
+      const wrapper = toggle.closest("span");
+      const badge = wrapper?.querySelector(".rounded-full");
+      expect(badge?.textContent).toBe("2");
+    });
+  });
+
+  it("サイドバーのトグルで開閉できる", async () => {
+    mockFetchUnscheduledTasks.mockResolvedValue([mockUnscheduledTask]);
+
+    const user = userEvent.setup();
+    renderWithQueryClient(<Calendar />);
+
+    await waitFor(() => {
+      expect(screen.getByText("未スケジュールタスク")).toBeInTheDocument();
+    });
+
+    // トグルボタンをクリックして閉じる
+    await user.click(screen.getByText("未スケジュール"));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText("未スケジュールタスク"),
+      ).not.toBeInTheDocument();
+    });
+
+    // 再度クリックして開く
+    await user.click(screen.getByText("未スケジュール"));
+
+    await waitFor(() => {
+      expect(screen.getByText("未スケジュールタスク")).toBeInTheDocument();
+    });
+  });
+
+  it("カレンダー上のタスクをサイドバーにドロップして未スケジュールに戻せる", async () => {
+    mockFetchTasks.mockResolvedValue([mockTask]);
+    mockUpdateTask.mockResolvedValue({ ...mockTask, date: null });
+
+    renderWithQueryClient(<Calendar />);
+
+    await waitFor(() => {
+      expect(screen.getByText("テストタスク")).toBeInTheDocument();
+    });
+
+    capturedOnDragEnd!({
+      active: { id: mockTask.id, data: { current: { task: mockTask } } },
+      over: { id: "unscheduled" },
+    });
+
+    await waitFor(() => {
+      expect(mockUpdateTask).toHaveBeenCalledWith(mockTask.id, {
+        date: null,
+      });
+    });
+  });
+
+  it("サイドバーの「+タスクを追加」から未スケジュールタスクを作成できる", async () => {
+    mockFetchUnscheduledTasks.mockResolvedValue([]);
+    mockCreateTask.mockResolvedValue(mockUnscheduledTask);
+
+    const user = userEvent.setup();
+    renderWithQueryClient(<Calendar />);
+
+    await waitFor(() => {
+      expect(screen.getByText("未スケジュール")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText("+ タスクを追加"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("未スケジュールタスクを追加"),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/apps/web/src/components/Calendar.tsx
+++ b/apps/web/src/components/Calendar.tsx
@@ -12,12 +12,20 @@ import {
 import type { Task } from "../types/task";
 import type { Category } from "../types/category";
 import { useCategories } from "../hooks/useCategories";
-import { useTasks, useUpdateTask } from "../hooks/useTasks";
+import {
+  useTasks,
+  useUnscheduledTasks,
+  useUpdateTask,
+} from "../hooks/useTasks";
 import { CATEGORY_COLORS } from "../constants/categoryColors";
 import { getCalendarDays, formatDateKey } from "../utils/calendar";
 import { CalendarDayCell } from "./CalendarDayCell";
 import { TaskFormModal } from "./TaskFormModal";
 import { TaskDetailModal } from "./TaskDetailModal";
+import {
+  UnscheduledTasksSidebar,
+  UNSCHEDULED_DROPPABLE_ID,
+} from "./UnscheduledTasksSidebar";
 
 const WEEKDAY_LABELS = ["月", "火", "水", "木", "金", "土", "日"];
 
@@ -55,6 +63,7 @@ export function Calendar() {
 
   // モーダル状態
   const [addDate, setAddDate] = useState<string | null>(null);
+  const [addUnscheduled, setAddUnscheduled] = useState(false);
   const [selectedTask, setSelectedTask] = useState<Task | null>(null);
   const [expandedDate, setExpandedDate] = useState<string | null>(null);
 
@@ -63,6 +72,9 @@ export function Calendar() {
     isLoading,
     error: queryError,
   } = useTasks(year, month);
+
+  const { data: unscheduledTasks = [], error: unscheduledError } =
+    useUnscheduledTasks();
 
   const { data: categories = [] } = useCategories();
   const updateTaskMutation = useUpdateTask(year, month);
@@ -82,10 +94,10 @@ export function Calendar() {
   const tasksByDate = useMemo(() => {
     const map = new Map<string, Task[]>();
     for (const task of tasks) {
-      const key = task.date;
-      const list = map.get(key) ?? [];
+      if (!task.date) continue;
+      const list = map.get(task.date) ?? [];
       list.push(task);
-      map.set(key, list);
+      map.set(task.date, list);
     }
     return map;
   }, [tasks]);
@@ -152,136 +164,161 @@ export function Calendar() {
     const task = active.data.current?.task as Task | undefined;
     if (!task) return;
 
-    const newDate = over.id as string;
-    if (task.date === newDate) return;
+    const targetId = over.id as string;
+
+    if (targetId === UNSCHEDULED_DROPPABLE_ID) {
+      if (task.date === null) return;
+      setMutationError(null);
+      updateTaskMutation.mutate(
+        { id: task.id, data: { date: null } },
+        {
+          onError: () => setMutationError("タスクの移動に失敗しました"),
+        },
+      );
+      return;
+    }
+
+    if (task.date === targetId) return;
 
     setMutationError(null);
     updateTaskMutation.mutate(
-      { id: task.id, data: { date: newDate } },
+      { id: task.id, data: { date: targetId } },
       {
         onError: () => setMutationError("タスクの移動に失敗しました"),
       },
     );
   };
 
-  const error = queryError ? "タスクの取得に失敗しました" : mutationError;
+  const error =
+    queryError || unscheduledError
+      ? "タスクの取得に失敗しました"
+      : mutationError;
 
   return (
-    <div className="mx-auto max-w-[1600px]">
-      <div className="mb-2 flex items-center justify-between">
-        <h2 className="text-xl font-bold text-on-surface">
-          {year}年{month}月
-        </h2>
-        <div className="flex items-center gap-2">
-          <button
-            type="button"
-            onClick={goToToday}
-            className="rounded-md border border-border bg-white px-2 py-1 text-xs text-on-surface-secondary hover:bg-surface-hover"
+    <DndContext
+      sensors={sensors}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+      onDragCancel={handleDragCancel}
+    >
+      <div className="mx-auto flex max-w-[1600px] gap-4">
+        <UnscheduledTasksSidebar
+          tasks={unscheduledTasks}
+          categoryMap={categoryMap}
+          onTaskClick={setSelectedTask}
+          onToggleStatus={handleToggleStatus}
+          onAddClick={() => setAddUnscheduled(true)}
+        />
+        <div className="min-w-0 flex-1">
+          <div className="mb-2 flex items-center justify-between">
+            <h2 className="text-xl font-bold text-on-surface">
+              {year}年{month}月
+            </h2>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={goToToday}
+                className="rounded-md border border-border bg-white px-2 py-1 text-xs text-on-surface-secondary hover:bg-surface-hover"
+              >
+                今日
+              </button>
+              <button
+                type="button"
+                onClick={goToPrevMonth}
+                className="rounded-md border border-border bg-white px-2 py-1 text-xs text-on-surface-secondary hover:bg-surface-hover"
+              >
+                ←
+              </button>
+              <button
+                type="button"
+                onClick={goToNextMonth}
+                className="rounded-md border border-border bg-white px-2 py-1 text-xs text-on-surface-secondary hover:bg-surface-hover"
+              >
+                →
+              </button>
+            </div>
+          </div>
+
+          {error && (
+            <div className="mb-4 rounded-md bg-danger-light px-4 py-3 text-sm text-danger">
+              {error}
+            </div>
+          )}
+
+          <div
+            className={`overflow-hidden rounded-lg border border-border-light ${isLoading ? "opacity-50" : ""}`}
           >
-            今日
-          </button>
-          <button
-            type="button"
-            onClick={goToPrevMonth}
-            className="rounded-md border border-border bg-white px-2 py-1 text-xs text-on-surface-secondary hover:bg-surface-hover"
-          >
-            ←
-          </button>
-          <button
-            type="button"
-            onClick={goToNextMonth}
-            className="rounded-md border border-border bg-white px-2 py-1 text-xs text-on-surface-secondary hover:bg-surface-hover"
-          >
-            →
-          </button>
+            <div className="grid grid-cols-7">
+              {WEEKDAY_LABELS.map((label, i) => (
+                <div
+                  key={label}
+                  className={`border-b border-border-light py-1 text-center text-sm font-medium ${
+                    i === 5
+                      ? "text-primary"
+                      : i === 6
+                        ? "text-danger"
+                        : "text-on-surface-secondary"
+                  }`}
+                >
+                  {label}
+                </div>
+              ))}
+            </div>
+
+            <div className="grid grid-cols-7">
+              {days.map((day) => {
+                const key = formatDateKey(day.date);
+                return (
+                  <CalendarDayCell
+                    key={key}
+                    date={day.date}
+                    isCurrentMonth={day.isCurrentMonth}
+                    tasks={tasksByDate.get(key) ?? []}
+                    categoryMap={categoryMap}
+                    isExpanded={expandedDate === key}
+                    onAddClick={setAddDate}
+                    onTaskClick={setSelectedTask}
+                    onToggleStatus={handleToggleStatus}
+                    onShowMore={setExpandedDate}
+                    onCollapse={() => setExpandedDate(null)}
+                  />
+                );
+              })}
+            </div>
+          </div>
         </div>
       </div>
-
-      {error && (
-        <div className="mb-4 rounded-md bg-danger-light px-4 py-3 text-sm text-danger">
-          {error}
-        </div>
-      )}
-
-      <DndContext
-        sensors={sensors}
-        onDragStart={handleDragStart}
-        onDragEnd={handleDragEnd}
-        onDragCancel={handleDragCancel}
-      >
-        <div
-          className={`overflow-hidden rounded-lg border border-border-light ${isLoading ? "opacity-50" : ""}`}
-        >
-          <div className="grid grid-cols-7">
-            {WEEKDAY_LABELS.map((label, i) => (
+      <DragOverlay dropAnimation={dropAnimationConfig}>
+        {activeTask &&
+          (() => {
+            const cat = activeTask.categoryId
+              ? categoryMap.get(activeTask.categoryId)
+              : null;
+            const bgColor = cat ? CATEGORY_COLORS[cat.color].bg : undefined;
+            return (
               <div
-                key={label}
-                className={`border-b border-border-light py-1 text-center text-sm font-medium ${
-                  i === 5
-                    ? "text-primary"
-                    : i === 6
-                      ? "text-danger"
-                      : "text-on-surface-secondary"
+                className={`flex items-center gap-1 rounded px-1 py-0.5 text-sm shadow-lg scale-105 ${
+                  activeTask.status === "done"
+                    ? bgColor
+                      ? "text-on-surface/60 line-through"
+                      : "bg-white text-on-surface-muted line-through"
+                    : bgColor
+                      ? "text-on-surface"
+                      : "bg-white text-on-surface"
                 }`}
+                style={bgColor ? { backgroundColor: bgColor } : undefined}
               >
-                {label}
-              </div>
-            ))}
-          </div>
-
-          <div className="grid grid-cols-7">
-            {days.map((day) => {
-              const key = formatDateKey(day.date);
-              return (
-                <CalendarDayCell
-                  key={key}
-                  date={day.date}
-                  isCurrentMonth={day.isCurrentMonth}
-                  tasks={tasksByDate.get(key) ?? []}
-                  categoryMap={categoryMap}
-                  isExpanded={expandedDate === key}
-                  onAddClick={setAddDate}
-                  onTaskClick={setSelectedTask}
-                  onToggleStatus={handleToggleStatus}
-                  onShowMore={setExpandedDate}
-                  onCollapse={() => setExpandedDate(null)}
+                <input
+                  type="checkbox"
+                  checked={activeTask.status === "done"}
+                  readOnly
+                  className="h-3.5 w-3.5 shrink-0"
                 />
-              );
-            })}
-          </div>
-        </div>
-        <DragOverlay dropAnimation={dropAnimationConfig}>
-          {activeTask &&
-            (() => {
-              const cat = activeTask.categoryId
-                ? categoryMap.get(activeTask.categoryId)
-                : null;
-              const bgColor = cat ? CATEGORY_COLORS[cat.color].bg : undefined;
-              return (
-                <div
-                  className={`flex items-center gap-1 rounded px-1 py-0.5 text-sm shadow-lg scale-105 ${
-                    activeTask.status === "done"
-                      ? bgColor
-                        ? "text-on-surface/60 line-through"
-                        : "bg-white text-on-surface-muted line-through"
-                      : bgColor
-                        ? "text-on-surface"
-                        : "bg-white text-on-surface"
-                  }`}
-                  style={bgColor ? { backgroundColor: bgColor } : undefined}
-                >
-                  <input
-                    type="checkbox"
-                    checked={activeTask.status === "done"}
-                    readOnly
-                    className="h-3.5 w-3.5 shrink-0"
-                  />
-                  <span className="break-all">{activeTask.title}</span>
-                </div>
-              );
-            })()}
-        </DragOverlay>
-      </DndContext>
+                <span className="break-all">{activeTask.title}</span>
+              </div>
+            );
+          })()}
+      </DragOverlay>
 
       {addDate && (
         <TaskFormModal
@@ -292,6 +329,19 @@ export function Calendar() {
           onClose={() => setAddDate(null)}
           onCreated={() => {
             setAddDate(null);
+          }}
+        />
+      )}
+
+      {addUnscheduled && (
+        <TaskFormModal
+          open
+          date={null}
+          year={year}
+          month={month}
+          onClose={() => setAddUnscheduled(false)}
+          onCreated={() => {
+            setAddUnscheduled(false);
           }}
         />
       )}
@@ -308,6 +358,6 @@ export function Calendar() {
           }}
         />
       )}
-    </div>
+    </DndContext>
   );
 }

--- a/apps/web/src/components/Calendar.tsx
+++ b/apps/web/src/components/Calendar.tsx
@@ -266,7 +266,7 @@ export function Calendar() {
           </div>
         )}
 
-        <div className="flex gap-4">
+        <div className="flex items-stretch gap-4">
           <UnscheduledTasksSidebar
             tasks={unscheduledTasks}
             categoryMap={categoryMap}

--- a/apps/web/src/components/Calendar.tsx
+++ b/apps/web/src/components/Calendar.tsx
@@ -61,6 +61,9 @@ export function Calendar() {
   // ドラッグ状態
   const [activeTask, setActiveTask] = useState<Task | null>(null);
 
+  // サイドバー状態
+  const [showSidebar, setShowSidebar] = useState(false);
+
   // モーダル状態
   const [addDate, setAddDate] = useState<string | null>(null);
   const [addUnscheduled, setAddUnscheduled] = useState(false);
@@ -201,52 +204,80 @@ export function Calendar() {
       onDragEnd={handleDragEnd}
       onDragCancel={handleDragCancel}
     >
-      <div className="mx-auto flex max-w-[1600px] gap-4">
-        <UnscheduledTasksSidebar
-          tasks={unscheduledTasks}
-          categoryMap={categoryMap}
-          onTaskClick={setSelectedTask}
-          onToggleStatus={handleToggleStatus}
-          onAddClick={() => setAddUnscheduled(true)}
-        />
-        <div className="min-w-0 flex-1">
-          <div className="mb-2 flex items-center justify-between">
+      <div className="mx-auto max-w-[1600px]">
+        <div className="mb-2 flex items-center justify-between">
+          <div className="flex items-center gap-3">
             <h2 className="text-xl font-bold text-on-surface">
               {year}年{month}月
             </h2>
-            <div className="flex items-center gap-2">
-              <button
-                type="button"
-                onClick={goToToday}
-                className="rounded-md border border-border bg-white px-2 py-1 text-xs text-on-surface-secondary hover:bg-surface-hover"
+            <button
+              type="button"
+              onClick={() => setShowSidebar(!showSidebar)}
+              className="relative rounded-md border border-border bg-white p-1.5 text-on-surface-secondary hover:bg-surface-hover"
+              aria-label="未スケジュールタスク"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+                className="h-4 w-4"
               >
-                今日
-              </button>
-              <button
-                type="button"
-                onClick={goToPrevMonth}
-                className="rounded-md border border-border bg-white px-2 py-1 text-xs text-on-surface-secondary hover:bg-surface-hover"
-              >
-                ←
-              </button>
-              <button
-                type="button"
-                onClick={goToNextMonth}
-                className="rounded-md border border-border bg-white px-2 py-1 text-xs text-on-surface-secondary hover:bg-surface-hover"
-              >
-                →
-              </button>
-            </div>
+                <path
+                  fillRule="evenodd"
+                  d="M6 4.75A.75.75 0 0 1 6.75 4h10.5a.75.75 0 0 1 0 1.5H6.75A.75.75 0 0 1 6 4.75ZM6 10a.75.75 0 0 1 .75-.75h10.5a.75.75 0 0 1 0 1.5H6.75A.75.75 0 0 1 6 10Zm0 5.25a.75.75 0 0 1 .75-.75h10.5a.75.75 0 0 1 0 1.5H6.75a.75.75 0 0 1-.75-.75ZM1.99 4.75a1 1 0 0 1 1-1H3a1 1 0 0 1 1 1v.01a1 1 0 0 1-1 1h-.01a1 1 0 0 1-1-1v-.01ZM1.99 15.25a1 1 0 0 1 1-1H3a1 1 0 0 1 1 1v.01a1 1 0 0 1-1 1h-.01a1 1 0 0 1-1-1v-.01ZM1.99 10a1 1 0 0 1 1-1H3a1 1 0 0 1 1 1v.01a1 1 0 0 1-1 1h-.01a1 1 0 0 1-1-1V10Z"
+                  clipRule="evenodd"
+                />
+              </svg>
+              {unscheduledTasks.length > 0 && (
+                <span className="absolute -top-1.5 -right-1.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-bold text-white">
+                  {unscheduledTasks.length}
+                </span>
+              )}
+            </button>
           </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={goToToday}
+              className="rounded-md border border-border bg-white px-2 py-1 text-xs text-on-surface-secondary hover:bg-surface-hover"
+            >
+              今日
+            </button>
+            <button
+              type="button"
+              onClick={goToPrevMonth}
+              className="rounded-md border border-border bg-white px-2 py-1 text-xs text-on-surface-secondary hover:bg-surface-hover"
+            >
+              ←
+            </button>
+            <button
+              type="button"
+              onClick={goToNextMonth}
+              className="rounded-md border border-border bg-white px-2 py-1 text-xs text-on-surface-secondary hover:bg-surface-hover"
+            >
+              →
+            </button>
+          </div>
+        </div>
 
-          {error && (
-            <div className="mb-4 rounded-md bg-danger-light px-4 py-3 text-sm text-danger">
-              {error}
-            </div>
+        {error && (
+          <div className="mb-4 rounded-md bg-danger-light px-4 py-3 text-sm text-danger">
+            {error}
+          </div>
+        )}
+
+        <div className="flex gap-4">
+          {showSidebar && (
+            <UnscheduledTasksSidebar
+              tasks={unscheduledTasks}
+              categoryMap={categoryMap}
+              onTaskClick={setSelectedTask}
+              onToggleStatus={handleToggleStatus}
+              onAddClick={() => setAddUnscheduled(true)}
+            />
           )}
-
           <div
-            className={`overflow-hidden rounded-lg border border-border-light ${isLoading ? "opacity-50" : ""}`}
+            className={`min-w-0 flex-1 overflow-hidden rounded-lg border border-border-light ${isLoading ? "opacity-50" : ""}`}
           >
             <div className="grid grid-cols-7">
               {WEEKDAY_LABELS.map((label, i) => (

--- a/apps/web/src/components/Calendar.tsx
+++ b/apps/web/src/components/Calendar.tsx
@@ -207,9 +207,6 @@ export function Calendar() {
       <div className="mx-auto max-w-[1600px]">
         <div className="mb-2 flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <h2 className="text-xl font-bold text-on-surface">
-              {year}年{month}月
-            </h2>
             <button
               type="button"
               onClick={() => setShowSidebar(!showSidebar)}
@@ -234,6 +231,9 @@ export function Calendar() {
                 </span>
               )}
             </button>
+            <h2 className="text-xl font-bold text-on-surface">
+              {year}年{month}月
+            </h2>
           </div>
           <div className="flex items-center gap-2">
             <button

--- a/apps/web/src/components/Calendar.tsx
+++ b/apps/web/src/components/Calendar.tsx
@@ -267,15 +267,14 @@ export function Calendar() {
         )}
 
         <div className="flex gap-4">
-          {showSidebar && (
-            <UnscheduledTasksSidebar
-              tasks={unscheduledTasks}
-              categoryMap={categoryMap}
-              onTaskClick={setSelectedTask}
-              onToggleStatus={handleToggleStatus}
-              onAddClick={() => setAddUnscheduled(true)}
-            />
-          )}
+          <UnscheduledTasksSidebar
+            tasks={unscheduledTasks}
+            categoryMap={categoryMap}
+            isOpen={showSidebar}
+            onTaskClick={setSelectedTask}
+            onToggleStatus={handleToggleStatus}
+            onAddClick={() => setAddUnscheduled(true)}
+          />
           <div
             className={`min-w-0 flex-1 overflow-hidden rounded-lg border border-border-light ${isLoading ? "opacity-50" : ""}`}
           >

--- a/apps/web/src/components/TaskDetailModal.tsx
+++ b/apps/web/src/components/TaskDetailModal.tsx
@@ -23,7 +23,7 @@ export function TaskDetailModal({
 }: TaskDetailModalProps) {
   const [title, setTitle] = useState(task.title);
   const [description, setDescription] = useState(task.description ?? "");
-  const [date, setDate] = useState(task.date);
+  const [date, setDate] = useState(task.date ?? "");
   const [categoryId, setCategoryId] = useState<string>(task.categoryId ?? "");
   const [error, setError] = useState<string | null>(null);
 
@@ -52,7 +52,7 @@ export function TaskDetailModal({
         data: {
           title: title.trim(),
           description: description.trim() || null,
-          date,
+          date: date || null,
           categoryId: categoryId || null,
         },
       },
@@ -124,7 +124,6 @@ export function TaskDetailModal({
             value={date}
             onChange={(e) => setDate(e.target.value)}
             className="w-full rounded-md border border-border px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
-            required
           />
         </div>
         {categories.length > 0 && (

--- a/apps/web/src/components/TaskFormModal.tsx
+++ b/apps/web/src/components/TaskFormModal.tsx
@@ -5,7 +5,7 @@ import { ModalWrapper } from "./ModalWrapper";
 
 type TaskFormModalProps = {
   open: boolean;
-  date: string;
+  date: string | null;
   year: number;
   month: number;
   onClose: () => void;
@@ -37,7 +37,7 @@ export function TaskFormModal({
       {
         title: title.trim(),
         description: description.trim() || null,
-        date,
+        date: date ?? undefined,
         categoryId: categoryId || null,
       },
       {
@@ -49,7 +49,7 @@ export function TaskFormModal({
   return (
     <ModalWrapper open={open} onClose={onClose}>
       <h3 className="mb-4 text-lg font-bold text-on-surface">
-        タスクを追加（{date}）
+        {date ? `タスクを追加（${date}）` : "未スケジュールタスクを追加"}
       </h3>
       {error && (
         <div className="mb-3 rounded-md bg-danger-light px-3 py-2 text-sm text-danger">

--- a/apps/web/src/components/UnscheduledTasksSidebar.tsx
+++ b/apps/web/src/components/UnscheduledTasksSidebar.tsx
@@ -28,11 +28,11 @@ export function UnscheduledTasksSidebar({
 
   return (
     <div
-      className="shrink-0 overflow-hidden transition-[width] duration-300 ease-in-out"
+      className="shrink-0 self-stretch overflow-hidden transition-[width] duration-300 ease-in-out"
       style={{ width: isOpen ? "16rem" : "0px" }}
     >
       <div className="flex h-full w-64 flex-col overflow-hidden rounded-lg border border-border-light bg-white">
-        <div className="border-b border-border-light px-3 py-2 text-sm font-medium text-on-surface">
+        <div className="border-b border-border-light px-3 py-1 text-sm font-medium text-on-surface">
           未スケジュール
           <span className="ml-2 inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-on-surface-muted/20 px-1.5 text-xs font-medium text-on-surface-secondary">
             {tasks.length}

--- a/apps/web/src/components/UnscheduledTasksSidebar.tsx
+++ b/apps/web/src/components/UnscheduledTasksSidebar.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { useDroppable } from "@dnd-kit/core";
 import type { Task } from "../types/task";
 import type { Category } from "../types/category";
@@ -23,69 +22,48 @@ export function UnscheduledTasksSidebar({
   onToggleStatus,
   onAddClick,
 }: UnscheduledTasksSidebarProps) {
-  const [isOpen, setIsOpen] = useState(true);
   const { setNodeRef, isOver } = useDroppable({ id: DROPPABLE_ID });
 
   return (
-    <div className="flex h-full w-64 shrink-0 flex-col border-r border-border-light bg-white">
-      <button
-        type="button"
-        onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center justify-between border-b border-border-light px-3 py-2 text-sm font-medium text-on-surface hover:bg-surface-hover"
-      >
-        <span className="flex items-center gap-2">
-          未スケジュール
-          <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-on-surface-muted/20 px-1.5 text-xs font-medium text-on-surface-secondary">
-            {tasks.length}
-          </span>
+    <div className="flex w-64 shrink-0 flex-col overflow-hidden rounded-lg border border-border-light bg-white">
+      <div className="border-b border-border-light px-3 py-2 text-sm font-medium text-on-surface">
+        未スケジュール
+        <span className="ml-2 inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-on-surface-muted/20 px-1.5 text-xs font-medium text-on-surface-secondary">
+          {tasks.length}
         </span>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 20 20"
-          fill="currentColor"
-          className={`h-4 w-4 text-on-surface-muted transition-transform ${isOpen ? "rotate-180" : ""}`}
-        >
-          <path
-            fillRule="evenodd"
-            d="M5.22 8.22a.75.75 0 0 1 1.06 0L10 11.94l3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.22 9.28a.75.75 0 0 1 0-1.06Z"
-            clipRule="evenodd"
-          />
-        </svg>
-      </button>
-      {isOpen && (
-        <div
-          ref={setNodeRef}
-          className={`flex-1 overflow-y-auto p-2 ${isOver ? "bg-primary-lighter ring-2 ring-primary-muted ring-inset" : ""}`}
-        >
-          <div className="space-y-1">
-            {tasks.map((task) => (
-              <DraggableTask
-                key={task.id}
-                task={task}
-                category={
-                  task.categoryId
-                    ? (categoryMap.get(task.categoryId) ?? null)
-                    : null
-                }
-                onTaskClick={onTaskClick}
-                onToggleStatus={onToggleStatus}
-              />
-            ))}
-            {tasks.length === 0 && (
-              <p className="px-1 py-2 text-center text-xs text-on-surface-muted">
-                未スケジュールタスクはありません
-              </p>
-            )}
-          </div>
-          <button
-            type="button"
-            onClick={onAddClick}
-            className="mt-2 w-full rounded-md border border-dashed border-border px-2 py-1.5 text-xs text-on-surface-muted hover:border-primary hover:text-primary"
-          >
-            + タスクを追加
-          </button>
+      </div>
+      <div
+        ref={setNodeRef}
+        className={`flex-1 overflow-y-auto p-2 ${isOver ? "bg-primary-lighter ring-2 ring-primary-muted ring-inset" : ""}`}
+      >
+        <div className="space-y-1">
+          {tasks.map((task) => (
+            <DraggableTask
+              key={task.id}
+              task={task}
+              category={
+                task.categoryId
+                  ? (categoryMap.get(task.categoryId) ?? null)
+                  : null
+              }
+              onTaskClick={onTaskClick}
+              onToggleStatus={onToggleStatus}
+            />
+          ))}
+          {tasks.length === 0 && (
+            <p className="px-1 py-2 text-center text-xs text-on-surface-muted">
+              未スケジュールタスクはありません
+            </p>
+          )}
         </div>
-      )}
+        <button
+          type="button"
+          onClick={onAddClick}
+          className="mt-2 w-full rounded-md border border-dashed border-border px-2 py-1.5 text-xs text-on-surface-muted hover:border-primary hover:text-primary"
+        >
+          + タスクを追加
+        </button>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/UnscheduledTasksSidebar.tsx
+++ b/apps/web/src/components/UnscheduledTasksSidebar.tsx
@@ -1,0 +1,91 @@
+import { useState } from "react";
+import { useDroppable } from "@dnd-kit/core";
+import type { Task } from "../types/task";
+import type { Category } from "../types/category";
+import { DraggableTask } from "./DraggableTask";
+
+type UnscheduledTasksSidebarProps = {
+  tasks: Task[];
+  categoryMap: Map<string, Category>;
+  onTaskClick: (task: Task) => void;
+  onToggleStatus: (task: Task) => void;
+  onAddClick: () => void;
+};
+
+const DROPPABLE_ID = "unscheduled";
+
+export { DROPPABLE_ID as UNSCHEDULED_DROPPABLE_ID };
+
+export function UnscheduledTasksSidebar({
+  tasks,
+  categoryMap,
+  onTaskClick,
+  onToggleStatus,
+  onAddClick,
+}: UnscheduledTasksSidebarProps) {
+  const [isOpen, setIsOpen] = useState(true);
+  const { setNodeRef, isOver } = useDroppable({ id: DROPPABLE_ID });
+
+  return (
+    <div className="flex h-full w-64 shrink-0 flex-col border-r border-border-light bg-white">
+      <button
+        type="button"
+        onClick={() => setIsOpen(!isOpen)}
+        className="flex items-center justify-between border-b border-border-light px-3 py-2 text-sm font-medium text-on-surface hover:bg-surface-hover"
+      >
+        <span className="flex items-center gap-2">
+          未スケジュール
+          <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-on-surface-muted/20 px-1.5 text-xs font-medium text-on-surface-secondary">
+            {tasks.length}
+          </span>
+        </span>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+          className={`h-4 w-4 text-on-surface-muted transition-transform ${isOpen ? "rotate-180" : ""}`}
+        >
+          <path
+            fillRule="evenodd"
+            d="M5.22 8.22a.75.75 0 0 1 1.06 0L10 11.94l3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.22 9.28a.75.75 0 0 1 0-1.06Z"
+            clipRule="evenodd"
+          />
+        </svg>
+      </button>
+      {isOpen && (
+        <div
+          ref={setNodeRef}
+          className={`flex-1 overflow-y-auto p-2 ${isOver ? "bg-primary-lighter ring-2 ring-primary-muted ring-inset" : ""}`}
+        >
+          <div className="space-y-1">
+            {tasks.map((task) => (
+              <DraggableTask
+                key={task.id}
+                task={task}
+                category={
+                  task.categoryId
+                    ? (categoryMap.get(task.categoryId) ?? null)
+                    : null
+                }
+                onTaskClick={onTaskClick}
+                onToggleStatus={onToggleStatus}
+              />
+            ))}
+            {tasks.length === 0 && (
+              <p className="px-1 py-2 text-center text-xs text-on-surface-muted">
+                未スケジュールタスクはありません
+              </p>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={onAddClick}
+            className="mt-2 w-full rounded-md border border-dashed border-border px-2 py-1.5 text-xs text-on-surface-muted hover:border-primary hover:text-primary"
+          >
+            + タスクを追加
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/UnscheduledTasksSidebar.tsx
+++ b/apps/web/src/components/UnscheduledTasksSidebar.tsx
@@ -6,6 +6,7 @@ import { DraggableTask } from "./DraggableTask";
 type UnscheduledTasksSidebarProps = {
   tasks: Task[];
   categoryMap: Map<string, Category>;
+  isOpen: boolean;
   onTaskClick: (task: Task) => void;
   onToggleStatus: (task: Task) => void;
   onAddClick: () => void;
@@ -18,6 +19,7 @@ export { DROPPABLE_ID as UNSCHEDULED_DROPPABLE_ID };
 export function UnscheduledTasksSidebar({
   tasks,
   categoryMap,
+  isOpen,
   onTaskClick,
   onToggleStatus,
   onAddClick,
@@ -25,44 +27,49 @@ export function UnscheduledTasksSidebar({
   const { setNodeRef, isOver } = useDroppable({ id: DROPPABLE_ID });
 
   return (
-    <div className="flex w-64 shrink-0 flex-col overflow-hidden rounded-lg border border-border-light bg-white">
-      <div className="border-b border-border-light px-3 py-2 text-sm font-medium text-on-surface">
-        未スケジュール
-        <span className="ml-2 inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-on-surface-muted/20 px-1.5 text-xs font-medium text-on-surface-secondary">
-          {tasks.length}
-        </span>
-      </div>
-      <div
-        ref={setNodeRef}
-        className={`flex-1 overflow-y-auto p-2 ${isOver ? "bg-primary-lighter ring-2 ring-primary-muted ring-inset" : ""}`}
-      >
-        <div className="space-y-1">
-          {tasks.map((task) => (
-            <DraggableTask
-              key={task.id}
-              task={task}
-              category={
-                task.categoryId
-                  ? (categoryMap.get(task.categoryId) ?? null)
-                  : null
-              }
-              onTaskClick={onTaskClick}
-              onToggleStatus={onToggleStatus}
-            />
-          ))}
-          {tasks.length === 0 && (
-            <p className="px-1 py-2 text-center text-xs text-on-surface-muted">
-              未スケジュールタスクはありません
-            </p>
-          )}
+    <div
+      className="shrink-0 overflow-hidden transition-[width] duration-300 ease-in-out"
+      style={{ width: isOpen ? "16rem" : "0px" }}
+    >
+      <div className="flex h-full w-64 flex-col overflow-hidden rounded-lg border border-border-light bg-white">
+        <div className="border-b border-border-light px-3 py-2 text-sm font-medium text-on-surface">
+          未スケジュール
+          <span className="ml-2 inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-on-surface-muted/20 px-1.5 text-xs font-medium text-on-surface-secondary">
+            {tasks.length}
+          </span>
         </div>
-        <button
-          type="button"
-          onClick={onAddClick}
-          className="mt-2 w-full rounded-md border border-dashed border-border px-2 py-1.5 text-xs text-on-surface-muted hover:border-primary hover:text-primary"
+        <div
+          ref={setNodeRef}
+          className={`flex-1 overflow-y-auto p-2 ${isOver ? "bg-primary-lighter ring-2 ring-primary-muted ring-inset" : ""}`}
         >
-          + タスクを追加
-        </button>
+          <div className="space-y-1">
+            {tasks.map((task) => (
+              <DraggableTask
+                key={task.id}
+                task={task}
+                category={
+                  task.categoryId
+                    ? (categoryMap.get(task.categoryId) ?? null)
+                    : null
+                }
+                onTaskClick={onTaskClick}
+                onToggleStatus={onToggleStatus}
+              />
+            ))}
+            {tasks.length === 0 && (
+              <p className="px-1 py-2 text-center text-xs text-on-surface-muted">
+                未スケジュールタスクはありません
+              </p>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={onAddClick}
+            className="mt-2 w-full rounded-md border border-dashed border-border px-2 py-1.5 text-xs text-on-surface-muted hover:border-primary hover:text-primary"
+          >
+            + タスクを追加
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/hooks/useTasks.ts
+++ b/apps/web/src/hooks/useTasks.ts
@@ -1,16 +1,31 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import type { Task } from "../types/task";
-import { fetchTasks, createTask, updateTask, deleteTask } from "../api/tasks";
+import {
+  fetchTasks,
+  fetchUnscheduledTasks,
+  createTask,
+  updateTask,
+  deleteTask,
+} from "../api/tasks";
 
 function tasksQueryKey(year: number, month: number) {
   return ["tasks", year, month] as const;
 }
 
+const unscheduledTasksQueryKey = ["tasks", "unscheduled"] as const;
+
 export function useTasks(year: number, month: number) {
   return useQuery({
     queryKey: tasksQueryKey(year, month),
     queryFn: ({ signal }) => fetchTasks(year, month, signal),
+  });
+}
+
+export function useUnscheduledTasks() {
+  return useQuery({
+    queryKey: unscheduledTasksQueryKey,
+    queryFn: ({ signal }) => fetchUnscheduledTasks(signal),
   });
 }
 
@@ -22,21 +37,22 @@ export function useCreateTask(year: number, month: number) {
     mutationFn: (data: {
       title: string;
       description?: string | null;
-      date: string;
+      date?: string | null;
       status?: "todo" | "done";
       categoryId?: string | null;
     }) => createTask(data),
     onMutate: async (newTask) => {
-      await queryClient.cancelQueries({ queryKey: key });
-      const previous = queryClient.getQueryData<Task[]>(key);
+      const targetKey = newTask.date ? key : unscheduledTasksQueryKey;
+      await queryClient.cancelQueries({ queryKey: targetKey });
+      const previous = queryClient.getQueryData<Task[]>(targetKey);
 
-      queryClient.setQueryData<Task[]>(key, (old) => [
+      queryClient.setQueryData<Task[]>(targetKey, (old) => [
         ...(old ?? []),
         {
           id: `temp-${Date.now()}`,
           title: newTask.title,
           description: newTask.description ?? null,
-          date: newTask.date,
+          date: newTask.date ?? null,
           status: newTask.status ?? "todo",
           categoryId: newTask.categoryId ?? null,
           userId: "",
@@ -45,16 +61,19 @@ export function useCreateTask(year: number, month: number) {
         },
       ]);
 
-      return { previous };
+      return { previous, targetKey };
     },
     onError: (_err, _variables, context) => {
       if (context) {
-        queryClient.setQueryData(key, context.previous);
+        queryClient.setQueryData(context.targetKey, context.previous);
       }
       toast.error("タスクの作成に失敗しました");
     },
     onSettled: () => {
       void queryClient.invalidateQueries({ queryKey: key });
+      void queryClient.invalidateQueries({
+        queryKey: unscheduledTasksQueryKey,
+      });
     },
   });
 }
@@ -72,7 +91,7 @@ export function useUpdateTask(year: number, month: number) {
       data: {
         title?: string;
         description?: string | null;
-        date?: string;
+        date?: string | null;
         status?: "todo" | "done";
         categoryId?: string | null;
       };
@@ -97,6 +116,9 @@ export function useUpdateTask(year: number, month: number) {
     },
     onSettled: () => {
       void queryClient.invalidateQueries({ queryKey: key });
+      void queryClient.invalidateQueries({
+        queryKey: unscheduledTasksQueryKey,
+      });
     },
   });
 }
@@ -155,6 +177,9 @@ export function useDeleteTask(year: number, month: number) {
     },
     onSettled: () => {
       void queryClient.invalidateQueries({ queryKey: key });
+      void queryClient.invalidateQueries({
+        queryKey: unscheduledTasksQueryKey,
+      });
     },
   });
 }


### PR DESCRIPTION
close #189

## Summary

- DB: `tasks.date` カラムを nullable に変更し、マイグレーションを追加
- API: `POST /api/tasks` で `date` 省略可に、`PATCH` で `date: null` による未スケジュール化、`GET /api/tasks/unscheduled` エンドポイントを新設
- Web: カレンダー左に開閉可能な未スケジュールタスクサイドバーを配置。件数バッジ表示、dnd-kit による D&D でカレンダー ↔ サイドバー間のタスク移動が可能
- CLI: `add` コマンドの `--date` オプションを任意化。省略時は未スケジュールタスクとして作成

## Test plan

- [x] API: 未スケジュールタスクの作成・取得・date null 更新のテストを追加（全 82 テストパス）
- [x] Web: サイドバー表示、件数バッジ、トグル開閉、D&D によるサイドバーへのドロップのテストを追加（全 71 テストパス）
- [x] CLI: `--date` 省略時の未スケジュールタスク作成テストを追加（全 32 テストパス）
- [x] 既存テストに影響なし
- [x] lint / format / typecheck / knip 全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)