### PR TITLE
fix(web): iOS PWA 起動時のスタート画面を /app に変更

### DIFF
--- a/apps/web/public/site.webmanifest
+++ b/apps/web/public/site.webmanifest
@@ -13,7 +13,7 @@
       "type": "image/png"
     }
   ],
-  "start_url": "/",
+  "start_url": "/app",
   "scope": "/",
   "theme_color": "#4a4181",
   "background_color": "#ffffff",

--- a/apps/web/src/routes/auth-redirect.test.ts
+++ b/apps/web/src/routes/auth-redirect.test.ts
@@ -44,6 +44,60 @@ describe("/login beforeLoad", () => {
   });
 });
 
+describe("/ beforeLoad (PWA standalone redirect)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("display-mode: standalone のとき /app にリダイレクトする", async () => {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: (query: string) => ({
+        matches: query === "(display-mode: standalone)",
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false,
+      }),
+    });
+
+    const { Route } = await import("./index");
+    const beforeLoad = Route.options.beforeLoad!;
+
+    try {
+      (beforeLoad as () => void)();
+      expect.fail("redirect が throw されるべき");
+    } catch (e) {
+      expect(isRedirect(e)).toBe(true);
+      expect((e as { options: { to: string } }).options.to).toBe("/app");
+    }
+  });
+
+  it("通常ブラウザ (non-standalone) ではリダイレクトしない", async () => {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: (query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false,
+      }),
+    });
+
+    const { Route } = await import("./index");
+    const beforeLoad = Route.options.beforeLoad!;
+
+    expect(() => (beforeLoad as () => void)()).not.toThrow();
+  });
+});
+
 describe("/signup beforeLoad", () => {
   beforeEach(() => {
     vi.resetModules();

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -8,7 +8,8 @@ export const Route = createFileRoute("/")({
         "matchMedia" in window &&
         window.matchMedia("(display-mode: standalone)").matches) ||
       (typeof navigator !== "undefined" &&
-        (navigator as Navigator & { standalone?: boolean }).standalone === true);
+        (navigator as Navigator & { standalone?: boolean }).standalone ===
+          true);
     if (isStandalone) {
       // eslint-disable-next-line @typescript-eslint/only-throw-error
       throw redirect({ to: "/app" });

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,6 +1,16 @@
-import { createFileRoute, Link } from "@tanstack/react-router";
+import { createFileRoute, Link, redirect } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/")({
+  beforeLoad: () => {
+    // PWA standalone モードで起動した場合は /app へリダイレクト
+    const isStandalone =
+      window.matchMedia("(display-mode: standalone)").matches ||
+      (navigator as Navigator & { standalone?: boolean }).standalone === true;
+    if (isStandalone) {
+      // eslint-disable-next-line @typescript-eslint/only-throw-error
+      throw redirect({ to: "/app" });
+    }
+  },
   component: LandingPage,
 });
 

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -4,8 +4,11 @@ export const Route = createFileRoute("/")({
   beforeLoad: () => {
     // PWA standalone モードで起動した場合は /app へリダイレクト
     const isStandalone =
-      window.matchMedia("(display-mode: standalone)").matches ||
-      (navigator as Navigator & { standalone?: boolean }).standalone === true;
+      (typeof window !== "undefined" &&
+        "matchMedia" in window &&
+        window.matchMedia("(display-mode: standalone)").matches) ||
+      (typeof navigator !== "undefined" &&
+        (navigator as Navigator & { standalone?: boolean }).standalone === true);
     if (isStandalone) {
       // eslint-disable-next-line @typescript-eslint/only-throw-error
       throw redirect({ to: "/app" });


### PR DESCRIPTION
## 概要

iOS ホーム画面に追加した PWA を起動するたびにランディングページ（`/`）が表示される問題を修正します。

## 変更内容

- `apps/web/public/site.webmanifest`: `start_url` を `/` → `/app` に変更
  - 新規ホーム画面追加時に PWA が `/app` から起動するようになる
- `apps/web/src/routes/index.tsx`: `beforeLoad` で standalone モードを検出し `/app` にリダイレクト
  - `display-mode: standalone`（Android/Chrome PWA）と `navigator.standalone`（iOS Safari）の両方に対応
  - `manifest` の `start_url` 変更前に追加済みの iOS PWA セッションにも対処

## 動作フロー

```
PWA 起動 → /app
  ├── 認証済み → カレンダー画面
  └── 未認証  → /login
```

## テスト

`apps/web/src/routes/auth-redirect.test.ts` に `/ beforeLoad` のテストを追加：
- `display-mode: standalone` のとき `/app` にリダイレクトすること
- 通常ブラウザ（non-standalone）ではリダイレクトしないこと

## ローカル検証手順

1. `pnpm dev` でサーバー起動
2. iOS Safari で PWA をホーム画面に追加（または Chrome DevTools で display-mode を standalone に切り替え）
3. ホーム画面から起動 → `/app` に直接遷移することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)