### PR TITLE
feat: 認証系ボタンにローディング状態を追加

### DIFF
--- a/apps/web/src/routes/app/settings.tsx
+++ b/apps/web/src/routes/app/settings.tsx
@@ -40,6 +40,7 @@ function SettingsPage() {
   );
   const [showDeleteAccountModal, setShowDeleteAccountModal] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [isSigningOut, setIsSigningOut] = useState(false);
 
   const handleCreate = (data: { name: string; color: CategoryColor }) => {
     setError(null);
@@ -71,9 +72,15 @@ function SettingsPage() {
   };
 
   const handleSignOut = () => {
-    void authClient.signOut().then(() => {
-      window.location.href = "/login";
-    });
+    setIsSigningOut(true);
+    void authClient
+      .signOut()
+      .then(() => {
+        window.location.href = "/login";
+      })
+      .catch(() => {
+        setIsSigningOut(false);
+      });
   };
 
   return (
@@ -215,9 +222,10 @@ function SettingsPage() {
           <button
             type="button"
             onClick={handleSignOut}
-            className="rounded-md border border-border bg-white px-4 py-2 text-sm text-on-surface-secondary hover:bg-surface-hover"
+            disabled={isSigningOut}
+            className="rounded-md border border-border bg-white px-4 py-2 text-sm text-on-surface-secondary hover:bg-surface-hover disabled:opacity-50"
           >
-            ログアウト
+            {isSigningOut ? "ログアウト中..." : "ログアウト"}
           </button>
           <div>
             <button

--- a/apps/web/src/routes/login.test.tsx
+++ b/apps/web/src/routes/login.test.tsx
@@ -113,6 +113,31 @@ describe("LoginPage", () => {
     });
   });
 
+  it("API 呼び出し中はボタンが disabled になり「ログイン中...」と表示される", async () => {
+    let resolveSignIn!: (value: { error: null }) => void;
+    mockSignInEmail.mockReturnValue(
+      new Promise((resolve) => {
+        resolveSignIn = resolve;
+      }),
+    );
+    const user = userEvent.setup();
+    renderLoginPage();
+
+    await user.type(
+      screen.getByLabelText("メールアドレス"),
+      "test@example.com",
+    );
+    await user.type(screen.getByLabelText("パスワード"), "password123");
+    await user.click(screen.getByRole("button", { name: "ログイン" }));
+
+    await waitFor(() => {
+      const button = screen.getByRole("button", { name: "ログイン中..." });
+      expect(button).toBeDisabled();
+    });
+
+    resolveSignIn({ error: null });
+  });
+
   it("サインアップページへのナビゲーションリンクが動作する", async () => {
     const user = userEvent.setup();
     renderLoginPage();

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -18,10 +18,12 @@ function LoginPage() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
+  const [isPending, setIsPending] = useState(false);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     setError("");
+    setIsPending(true);
 
     void authClient.signIn
       .email({
@@ -31,9 +33,14 @@ function LoginPage() {
       .then(({ error }) => {
         if (error) {
           setError(error.message ?? "ログインに失敗しました");
+          setIsPending(false);
           return;
         }
         void navigate({ to: "/app" });
+      })
+      .catch(() => {
+        setError("ログインに失敗しました");
+        setIsPending(false);
       });
   };
 
@@ -83,9 +90,10 @@ function LoginPage() {
           )}
           <button
             type="submit"
-            className="w-full rounded-md bg-primary px-4 py-2 text-sm text-white hover:bg-primary-dark"
+            disabled={isPending}
+            className="w-full rounded-md bg-primary px-4 py-2 text-sm text-white hover:bg-primary-dark disabled:opacity-50"
           >
-            ログイン
+            {isPending ? "ログイン中..." : "ログイン"}
           </button>
         </form>
         <p className="mt-4 text-center text-sm text-on-surface-secondary">

--- a/apps/web/src/routes/settings.test.tsx
+++ b/apps/web/src/routes/settings.test.tsx
@@ -76,6 +76,26 @@ describe("SettingsPage アカウントセクション", () => {
     ).toBeInTheDocument();
   });
 
+  it("ログアウトボタンクリック中は disabled になり「ログアウト中...」と表示される", async () => {
+    let resolveSignOut!: (value: void) => void;
+    mockSignOut.mockReturnValue(
+      new Promise((resolve) => {
+        resolveSignOut = resolve;
+      }),
+    );
+    const user = userEvent.setup();
+    renderSettingsPage();
+
+    await user.click(screen.getByRole("button", { name: "ログアウト" }));
+
+    await waitFor(() => {
+      const button = screen.getByRole("button", { name: "ログアウト中..." });
+      expect(button).toBeDisabled();
+    });
+
+    resolveSignOut();
+  });
+
   it("アカウント削除ボタンが表示される", () => {
     renderSettingsPage();
 

--- a/apps/web/src/routes/signup.test.tsx
+++ b/apps/web/src/routes/signup.test.tsx
@@ -133,6 +133,32 @@ describe("SignupPage", () => {
     });
   });
 
+  it("API 呼び出し中はボタンが disabled になり「サインアップ中...」と表示される", async () => {
+    let resolveSignUp!: (value: { error: null }) => void;
+    mockSignUpEmail.mockReturnValue(
+      new Promise((resolve) => {
+        resolveSignUp = resolve;
+      }),
+    );
+    const user = userEvent.setup();
+    renderSignupPage();
+
+    await user.type(screen.getByLabelText("名前"), "テストユーザー");
+    await user.type(
+      screen.getByLabelText("メールアドレス"),
+      "test@example.com",
+    );
+    await user.type(screen.getByLabelText("パスワード"), "password123");
+    await user.click(screen.getByRole("button", { name: "サインアップ" }));
+
+    await waitFor(() => {
+      const button = screen.getByRole("button", { name: "サインアップ中..." });
+      expect(button).toBeDisabled();
+    });
+
+    resolveSignUp({ error: null });
+  });
+
   it("利用規約とプライバシーポリシーへのリンクが表示される", () => {
     renderSignupPage();
 

--- a/apps/web/src/routes/signup.tsx
+++ b/apps/web/src/routes/signup.tsx
@@ -24,10 +24,12 @@ function SignupPage() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
+  const [isPending, setIsPending] = useState(false);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     setError("");
+    setIsPending(true);
 
     void authClient.signUp
       .email({
@@ -38,9 +40,14 @@ function SignupPage() {
       .then(({ error }) => {
         if (error) {
           setError(error.message ?? "サインアップに失敗しました");
+          setIsPending(false);
           return;
         }
         void navigate({ to: "/app" });
+      })
+      .catch(() => {
+        setError("サインアップに失敗しました");
+        setIsPending(false);
       });
   };
 
@@ -123,9 +130,10 @@ function SignupPage() {
           </p>
           <button
             type="submit"
-            className="w-full rounded-md bg-primary px-4 py-2 text-sm text-white hover:bg-primary-dark"
+            disabled={isPending}
+            className="w-full rounded-md bg-primary px-4 py-2 text-sm text-white hover:bg-primary-dark disabled:opacity-50"
           >
-            サインアップ
+            {isPending ? "サインアップ中..." : "サインアップ"}
           </button>
         </form>
         <p className="mt-4 text-center text-sm text-on-surface-secondary">


### PR DESCRIPTION
close #220

## 概要
ログイン・サインアップ・ログアウトボタンに API 呼び出し中のローディング状態（disabled + テキスト変更）を追加し、連打による重複リクエストを防止する。

## 変更内容
- **ログインボタン**: API 呼び出し中に disabled + 「ログイン中...」表示
- **サインアップボタン**: API 呼び出し中に disabled + 「サインアップ中...」表示
- **ログアウトボタン**: API 呼び出し中に disabled + 「ログアウト中...」表示
- Promise reject 時のエラーハンドリングも追加し、ボタンが無効化されたまま残らないようにした
- 各ボタンのローディング状態テストを追加（3件）

## 対象ファイル
- `apps/web/src/routes/login.tsx`
- `apps/web/src/routes/signup.tsx`
- `apps/web/src/routes/app/settings.tsx`
- 対応するテストファイル

## テスト計画
- [x] ログインボタンが API 呼び出し中に disabled になり「ログイン中...」と表示される
- [x] サインアップボタンが API 呼び出し中に disabled になり「サインアップ中...」と表示される
- [x] ログアウトボタンが API 呼び出し中に disabled になり「ログアウト中...」と表示される
- [x] 既存テスト全通過（18件）

🤖 Generated with [Claude Code](https://claude.com/claude-code)