### PR TITLE
fix: Web フッターの著作権表記を LICENSE と統一する

### DIFF
--- a/apps/web/src/routes/app/index.tsx
+++ b/apps/web/src/routes/app/index.tsx
@@ -80,7 +80,7 @@ function HomePage() {
             </a>
           </div>
           <p className="text-sm text-on-surface-secondary">
-            &copy; 2026 tascal
+            &copy; 2026 Hiroki SAKABE
           </p>
         </div>
       </footer>

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -124,7 +124,7 @@ function LandingPage() {
             </a>
           </div>
           <p className="text-sm text-on-surface-secondary">
-            &copy; 2026 tascal
+            &copy; 2026 Hiroki SAKABE
           </p>
         </div>
       </footer>


### PR DESCRIPTION
close #210

## Summary
- ランディングページ (`index.tsx`) とアプリページ (`app/index.tsx`) のフッター著作権表記を `© 2026 tascal` から `© 2026 Hiroki SAKABE` に修正
- LICENSE ファイルの `Copyright (c) 2026-present Hiroki SAKABE` と表記を統一

## Test plan
- [x] lint / format / typecheck 通過
- [x] 全テスト通過 (API 41, Web 70, CLI 32)
- [x] Codex レビュー指摘なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)