### PR TITLE
設定画面のカテゴリセクション見出しを簡潔にする

### DIFF
--- a/apps/web/src/routes/app/settings.tsx
+++ b/apps/web/src/routes/app/settings.tsx
@@ -115,7 +115,7 @@ function SettingsPage() {
       </header>
 
       <main className="mx-auto max-w-2xl p-4">
-        <h2 className="mb-4 text-xl font-bold text-on-surface">カテゴリ管理</h2>
+        <h2 className="mb-4 text-xl font-bold text-on-surface">カテゴリ</h2>
 
         {error && (
           <div className="mb-4 rounded-md bg-danger-light px-3 py-2 text-sm text-danger">


### PR DESCRIPTION
## Summary
- 設定画面の見出しを「カテゴリ管理」から「カテゴリ」に変更
- 設定画面内にある時点で「管理」は自明なため、冗長な表現を削除

## Test plan
- [ ] 設定画面（`/app/settings`）で見出しが「カテゴリ」と表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)