### PR TITLE
fix: プロジェクトのサブ説明文を統一する

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 <div align="center">
 
-![tascal — カレンダービューでタスクを管理](apps/web/public/screenshot.png)
+![tascal — シンプルなカレンダー UI でタスクを俯瞰・整理できるタスク管理アプリ](apps/web/public/screenshot.png)
 
 </div>
 

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -6,7 +6,7 @@
     <title>tascal</title>
     <meta
       name="description"
-      content="tascal はシンプルなタスク管理アプリです。カレンダー上でタスクをドラッグ&ドロップして直感的にスケジュール管理できます。"
+      content="tascal — シンプルなカレンダー UI でタスクを俯瞰・整理できるタスク管理アプリ"
     />
     <meta name="theme-color" content="#4a4181" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
@@ -16,7 +16,7 @@
     <meta property="og:title" content="tascal" />
     <meta
       property="og:description"
-      content="tascal はシンプルなタスク管理アプリです。カレンダー上でタスクをドラッグ&ドロップして直感的にスケジュール管理できます。"
+      content="tascal — シンプルなカレンダー UI でタスクを俯瞰・整理できるタスク管理アプリ"
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://tascal.dev" />
@@ -29,7 +29,7 @@
     <meta name="twitter:title" content="tascal" />
     <meta
       name="twitter:description"
-      content="tascal はシンプルなタスク管理アプリです。カレンダー上でタスクをドラッグ&ドロップして直感的にスケジュール管理できます。"
+      content="tascal — シンプルなカレンダー UI でタスクを俯瞰・整理できるタスク管理アプリ"
     />
     <meta name="twitter:image" content="https://tascal.dev/ogp.png" />
   </head>

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -32,7 +32,7 @@ function LandingPage() {
           <h1 className="mb-4 text-4xl font-bold text-on-surface">
             タスク管理を、カレンダーから。
           </h1>
-          <p className="mx-auto mb-8 max-w-xl text-lg text-on-surface-secondary">
+          <p className="mx-auto mb-8 max-w-2xl text-lg text-on-surface-secondary">
             シンプルなカレンダー UI でタスクを俯瞰・整理できるタスク管理アプリ
           </p>
           <Link

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -33,7 +33,7 @@ function LandingPage() {
             タスク管理を、カレンダーから。
           </h1>
           <p className="mx-auto mb-8 max-w-xl text-lg text-on-surface-secondary">
-            カレンダービューでタスクを直感的に管理。ドラッグ&ドロップで手軽にスケジュールを調整できます。
+            シンプルなカレンダー UI でタスクを俯瞰・整理できるタスク管理アプリ
           </p>
           <Link
             to="/signup"


### PR DESCRIPTION
close #216

## Summary
- ランディングページ（`apps/web/src/routes/index.tsx`）の p タグの説明文を統一
- `apps/web/index.html` の meta description / OGP / Twitter Card の説明文を統一
- `README.md` の screenshot alt テキストを統一

すべて「シンプルなカレンダー UI でタスクを俯瞰・整理できるタスク管理アプリ」に揃えました。

## Test plan
- [x] lint / format チェック通過
- [x] Web テスト全件通過（72 tests）
- [ ] ランディングページの表示確認
- [ ] OGP デバッガーで meta description / OGP / Twitter Card の表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)