### PR TITLE
fix: 未スケジュールトグルボタンとカレンダーの左端を揃える

### DIFF
--- a/apps/web/src/components/Calendar.tsx
+++ b/apps/web/src/components/Calendar.tsx
@@ -266,7 +266,7 @@ export function Calendar() {
           </div>
         </div>
 
-        <div className="flex items-stretch gap-4">
+        <div className={`flex items-stretch ${showSidebar ? "gap-4" : ""}`}>
           <UnscheduledTasksSidebar
             tasks={unscheduledTasks}
             categoryMap={categoryMap}


### PR DESCRIPTION
## Summary

- サイドバーが閉じているとき（width: 0）でも `gap-4`（16px）が残り、ヘッダーのトグルボタンとカレンダーの左端がずれていた問題を修正
- サイドバーの開閉に連動して gap を切り替えるよう変更

## Test plan

- [x] 既存テスト全70件パス
- [x] lint / format パス
- [x] サイドバー閉じ: トグルボタンとカレンダーの左端が揃うことをブラウザで確認
- [x] サイドバー開き: サイドバーとカレンダーの間に適切な gap があることをブラウザで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)