### PR TITLE
feat: タスク行全体のクリックで詳細モーダルを開けるようにする

### DIFF
--- a/apps/web/src/components/DraggableTask.test.tsx
+++ b/apps/web/src/components/DraggableTask.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { DraggableTask } from "./DraggableTask";
 import type { Task } from "../types/task";
 import type { Category } from "../types/category";
@@ -70,6 +71,44 @@ describe("DraggableTask", () => {
       backgroundColor: CATEGORY_COLORS.blue.bg,
     });
     expect(el).toHaveClass("line-through");
+  });
+
+  it("タスク行クリックで onTaskClick が呼ばれる", async () => {
+    const onTaskClick = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <DraggableTask
+        task={baseTask}
+        category={category}
+        onTaskClick={onTaskClick}
+        onToggleStatus={noop}
+      />,
+    );
+
+    const row = screen.getByText("テストタスク").closest("div[class]")!;
+    await user.click(row);
+
+    expect(onTaskClick).toHaveBeenCalledWith(baseTask);
+  });
+
+  it("チェックボックスクリックで onTaskClick は呼ばれない", async () => {
+    const onTaskClick = vi.fn();
+    const onToggleStatus = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <DraggableTask
+        task={baseTask}
+        category={category}
+        onTaskClick={onTaskClick}
+        onToggleStatus={onToggleStatus}
+      />,
+    );
+
+    const checkbox = screen.getByRole("checkbox");
+    await user.click(checkbox);
+
+    expect(onToggleStatus).toHaveBeenCalledWith(baseTask);
+    expect(onTaskClick).not.toHaveBeenCalled();
   });
 
   it("カテゴリ未設定の done タスクは白背景", () => {

--- a/apps/web/src/components/DraggableTask.tsx
+++ b/apps/web/src/components/DraggableTask.tsx
@@ -27,8 +27,11 @@ export function DraggableTask({
       ref={setNodeRef}
       {...listeners}
       {...attributes}
-      onClick={(e) => e.stopPropagation()}
-      className={`flex items-center gap-1 rounded px-1 py-0 text-xs leading-tight h-[2rem] touch-none ${isDragging ? "cursor-grabbing" : "cursor-grab"} ${
+      onClick={(e) => {
+        e.stopPropagation();
+        onTaskClick(task);
+      }}
+      className={`flex items-center gap-1 rounded px-1 py-0 text-xs leading-tight h-[2rem] touch-none ${isDragging ? "cursor-grabbing" : "cursor-pointer"} ${
         isDragging
           ? "border border-dashed border-border bg-surface text-transparent [&_input]:invisible"
           : task.status === "done"
@@ -51,12 +54,7 @@ export function DraggableTask({
         onPointerDown={(e) => e.stopPropagation()}
         className="h-3.5 w-3.5 shrink-0 cursor-pointer"
       />
-      <span
-        className="cursor-pointer break-all line-clamp-2"
-        onClick={() => onTaskClick(task)}
-      >
-        {task.title}
-      </span>
+      <span className="break-all line-clamp-2">{task.title}</span>
     </div>
   );
 }


### PR DESCRIPTION
close #219

## 概要

- DraggableTask コンポーネントで、チェックボックス以外のタスク行全体をクリックしたときに詳細モーダルが開くようにした
- `<span>` に付いていた `onClick` を外側の `<div>` に移動し、クリックターゲットを行全体に拡大
- チェックボックスは `e.stopPropagation()` により従来どおりステータス切り替えのまま
- ドラッグ操作は PointerSensor の距離閾値 5px で区別されるため干渉なし

## 変更内容

- `apps/web/src/components/DraggableTask.tsx`: `onTaskClick` を行全体の `onClick` に移動、カーソルを `cursor-pointer` に変更
- `apps/web/src/components/DraggableTask.test.tsx`: 行クリック・チェックボックスクリックの挙動テストを追加

## テスト計画

- [x] 既存テスト 74 件が全て通過
- [x] タスク行クリックで `onTaskClick` が呼ばれることを確認するテスト追加
- [x] チェックボックスクリックで `onTaskClick` が呼ばれないことを確認するテスト追加
- [ ] 手動確認: カレンダー上のタスク行クリックで詳細モーダルが開く
- [ ] 手動確認: チェックボックスクリックでステータス切り替えのみ
- [ ] 手動確認: ドラッグ操作が正常に動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)