### PR TITLE
feat: EAS Build セットアップ

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -9,9 +9,11 @@
     "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
     "ios": {
-      "supportsTablet": true
+      "supportsTablet": true,
+      "bundleIdentifier": "com.hirokisakabe.tascal"
     },
     "android": {
+      "package": "com.hirokisakabe.tascal",
       "adaptiveIcon": {
         "backgroundColor": "#E6F4FE",
         "foregroundImage": "./assets/images/android-icon-foreground.png",

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -1,0 +1,25 @@
+{
+  "cli": {
+    "version": ">= 16.0.0"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal",
+      "ios": {
+        "simulator": true
+      }
+    },
+    "preview": {
+      "distribution": "internal",
+      "env": {
+        "EXPO_PUBLIC_API_URL": "https://tascal-api.example.com"
+      }
+    },
+    "production": {
+      "env": {
+        "EXPO_PUBLIC_API_URL": "https://tascal-api.example.com"
+      }
+    }
+  }
+}

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -13,12 +13,12 @@
     "preview": {
       "distribution": "internal",
       "env": {
-        "EXPO_PUBLIC_API_URL": "https://tascal-api.example.com"
+        "EXPO_PUBLIC_API_URL": "https://tascal-aphbwdv5ia-an.a.run.app"
       }
     },
     "production": {
       "env": {
-        "EXPO_PUBLIC_API_URL": "https://tascal-api.example.com"
+        "EXPO_PUBLIC_API_URL": "https://tascal-aphbwdv5ia-an.a.run.app"
       }
     }
   }


### PR DESCRIPTION
close #228

## Summary
- EAS Build の設定ファイル (`eas.json`) を追加し、development / preview / production の3プロファイルを構成
- `app.json` に iOS `bundleIdentifier` と Android `package` を追加
- preview / production プロファイルで本番 API URL を環境変数 `EXPO_PUBLIC_API_URL` で設定

## 各プロファイルの用途
| プロファイル | 用途 | 配布方法 |
|---|---|---|
| development | 開発ビルド (dev client) | シミュレータ |
| preview | テスト用ビルド | 内部配布 (ad-hoc) |
| production | App Store 提出用 | Store |

## 注意事項
- `eas.json` の `EXPO_PUBLIC_API_URL` はプレースホルダー (`https://tascal-api.example.com`) です。実際のデプロイ先 URL に変更してください
- EAS Build の実行には `eas-cli` のインストールと Expo アカウントへのログインが必要です
- iOS のビルドには Apple Developer Program への加入が前提です

## Test plan
- [ ] `eas build --profile development --platform ios` でシミュレータ向けビルドが成功すること
- [ ] `eas build --profile preview --platform ios` で内部配布用ビルドが成功すること
- [ ] ビルドした .ipa を実機にインストールして本番 API で動作確認できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)