### PR TITLE
fix: トグルボタンのx座標をカレンダーと揃える

### DIFF
--- a/apps/web/src/components/Calendar.tsx
+++ b/apps/web/src/components/Calendar.tsx
@@ -211,6 +211,67 @@ export function Calendar() {
           </div>
         )}
 
+        <div className="mb-2 flex items-center gap-4">
+          <div
+            className="shrink-0 overflow-hidden transition-[width] duration-300 ease-in-out"
+            style={{ width: showSidebar ? "16rem" : "0px" }}
+          />
+          <div className="flex min-w-0 flex-1 items-center justify-between">
+            <div className="flex items-center gap-3">
+              <button
+                type="button"
+                onClick={() => setShowSidebar(!showSidebar)}
+                className="relative rounded-md border border-border bg-white p-1.5 text-on-surface-secondary hover:bg-surface-hover"
+                aria-label="未スケジュールタスク"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
+                  className="h-4 w-4"
+                >
+                  <path
+                    fillRule="evenodd"
+                    d="M6 4.75A.75.75 0 0 1 6.75 4h10.5a.75.75 0 0 1 0 1.5H6.75A.75.75 0 0 1 6 4.75ZM6 10a.75.75 0 0 1 .75-.75h10.5a.75.75 0 0 1 0 1.5H6.75A.75.75 0 0 1 6 10Zm0 5.25a.75.75 0 0 1 .75-.75h10.5a.75.75 0 0 1 0 1.5H6.75a.75.75 0 0 1-.75-.75ZM1.99 4.75a1 1 0 0 1 1-1H3a1 1 0 0 1 1 1v.01a1 1 0 0 1-1 1h-.01a1 1 0 0 1-1-1v-.01ZM1.99 15.25a1 1 0 0 1 1-1H3a1 1 0 0 1 1 1v.01a1 1 0 0 1-1 1h-.01a1 1 0 0 1-1-1v-.01ZM1.99 10a1 1 0 0 1 1-1H3a1 1 0 0 1 1 1v.01a1 1 0 0 1-1 1h-.01a1 1 0 0 1-1-1V10Z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+                {unscheduledTasks.length > 0 && (
+                  <span className="absolute -top-1.5 -right-1.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-bold text-white">
+                    {unscheduledTasks.length}
+                  </span>
+                )}
+              </button>
+              <h2 className="text-xl font-bold text-on-surface">
+                {year}年{month}月
+              </h2>
+            </div>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={goToToday}
+                className="rounded-md border border-border bg-white px-2 py-1 text-xs text-on-surface-secondary hover:bg-surface-hover"
+              >
+                今日
+              </button>
+              <button
+                type="button"
+                onClick={goToPrevMonth}
+                className="rounded-md border border-border bg-white px-2 py-1 text-xs text-on-surface-secondary hover:bg-surface-hover"
+              >
+                ←
+              </button>
+              <button
+                type="button"
+                onClick={goToNextMonth}
+                className="rounded-md border border-border bg-white px-2 py-1 text-xs text-on-surface-secondary hover:bg-surface-hover"
+              >
+                →
+              </button>
+            </div>
+          </div>
+        </div>
+
         <div className="flex items-stretch gap-4">
           <UnscheduledTasksSidebar
             tasks={unscheduledTasks}
