### PR TITLE
fix: カレンダーを常に6行表示にして5週月の空行問題を修正

### DIFF
--- a/apps/web/src/components/Calendar.test.tsx
+++ b/apps/web/src/components/Calendar.test.tsx
@@ -190,6 +190,37 @@ describe("Calendar", () => {
     });
   });
 
+  it("5週で収まる月でも常に42セル（6行）描画される", async () => {
+    const user = userEvent.setup();
+    renderWithQueryClient(<Calendar />);
+
+    const now = new Date();
+    await waitFor(() => {
+      expect(
+        screen.getByText(`${now.getFullYear()}年${now.getMonth() + 1}月`),
+      ).toBeInTheDocument();
+    });
+
+    // 2027年2月（月曜始まり・28日 = 5週で収まる月）までナビゲーション
+    const target = new Date(2027, 1, 1);
+    const currentTotal = now.getFullYear() * 12 + (now.getMonth() + 1);
+    const targetTotal = target.getFullYear() * 12 + (target.getMonth() + 1);
+    const diff = targetTotal - currentTotal;
+    const button = diff > 0 ? "→" : "←";
+    for (let i = 0; i < Math.abs(diff); i++) {
+      await user.click(screen.getByText(button));
+    }
+
+    await waitFor(() => {
+      expect(screen.getByText("2027年2月")).toBeInTheDocument();
+    });
+
+    const dayCells = screen.getAllByRole("button", {
+      name: /にタスクを追加$/,
+    });
+    expect(dayCells).toHaveLength(42);
+  });
+
   it("タスク取得失敗時にエラーメッセージを表示する", async () => {
     mockFetchTasks.mockRejectedValue(new Error("API error"));
     renderWithQueryClient(<Calendar />);

--- a/apps/web/src/utils/calendar.test.ts
+++ b/apps/web/src/utils/calendar.test.ts
@@ -45,6 +45,17 @@ describe("getCalendarDays (月曜始まり)", () => {
     expect(days[6].isCurrentMonth).toBe(true);
   });
 
+  it("常に42セル（6行）を返す", () => {
+    // 5週で収まる月（2026年6月: 月曜始まり, 30日）
+    expect(getCalendarDays(2026, 6)).toHaveLength(42);
+
+    // 6週必要な月（2026年8月: 土曜始まり, 31日）
+    expect(getCalendarDays(2026, 8)).toHaveLength(42);
+
+    // パディングなし + 28日（2027年2月: 月曜始まり）
+    expect(getCalendarDays(2027, 2)).toHaveLength(42);
+  });
+
   it("各行が月〜日の順に並ぶ (2026年4月)", () => {
     const days = getCalendarDays(2026, 4);
 

--- a/apps/web/src/utils/calendar.ts
+++ b/apps/web/src/utils/calendar.ts
@@ -26,9 +26,8 @@ export function getCalendarDays(year: number, month: number): CalendarDay[] {
     });
   }
 
-  // 翌月のパディング (6行 = 42セルまで埋める)
-  const totalCells = days.length <= 35 ? 35 : 42;
-  const remaining = totalCells - days.length;
+  // 翌月のパディング (常に6行 = 42セルで統一)
+  const remaining = 42 - days.length;
   for (let i = 1; i <= remaining; i++) {
     days.push({
       date: new Date(year, month, i),


### PR DESCRIPTION
## Summary

- `getCalendarDays` が5週で収まる月に35セルしか返さず、カレンダーの高さが不揃いになり空の6行目のように見える問題を修正
- 常に42セル（6行）を返すように変更し、カレンダーの表示を統一
- ユニットテスト（常に42セル返却の検証）と結合テスト（5週月でも42セル描画の検証）を追加

## Test plan

- [x] `getCalendarDays` が5週月・6週月・28日月いずれでも42セルを返すユニットテスト追加
- [x] Calendar コンポーネントが5週月でも42セル描画する結合テスト追加
- [x] 既存テスト全通過確認（API 41, Web 72, CLI 32）
- [x] lint / format チェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)