### PR TITLE
feat: モバイルレスポンシブ対応 - カレンダー画面のモバイル UI 改善

### DIFF
--- a/apps/web/src/components/Calendar.test.tsx
+++ b/apps/web/src/components/Calendar.test.tsx
@@ -64,6 +64,7 @@ vi.mock("@dnd-kit/core", () => ({
     isOver: false,
   }),
   PointerSensor: class PointerSensor {},
+  TouchSensor: class TouchSensor {},
   useSensor: () => ({}),
   useSensors: () => [],
 }));

--- a/apps/web/src/components/Calendar.tsx
+++ b/apps/web/src/components/Calendar.tsx
@@ -3,6 +3,7 @@ import {
   DndContext,
   DragOverlay,
   PointerSensor,
+  TouchSensor,
   useSensor,
   useSensors,
   type DragEndEvent,
@@ -17,9 +18,11 @@ import {
   useUnscheduledTasks,
   useUpdateTask,
 } from "../hooks/useTasks";
+import { useMediaQuery } from "../hooks/useMediaQuery";
 import { CATEGORY_COLORS } from "../constants/categoryColors";
 import { getCalendarDays, formatDateKey } from "../utils/calendar";
 import { CalendarDayCell } from "./CalendarDayCell";
+import { MobileDayBottomSheet } from "./MobileDayBottomSheet";
 import { TaskFormModal } from "./TaskFormModal";
 import { TaskDetailModal } from "./TaskDetailModal";
 import {
@@ -52,9 +55,14 @@ export function Calendar() {
   const [year, setYear] = useState(now.getFullYear());
   const [month, setMonth] = useState(now.getMonth() + 1);
 
+  const isMobile = useMediaQuery("(max-width: 639px)");
+
   const sensors = useSensors(
     useSensor(PointerSensor, {
       activationConstraint: { distance: 5 },
+    }),
+    useSensor(TouchSensor, {
+      activationConstraint: { delay: 250, tolerance: 5 },
     }),
   );
 
@@ -69,6 +77,9 @@ export function Calendar() {
   const [addUnscheduled, setAddUnscheduled] = useState(false);
   const [selectedTask, setSelectedTask] = useState<Task | null>(null);
   const [expandedDate, setExpandedDate] = useState<string | null>(null);
+
+  // モバイル用ボトムシート状態
+  const [mobileSheetDate, setMobileSheetDate] = useState<string | null>(null);
 
   const {
     data: tasks = [],
@@ -271,6 +282,7 @@ export function Calendar() {
             tasks={unscheduledTasks}
             categoryMap={categoryMap}
             isOpen={showSidebar}
+            onClose={() => setShowSidebar(false)}
             onTaskClick={setSelectedTask}
             onToggleStatus={handleToggleStatus}
             onAddClick={() => setAddUnscheduled(true)}
@@ -306,7 +318,11 @@ export function Calendar() {
                     tasks={tasksByDate.get(key) ?? []}
                     categoryMap={categoryMap}
                     isExpanded={expandedDate === key}
-                    onAddClick={setAddDate}
+                    onAddClick={(dateKey) =>
+                      isMobile
+                        ? setMobileSheetDate(dateKey)
+                        : setAddDate(dateKey)
+                    }
                     onTaskClick={setSelectedTask}
                     onToggleStatus={handleToggleStatus}
                     onShowMore={setExpandedDate}
@@ -388,6 +404,23 @@ export function Calendar() {
           }}
         />
       )}
+
+      <MobileDayBottomSheet
+        date={mobileSheetDate}
+        tasks={mobileSheetDate ? (tasksByDate.get(mobileSheetDate) ?? []) : []}
+        categoryMap={categoryMap}
+        isOpen={mobileSheetDate !== null}
+        onClose={() => setMobileSheetDate(null)}
+        onTaskClick={(task) => {
+          setMobileSheetDate(null);
+          setSelectedTask(task);
+        }}
+        onToggleStatus={handleToggleStatus}
+        onAddClick={(date) => {
+          setMobileSheetDate(null);
+          setAddDate(date);
+        }}
+      />
     </DndContext>
   );
 }

--- a/apps/web/src/components/CalendarDayCell.tsx
+++ b/apps/web/src/components/CalendarDayCell.tsx
@@ -51,7 +51,7 @@ export function CalendarDayCell({
         }
       }}
       aria-label={`${dateKey}にタスクを追加`}
-      className={`group relative min-h-40 cursor-pointer border-[0.5px] border-border-light p-1.5 ${
+      className={`group relative min-h-20 cursor-pointer border-[0.5px] border-border-light p-1.5 sm:min-h-40 ${
         !isCurrentMonth ? "bg-surface" : "bg-white"
       } ${isOver ? "bg-primary-lighter ring-2 ring-primary-muted ring-inset" : isExpanded ? "" : ""}`}
     >
@@ -69,8 +69,13 @@ export function CalendarDayCell({
         >
           {date.getDate()}
         </span>
+        {tasks.length > 0 && (
+          <span className="ml-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-primary/70 px-1 text-[10px] font-bold text-white sm:hidden">
+            {tasks.length}
+          </span>
+        )}
       </div>
-      <div className="space-y-1">
+      <div className="hidden space-y-1 sm:block">
         {visibleTasks.map((task) => (
           <DraggableTask
             key={task.id}

--- a/apps/web/src/components/MobileDayBottomSheet.tsx
+++ b/apps/web/src/components/MobileDayBottomSheet.tsx
@@ -1,0 +1,127 @@
+import { useRef } from "react";
+import type { Task } from "../types/task";
+import type { Category } from "../types/category";
+import { CATEGORY_COLORS } from "../constants/categoryColors";
+
+type Props = {
+  date: string | null;
+  tasks: Task[];
+  categoryMap: Map<string, Category>;
+  isOpen: boolean;
+  onClose: () => void;
+  onTaskClick: (task: Task) => void;
+  onToggleStatus: (task: Task) => void;
+  onAddClick: (date: string) => void;
+};
+
+export function MobileDayBottomSheet({
+  date,
+  tasks,
+  categoryMap,
+  isOpen,
+  onClose,
+  onTaskClick,
+  onToggleStatus,
+  onAddClick,
+}: Props) {
+  const touchStartY = useRef(0);
+
+  const handleTouchStart = (e: React.TouchEvent) => {
+    touchStartY.current = e.touches[0].clientY;
+  };
+
+  const handleTouchMove = (e: React.TouchEvent) => {
+    const diff = e.touches[0].clientY - touchStartY.current;
+    if (diff > 80) {
+      onClose();
+    }
+  };
+
+  if (!date) return null;
+
+  const displayDate = new Date(`${date}T00:00:00`);
+  const monthDay = `${displayDate.getMonth() + 1}月${displayDate.getDate()}日`;
+
+  return (
+    <>
+      <div
+        className={`fixed inset-0 z-40 bg-black/30 transition-opacity duration-300 ${
+          isOpen ? "opacity-100" : "pointer-events-none opacity-0"
+        }`}
+        onClick={onClose}
+      />
+      <div
+        className={`fixed right-0 bottom-0 left-0 z-50 rounded-t-2xl bg-white shadow-xl transition-transform duration-300 ${
+          isOpen ? "translate-y-0" : "translate-y-full"
+        }`}
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+      >
+        <div className="flex justify-center pt-3 pb-1">
+          <div className="bg-border h-1 w-10 rounded-full" />
+        </div>
+        <div className="border-border-light flex items-center justify-between border-b px-4 py-2">
+          <h2 className="text-on-surface text-base font-semibold">
+            {monthDay}
+          </h2>
+          <button
+            type="button"
+            onClick={() => onAddClick(date)}
+            className="bg-primary flex items-center gap-1 rounded-md px-3 py-1.5 text-xs font-medium text-white"
+          >
+            + タスクを追加
+          </button>
+        </div>
+        <div className="max-h-[60vh] overflow-y-auto px-4 py-3">
+          {tasks.length === 0 ? (
+            <p className="text-on-surface-muted py-8 text-center text-sm">
+              この日のタスクはありません
+            </p>
+          ) : (
+            <div className="space-y-2">
+              {tasks.map((task) => {
+                const cat = task.categoryId
+                  ? (categoryMap.get(task.categoryId) ?? null)
+                  : null;
+                const bgColor = cat ? CATEGORY_COLORS[cat.color].bg : undefined;
+                return (
+                  <button
+                    key={task.id}
+                    type="button"
+                    onClick={() => onTaskClick(task)}
+                    className={`flex w-full items-center gap-3 rounded-lg p-3 text-left ${
+                      task.status === "done"
+                        ? "bg-surface text-on-surface-muted"
+                        : bgColor
+                          ? "text-on-surface"
+                          : "bg-surface text-on-surface"
+                    }`}
+                    style={
+                      task.status !== "done" && bgColor
+                        ? { backgroundColor: bgColor }
+                        : undefined
+                    }
+                  >
+                    <input
+                      type="checkbox"
+                      checked={task.status === "done"}
+                      onChange={() => onToggleStatus(task)}
+                      onClick={(e) => e.stopPropagation()}
+                      className="h-4 w-4 shrink-0 cursor-pointer"
+                    />
+                    <span
+                      className={`flex-1 text-sm ${task.status === "done" ? "line-through" : ""}`}
+                    >
+                      {task.title}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+        <div className="pb-6" />
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/components/MobileDayBottomSheet.tsx
+++ b/apps/web/src/components/MobileDayBottomSheet.tsx
@@ -85,11 +85,9 @@ export function MobileDayBottomSheet({
                   : null;
                 const bgColor = cat ? CATEGORY_COLORS[cat.color].bg : undefined;
                 return (
-                  <button
+                  <div
                     key={task.id}
-                    type="button"
-                    onClick={() => onTaskClick(task)}
-                    className={`flex w-full items-center gap-3 rounded-lg p-3 text-left ${
+                    className={`flex items-center gap-3 rounded-lg p-3 ${
                       task.status === "done"
                         ? "bg-surface text-on-surface-muted"
                         : bgColor
@@ -106,15 +104,16 @@ export function MobileDayBottomSheet({
                       type="checkbox"
                       checked={task.status === "done"}
                       onChange={() => onToggleStatus(task)}
-                      onClick={(e) => e.stopPropagation()}
                       className="h-4 w-4 shrink-0 cursor-pointer"
                     />
-                    <span
-                      className={`flex-1 text-sm ${task.status === "done" ? "line-through" : ""}`}
+                    <button
+                      type="button"
+                      onClick={() => onTaskClick(task)}
+                      className={`flex-1 text-left text-sm ${task.status === "done" ? "line-through" : ""}`}
                     >
                       {task.title}
-                    </span>
-                  </button>
+                    </button>
+                  </div>
                 );
               })}
             </div>

--- a/apps/web/src/components/UnscheduledTasksSidebar.tsx
+++ b/apps/web/src/components/UnscheduledTasksSidebar.tsx
@@ -1,6 +1,7 @@
 import { useDroppable } from "@dnd-kit/core";
 import type { Task } from "../types/task";
 import type { Category } from "../types/category";
+import { useMediaQuery } from "../hooks/useMediaQuery";
 import { DraggableTask } from "./DraggableTask";
 
 type UnscheduledTasksSidebarProps = {
@@ -26,9 +27,10 @@ export function UnscheduledTasksSidebar({
   onToggleStatus,
   onAddClick,
 }: UnscheduledTasksSidebarProps) {
+  const isMobile = useMediaQuery("(max-width: 639px)");
   const { setNodeRef, isOver } = useDroppable({ id: DROPPABLE_ID });
 
-  const innerContent = (
+  const droppableContent = (
     <div className="flex h-full w-64 flex-col overflow-hidden rounded-lg border border-border-light bg-white">
       <div className="border-b border-border-light px-3 py-1 text-sm font-medium text-on-surface">
         未スケジュール
@@ -71,19 +73,10 @@ export function UnscheduledTasksSidebar({
     </div>
   );
 
-  return (
-    <>
-      {/* デスクトップ: サイドバー */}
+  if (isMobile) {
+    return (
       <div
-        className="hidden shrink-0 self-stretch overflow-hidden transition-[width] duration-300 ease-in-out sm:block"
-        style={{ width: isOpen ? "16rem" : "0px" }}
-      >
-        {innerContent}
-      </div>
-
-      {/* モバイル: オーバーレイ */}
-      <div
-        className={`fixed inset-0 z-40 sm:hidden ${isOpen ? "pointer-events-auto" : "pointer-events-none"}`}
+        className={`fixed inset-0 z-40 ${isOpen ? "pointer-events-auto" : "pointer-events-none"}`}
       >
         <div
           className={`absolute inset-0 bg-black/30 transition-opacity duration-300 ${isOpen ? "opacity-100" : "opacity-0"}`}
@@ -92,9 +85,18 @@ export function UnscheduledTasksSidebar({
         <div
           className={`absolute top-0 bottom-0 left-0 w-64 shadow-xl transition-transform duration-300 ${isOpen ? "translate-x-0" : "-translate-x-full"}`}
         >
-          {innerContent}
+          {droppableContent}
         </div>
       </div>
-    </>
+    );
+  }
+
+  return (
+    <div
+      className="shrink-0 self-stretch overflow-hidden transition-[width] duration-300 ease-in-out"
+      style={{ width: isOpen ? "16rem" : "0px" }}
+    >
+      {droppableContent}
+    </div>
   );
 }

--- a/apps/web/src/components/UnscheduledTasksSidebar.tsx
+++ b/apps/web/src/components/UnscheduledTasksSidebar.tsx
@@ -7,6 +7,7 @@ type UnscheduledTasksSidebarProps = {
   tasks: Task[];
   categoryMap: Map<string, Category>;
   isOpen: boolean;
+  onClose: () => void;
   onTaskClick: (task: Task) => void;
   onToggleStatus: (task: Task) => void;
   onAddClick: () => void;
@@ -20,57 +21,80 @@ export function UnscheduledTasksSidebar({
   tasks,
   categoryMap,
   isOpen,
+  onClose,
   onTaskClick,
   onToggleStatus,
   onAddClick,
 }: UnscheduledTasksSidebarProps) {
   const { setNodeRef, isOver } = useDroppable({ id: DROPPABLE_ID });
 
-  return (
-    <div
-      className="shrink-0 self-stretch overflow-hidden transition-[width] duration-300 ease-in-out"
-      style={{ width: isOpen ? "16rem" : "0px" }}
-    >
-      <div className="flex h-full w-64 flex-col overflow-hidden rounded-lg border border-border-light bg-white">
-        <div className="border-b border-border-light px-3 py-1 text-sm font-medium text-on-surface">
-          未スケジュール
-          <span className="ml-2 inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-on-surface-muted/20 px-1.5 text-xs font-medium text-on-surface-secondary">
-            {tasks.length}
-          </span>
+  const innerContent = (
+    <div className="flex h-full w-64 flex-col overflow-hidden rounded-lg border border-border-light bg-white">
+      <div className="border-b border-border-light px-3 py-1 text-sm font-medium text-on-surface">
+        未スケジュール
+        <span className="ml-2 inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-on-surface-muted/20 px-1.5 text-xs font-medium text-on-surface-secondary">
+          {tasks.length}
+        </span>
+      </div>
+      <div
+        ref={setNodeRef}
+        className={`flex-1 overflow-y-auto p-2 ${isOver ? "bg-primary-lighter ring-2 ring-primary-muted ring-inset" : ""}`}
+      >
+        <div className="space-y-1">
+          {tasks.map((task) => (
+            <DraggableTask
+              key={task.id}
+              task={task}
+              category={
+                task.categoryId
+                  ? (categoryMap.get(task.categoryId) ?? null)
+                  : null
+              }
+              onTaskClick={onTaskClick}
+              onToggleStatus={onToggleStatus}
+            />
+          ))}
+          {tasks.length === 0 && (
+            <p className="px-1 py-2 text-center text-xs text-on-surface-muted">
+              未スケジュールタスクはありません
+            </p>
+          )}
         </div>
-        <div
-          ref={setNodeRef}
-          className={`flex-1 overflow-y-auto p-2 ${isOver ? "bg-primary-lighter ring-2 ring-primary-muted ring-inset" : ""}`}
+        <button
+          type="button"
+          onClick={onAddClick}
+          className="mt-2 w-full rounded-md border border-dashed border-border px-2 py-1.5 text-xs text-on-surface-muted hover:border-primary hover:text-primary"
         >
-          <div className="space-y-1">
-            {tasks.map((task) => (
-              <DraggableTask
-                key={task.id}
-                task={task}
-                category={
-                  task.categoryId
-                    ? (categoryMap.get(task.categoryId) ?? null)
-                    : null
-                }
-                onTaskClick={onTaskClick}
-                onToggleStatus={onToggleStatus}
-              />
-            ))}
-            {tasks.length === 0 && (
-              <p className="px-1 py-2 text-center text-xs text-on-surface-muted">
-                未スケジュールタスクはありません
-              </p>
-            )}
-          </div>
-          <button
-            type="button"
-            onClick={onAddClick}
-            className="mt-2 w-full rounded-md border border-dashed border-border px-2 py-1.5 text-xs text-on-surface-muted hover:border-primary hover:text-primary"
-          >
-            + タスクを追加
-          </button>
-        </div>
+          + タスクを追加
+        </button>
       </div>
     </div>
+  );
+
+  return (
+    <>
+      {/* デスクトップ: サイドバー */}
+      <div
+        className="hidden shrink-0 self-stretch overflow-hidden transition-[width] duration-300 ease-in-out sm:block"
+        style={{ width: isOpen ? "16rem" : "0px" }}
+      >
+        {innerContent}
+      </div>
+
+      {/* モバイル: オーバーレイ */}
+      <div
+        className={`fixed inset-0 z-40 sm:hidden ${isOpen ? "pointer-events-auto" : "pointer-events-none"}`}
+      >
+        <div
+          className={`absolute inset-0 bg-black/30 transition-opacity duration-300 ${isOpen ? "opacity-100" : "opacity-0"}`}
+          onClick={onClose}
+        />
+        <div
+          className={`absolute top-0 bottom-0 left-0 w-64 shadow-xl transition-transform duration-300 ${isOpen ? "translate-x-0" : "-translate-x-full"}`}
+        >
+          {innerContent}
+        </div>
+      </div>
+    </>
   );
 }

--- a/apps/web/src/hooks/useMediaQuery.ts
+++ b/apps/web/src/hooks/useMediaQuery.ts
@@ -1,0 +1,16 @@
+import { useEffect, useState } from "react";
+
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(
+    () => window.matchMedia(query).matches,
+  );
+
+  useEffect(() => {
+    const mql = window.matchMedia(query);
+    const handler = (e: MediaQueryListEvent) => setMatches(e.matches);
+    mql.addEventListener("change", handler);
+    return () => mql.removeEventListener("change", handler);
+  }, [query]);
+
+  return matches;
+}

--- a/apps/web/src/hooks/useMediaQuery.ts
+++ b/apps/web/src/hooks/useMediaQuery.ts
@@ -1,11 +1,15 @@
 import { useEffect, useState } from "react";
 
+const canUseMatchMedia =
+  typeof window !== "undefined" && "matchMedia" in window;
+
 export function useMediaQuery(query: string): boolean {
-  const [matches, setMatches] = useState(
-    () => window.matchMedia(query).matches,
+  const [matches, setMatches] = useState(() =>
+    canUseMatchMedia ? window.matchMedia(query).matches : false,
   );
 
   useEffect(() => {
+    if (!canUseMatchMedia) return;
     const mql = window.matchMedia(query);
     const handler = (e: MediaQueryListEvent) => setMatches(e.matches);
     mql.addEventListener("change", handler);

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -1,1 +1,15 @@
 import "@testing-library/jest-dom/vitest";
+
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }),
+});


### PR DESCRIPTION
close #232

## 概要

カレンダー画面をモバイル（スマートフォン）で実用的に使えるよう UI を改善した。

- モバイル幅（639px 未満）ではカレンダーセルをナビゲーション用途に特化し、日付タップでボトムシートを表示するUXに変更
- 未スケジュールタスクサイドバーをモバイルではオーバーレイ（ドロワー）として表示
- `dnd-kit` に `TouchSensor` を追加してモバイルでのタッチ操作によるドラッグ&ドロップを有効化

## 変更内容

### 新規ファイル
- `apps/web/src/hooks/useMediaQuery.ts` — ブレークポイント判定 hook
- `apps/web/src/components/MobileDayBottomSheet.tsx` — モバイル用ボトムシートコンポーネント（スワイプダウン・背景タップで閉じる）

### 変更ファイル
- `apps/web/src/components/CalendarDayCell.tsx` — モバイルでセル高さ縮小（`min-h-20 sm:min-h-40`）・タスク数バッジ表示・タスクテキスト非表示
- `apps/web/src/components/Calendar.tsx` — `TouchSensor` 追加・モバイル用ボトムシート状態管理・`isMobile` による動線分岐
- `apps/web/src/components/UnscheduledTasksSidebar.tsx` — `useMediaQuery` で条件レンダリングし、モバイルではオーバーレイ表示に変更（`setNodeRef` 二重付与問題も修正）
- `apps/web/src/test/setup.ts` — jsdom 向け `matchMedia` モックを追加

## ローカル検証手順

1. `pnpm dev` で起動
2. ブラウザの DevTools でモバイルサイズ（390×844 等）に切り替える
3. カレンダーのセルをタップ → ボトムシートが下から表示されることを確認
4. ボトムシートを背景タップまたはスワイプダウンで閉じられることを確認
5. リストアイコンをタップ → 未スケジュールサイドバーがオーバーレイとして表示されることを確認
6. ブラウザをデスクトップサイズに戻し、既存の動作が変わっていないことを確認

## 対応したクロスレビュー指摘

- `useMediaQuery`: `window.matchMedia` 未実装環境（jsdom / SSR）でのクラッシュを防ぐガードを追加
- `MobileDayBottomSheet`: `<button>` 内の `<input type="checkbox">` という HTML 不正構造を `<div>` + 兄弟要素に修正
- `UnscheduledTasksSidebar`: `setNodeRef` が CSS 非表示側にも付与されてドロップ判定が壊れる問題を、JS 条件レンダリングで修正