@@ -220,101 +281,45 @@ export function Calendar() {
             onToggleStatus={handleToggleStatus}
             onAddClick={() => setAddUnscheduled(true)}
           />
-          <div className="min-w-0 flex-1">
-            <div className="mb-2 flex items-center justify-between">
-              <div className="flex items-center gap-3">
-                <button
-                  type="button"
-                  onClick={() => setShowSidebar(!showSidebar)}
-                  className="relative rounded-md border border-border bg-white p-1.5 text-on-surface-secondary hover:bg-surface-hover"
-                  aria-label="未スケジュールタスク"
+          <div
+            className={`min-w-0 flex-1 overflow-hidden rounded-lg border border-border-light ${isLoading ? "opacity-50" : ""}`}
+          >
+            <div className="grid grid-cols-7">
+              {WEEKDAY_LABELS.map((label, i) => (
+                <div
+                  key={label}
+                  className={`border-b border-border-light py-1 text-center text-sm font-medium ${
+                    i === 5
+                      ? "text-primary"
+                      : i === 6
+                        ? "text-danger"
+                        : "text-on-surface-secondary"
+                  }`}
                 >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 20 20"
-                    fill="currentColor"
-                    className="h-4 w-4"
-                  >
-                    <path
-                      fillRule="evenodd"
-                      d="M6 4.75A.75.75 0 0 1 6.75 4h10.5a.75.75 0 0 1 0 1.5H6.75A.75.75 0 0 1 6 4.75ZM6 10a.75.75 0 0 1 .75-.75h10.5a.75.75 0 0 1 0 1.5H6.75A.75.75 0 0 1 6 10Zm0 5.25a.75.75 0 0 1 .75-.75h10.5a.75.75 0 0 1 0 1.5H6.75a.75.75 0 0 1-.75-.75ZM1.99 4.75a1 1 0 0 1 1-1H3a1 1 0 0 1 1 1v.01a1 1 0 0 1-1 1h-.01a1 1 0 0 1-1-1v-.01ZM1.99 15.25a1 1 0 0 1 1-1H3a1 1 0 0 1 1 1v.01a1 1 0 0 1-1 1h-.01a1 1 0 0 1-1-1v-.01ZM1.99 10a1 1 0 0 1 1-1H3a1 1 0 0 1 1 1v.01a1 1 0 0 1-1 1h-.01a1 1 0 0 1-1-1V10Z"
-                      clipRule="evenodd"
-                    />
-                  </svg>
-                  {unscheduledTasks.length > 0 && (
-                    <span className="absolute -top-1.5 -right-1.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-bold text-white">
-                      {unscheduledTasks.length}
-                    </span>
-                  )}
-                </button>
-                <h2 className="text-xl font-bold text-on-surface">
-                  {year}年{month}月
-                </h2>
-              </div>
-              <div className="flex items-center gap-2">
-                <button
-                  type="button"
-                  onClick={goToToday}
-                  className="rounded-md border border-border bg-white px-2 py-1 text-xs text-on-surface-secondary hover:bg-surface-hover"
-                >
-                  今日
-                </button>
-                <button
-                  type="button"
-                  onClick={goToPrevMonth}
-                  className="rounded-md border border-border bg-white px-2 py-1 text-xs text-on-surface-secondary hover:bg-surface-hover"
-                >
-                  ←
-                </button>
-                <button
-                  type="button"
-                  onClick={goToNextMonth}
-                  className="rounded-md border border-border bg-white px-2 py-1 text-xs text-on-surface-secondary hover:bg-surface-hover"
-                >
-                  →
-                </button>
-              </div>
+                  {label}
+                </div>
+              ))}
             </div>
-            <div
-              className={`overflow-hidden rounded-lg border border-border-light ${isLoading ? "opacity-50" : ""}`}
-            >
-              <div className="grid grid-cols-7">
-                {WEEKDAY_LABELS.map((label, i) => (
-                  <div
-                    key={label}
-                    className={`border-b border-border-light py-1 text-center text-sm font-medium ${
-                      i === 5
-                        ? "text-primary"
-                        : i === 6
-                          ? "text-danger"
-                          : "text-on-surface-secondary"
-                    }`}
-                  >
-                    {label}
-                  </div>
-                ))}
-              </div>
 
-              <div className="grid grid-cols-7">
-                {days.map((day) => {
-                  const key = formatDateKey(day.date);
-                  return (
-                    <CalendarDayCell
-                      key={key}
-                      date={day.date}
-                      isCurrentMonth={day.isCurrentMonth}
-                      tasks={tasksByDate.get(key) ?? []}
-                      categoryMap={categoryMap}
-                      isExpanded={expandedDate === key}
-                      onAddClick={setAddDate}
-                      onTaskClick={setSelectedTask}
-                      onToggleStatus={handleToggleStatus}
-                      onShowMore={setExpandedDate}
-                      onCollapse={() => setExpandedDate(null)}
-                    />
-                  );
-                })}
-              </div>
+            <div className="grid grid-cols-7">
+              {days.map((day) => {
+                const key = formatDateKey(day.date);
+                return (
+                  <CalendarDayCell
+                    key={key}
+                    date={day.date}
+                    isCurrentMonth={day.isCurrentMonth}
+                    tasks={tasksByDate.get(key) ?? []}
+                    categoryMap={categoryMap}
+                    isExpanded={expandedDate === key}
+                    onAddClick={setAddDate}
+                    onTaskClick={setSelectedTask}
+                    onToggleStatus={handleToggleStatus}
+                    onShowMore={setExpandedDate}
+                    onCollapse={() => setExpandedDate(null)}
+                  />
+                );
+              })}
             </div>
           </div>
         </div>

--- a/apps/web/src/components/Calendar.tsx
+++ b/apps/web/src/components/Calendar.tsx
@@ -205,61 +205,6 @@ export function Calendar() {
       onDragCancel={handleDragCancel}
     >
       <div className="mx-auto max-w-[1600px]">
-        <div className="mb-2 flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <button
-              type="button"
-              onClick={() => setShowSidebar(!showSidebar)}
-              className="relative rounded-md border border-border bg-white p-1.5 text-on-surface-secondary hover:bg-surface-hover"
-              aria-label="未スケジュールタスク"
-            >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 20 20"
-                fill="currentColor"
-                className="h-4 w-4"
-              >
-                <path
-                  fillRule="evenodd"
-                  d="M6 4.75A.75.75 0 0 1 6.75 4h10.5a.75.75 0 0 1 0 1.5H6.75A.75.75 0 0 1 6 4.75ZM6 10a.75.75 0 0 1 .75-.75h10.5a.75.75 0 0 1 0 1.5H6.75A.75.75 0 0 1 6 10Zm0 5.25a.75.75 0 0 1 .75-.75h10.5a.75.75 0 0 1 0 1.5H6.75a.75.75 0 0 1-.75-.75ZM1.99 4.75a1 1 0 0 1 1-1H3a1 1 0 0 1 1 1v.01a1 1 0 0 1-1 1h-.01a1 1 0 0 1-1-1v-.01ZM1.99 15.25a1 1 0 0 1 1-1H3a1 1 0 0 1 1 1v.01a1 1 0 0 1-1 1h-.01a1 1 0 0 1-1-1v-.01ZM1.99 10a1 1 0 0 1 1-1H3a1 1 0 0 1 1 1v.01a1 1 0 0 1-1 1h-.01a1 1 0 0 1-1-1V10Z"
-                  clipRule="evenodd"
-                />
-              </svg>
-              {unscheduledTasks.length > 0 && (
-                <span className="absolute -top-1.5 -right-1.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-bold text-white">
-                  {unscheduledTasks.length}
-                </span>
-              )}
-            </button>
-            <h2 className="text-xl font-bold text-on-surface">
-              {year}年{month}月
-            </h2>
-          </div>
-          <div className="flex items-center gap-2">
-            <button
-              type="button"
-              onClick={goToToday}
-              className="rounded-md border border-border bg-white px-2 py-1 text-xs text-on-surface-secondary hover:bg-surface-hover"
-            >
-              今日
-            </button>
-            <button
-              type="button"
-              onClick={goToPrevMonth}
-              className="rounded-md border border-border bg-white px-2 py-1 text-xs text-on-surface-secondary hover:bg-surface-hover"
-            >
-              ←
-            </button>
-            <button
-              type="button"
-              onClick={goToNextMonth}
-              className="rounded-md border border-border bg-white px-2 py-1 text-xs text-on-surface-secondary hover:bg-surface-hover"
-            >
-              →
-            </button>
-          </div>
-        </div>
-
         {error && (
           <div className="mb-4 rounded-md bg-danger-light px-4 py-3 text-sm text-danger">
             {error}
@@ -275,45 +220,101 @@ export function Calendar() {
             onToggleStatus={handleToggleStatus}
             onAddClick={() => setAddUnscheduled(true)}
           />
-          <div
-            className={`min-w-0 flex-1 overflow-hidden rounded-lg border border-border-light ${isLoading ? "opacity-50" : ""}`}
-          >
-            <div className="grid grid-cols-7">
-              {WEEKDAY_LABELS.map((label, i) => (
-                <div
-                  key={label}
-                  className={`border-b border-border-light py-1 text-center text-sm font-medium ${
-                    i === 5
-                      ? "text-primary"
-                      : i === 6
-                        ? "text-danger"
-                        : "text-on-surface-secondary"
-                  }`}
+          <div className="min-w-0 flex-1">
+            <div className="mb-2 flex items-center justify-between">
+              <div className="flex items-center gap-3">
+                <button
+                  type="button"
+                  onClick={() => setShowSidebar(!showSidebar)}
+                  className="relative rounded-md border border-border bg-white p-1.5 text-on-surface-secondary hover:bg-surface-hover"
+                  aria-label="未スケジュールタスク"
                 >
-                  {label}
-                </div>
-              ))}
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 20 20"
+                    fill="currentColor"
+                    className="h-4 w-4"
+                  >
+                    <path
+                      fillRule="evenodd"
+                      d="M6 4.75A.75.75 0 0 1 6.75 4h10.5a.75.75 0 0 1 0 1.5H6.75A.75.75 0 0 1 6 4.75ZM6 10a.75.75 0 0 1 .75-.75h10.5a.75.75 0 0 1 0 1.5H6.75A.75.75 0 0 1 6 10Zm0 5.25a.75.75 0 0 1 .75-.75h10.5a.75.75 0 0 1 0 1.5H6.75a.75.75 0 0 1-.75-.75ZM1.99 4.75a1 1 0 0 1 1-1H3a1 1 0 0 1 1 1v.01a1 1 0 0 1-1 1h-.01a1 1 0 0 1-1-1v-.01ZM1.99 15.25a1 1 0 0 1 1-1H3a1 1 0 0 1 1 1v.01a1 1 0 0 1-1 1h-.01a1 1 0 0 1-1-1v-.01ZM1.99 10a1 1 0 0 1 1-1H3a1 1 0 0 1 1 1v.01a1 1 0 0 1-1 1h-.01a1 1 0 0 1-1-1V10Z"
+                      clipRule="evenodd"
+                    />
+                  </svg>
+                  {unscheduledTasks.length > 0 && (
+                    <span className="absolute -top-1.5 -right-1.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-bold text-white">
+                      {unscheduledTasks.length}
+                    </span>
+                  )}
+                </button>
+                <h2 className="text-xl font-bold text-on-surface">
+                  {year}年{month}月
+                </h2>
+              </div>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={goToToday}
+                  className="rounded-md border border-border bg-white px-2 py-1 text-xs text-on-surface-secondary hover:bg-surface-hover"
+                >
+                  今日
+                </button>
+                <button
+                  type="button"
+                  onClick={goToPrevMonth}
+                  className="rounded-md border border-border bg-white px-2 py-1 text-xs text-on-surface-secondary hover:bg-surface-hover"
+                >
+                  ←
+                </button>
+                <button
+                  type="button"
+                  onClick={goToNextMonth}
+                  className="rounded-md border border-border bg-white px-2 py-1 text-xs text-on-surface-secondary hover:bg-surface-hover"
+                >
+                  →
+                </button>
+              </div>
             </div>
+            <div
+              className={`overflow-hidden rounded-lg border border-border-light ${isLoading ? "opacity-50" : ""}`}
+            >
+              <div className="grid grid-cols-7">
+                {WEEKDAY_LABELS.map((label, i) => (
+                  <div
+                    key={label}
+                    className={`border-b border-border-light py-1 text-center text-sm font-medium ${
+                      i === 5
+                        ? "text-primary"
+                        : i === 6
+                          ? "text-danger"
+                          : "text-on-surface-secondary"
+                    }`}
+                  >
+                    {label}
+                  </div>
+                ))}
+              </div>
 
-            <div className="grid grid-cols-7">
-              {days.map((day) => {
-                const key = formatDateKey(day.date);
-                return (
-                  <CalendarDayCell
-                    key={key}
-                    date={day.date}
-                    isCurrentMonth={day.isCurrentMonth}
-                    tasks={tasksByDate.get(key) ?? []}
-                    categoryMap={categoryMap}
-                    isExpanded={expandedDate === key}
-                    onAddClick={setAddDate}
-                    onTaskClick={setSelectedTask}
-                    onToggleStatus={handleToggleStatus}
-                    onShowMore={setExpandedDate}
-                    onCollapse={() => setExpandedDate(null)}
-                  />
-                );
-              })}
+              <div className="grid grid-cols-7">
+                {days.map((day) => {
+                  const key = formatDateKey(day.date);
+                  return (
+                    <CalendarDayCell
+                      key={key}
+                      date={day.date}
+                      isCurrentMonth={day.isCurrentMonth}
+                      tasks={tasksByDate.get(key) ?? []}
+                      categoryMap={categoryMap}
+                      isExpanded={expandedDate === key}
+                      onAddClick={setAddDate}
+                      onTaskClick={setSelectedTask}
+                      onToggleStatus={handleToggleStatus}
+                      onShowMore={setExpandedDate}
+                      onCollapse={() => setExpandedDate(null)}
+                    />
+                  );
+                })}
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

- 未スケジュールタスクのトグルボタンがカレンダーグリッドより左にずれていた問題を修正
- ヘッダー（トグルボタン・年月表示・ナビゲーション）をサイドバーと並ぶflexレイアウトのカレンダー側カラムに移動し、トグルボタンの左端がカレンダーの左端と揃うようにした

## Test plan

- [x] TypeScript 型チェック通過
- [x] 既存テスト全件（70件）通過
- [x] ESLint / Prettier チェック通過
- [ ] サイドバー閉じた状態でトグルボタンがカレンダー左端と揃っていることを確認
- [ ] サイドバー開いた状態でもレイアウトが崩れないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)