### PR TITLE
feat(web): beforeLoad中の白画面対策としてローディング表示を追加

### DIFF
--- a/apps/web/src/components/LoadingScreen.tsx
+++ b/apps/web/src/components/LoadingScreen.tsx
@@ -1,7 +1,15 @@
 export function LoadingScreen() {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-surface">
-      <div className="h-8 w-8 animate-spin rounded-full border-4 border-border border-t-primary" />
+    <div
+      role="status"
+      aria-live="polite"
+      className="flex min-h-screen items-center justify-center bg-surface"
+    >
+      <div
+        aria-hidden="true"
+        className="h-8 w-8 animate-spin rounded-full border-4 border-border border-t-primary"
+      />
+      <span className="sr-only">読み込み中</span>
     </div>
   );
 }

--- a/apps/web/src/components/LoadingScreen.tsx
+++ b/apps/web/src/components/LoadingScreen.tsx
@@ -1,0 +1,7 @@
+export function LoadingScreen() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-surface">
+      <div className="h-8 w-8 animate-spin rounded-full border-4 border-border border-t-primary" />
+    </div>
+  );
+}

--- a/apps/web/src/routes/app.tsx
+++ b/apps/web/src/routes/app.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, Outlet, redirect } from "@tanstack/react-router";
 import { authClient } from "../auth-client";
+import { LoadingScreen } from "../components/LoadingScreen";
 
 export const Route = createFileRoute("/app")({
   beforeLoad: async () => {
@@ -10,5 +11,6 @@ export const Route = createFileRoute("/app")({
     }
     return { session };
   },
+  pendingComponent: LoadingScreen,
   component: () => <Outlet />,
 });

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, redirect, useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
 import { authClient } from "../auth-client";
+import { LoadingScreen } from "../components/LoadingScreen";
 
 export const Route = createFileRoute("/login")({
   beforeLoad: async () => {
@@ -10,6 +11,7 @@ export const Route = createFileRoute("/login")({
       throw redirect({ to: "/app" });
     }
   },
+  pendingComponent: LoadingScreen,
   component: LoginPage,
 });
 

--- a/apps/web/src/routes/signup.tsx
+++ b/apps/web/src/routes/signup.tsx
@@ -6,6 +6,7 @@ import {
 } from "@tanstack/react-router";
 import { useState } from "react";
 import { authClient } from "../auth-client";
+import { LoadingScreen } from "../components/LoadingScreen";
 
 export const Route = createFileRoute("/signup")({
   beforeLoad: async () => {
@@ -15,6 +16,7 @@ export const Route = createFileRoute("/signup")({
       throw redirect({ to: "/app" });
     }
   },
+  pendingComponent: LoadingScreen,
   component: SignupPage,
 });
 


### PR DESCRIPTION
close #221

## 目的

TanStack Router の `beforeLoad` でセッション確認 API を呼び出している間、画面が真っ白になる問題を解消する。

Cloud Run のコールドスタート時など `authClient.getSession()` に数秒かかるケースで、白画面の代わりにスピナーを表示する。

## 変更内容

- `apps/web/src/components/LoadingScreen.tsx` — スピナーを表示する共通ローディングコンポーネントを追加（アクセシビリティ属性 `role="status"` / `aria-live="polite"` / `sr-only` テキスト付き）
- `apps/web/src/routes/login.tsx` — `pendingComponent: LoadingScreen` を設定
- `apps/web/src/routes/signup.tsx` — `pendingComponent: LoadingScreen` を設定
- `apps/web/src/routes/app.tsx` — `pendingComponent: LoadingScreen` を設定

## ローカル検証手順

1. `pnpm dev` で開発サーバーを起動
2. Chrome DevTools の Network タブで「Slow 3G」に throttle
3. `/login` / `/signup` / `/app` にアクセスし、セッション確認中にスピナーが表示されることを確認
4. 白画面が表示されないことを確認