### PR TITLE
fix: カレンダーとフッター間の余白追加とフッター背景色を修正

### DIFF
--- a/apps/web/src/routes/app/index.tsx
+++ b/apps/web/src/routes/app/index.tsx
@@ -44,10 +44,10 @@ function HomePage() {
           </div>
         </div>
       </header>
-      <main className="p-4">
+      <main className="px-4 pt-4 pb-8">
         <Calendar />
       </main>
-      <footer className="border-t border-border-light px-4 py-6">
+      <footer className="border-t border-border-light bg-white px-4 py-6">
         <div className="mx-auto flex max-w-[1600px] flex-col items-center gap-2">
           <div className="flex gap-4 text-sm">
             <Link


### PR DESCRIPTION
## Summary
- カレンダー（`main`）の下パディングを `p-4` → `px-4 pt-4 pb-8` に変更し、フッターとの間に余白を追加
- フッターに `bg-white` を追加し、ヘッダーと背景色を統一

## Test plan
- [ ] `/app` ページでカレンダーとフッターの間に適切な余白があることを確認
- [ ] フッターの背景色が白になり、ヘッダーと統一されていることを確認
- [ ] LP（`/`）のフッターとデザインの統一感を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)