### PR TITLE
タスクの日付選択を月曜始まりの DatePicker に統一する

### DIFF
--- a/apps/web/src/components/DatePicker.test.tsx
+++ b/apps/web/src/components/DatePicker.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useState } from "react";
@@ -11,27 +11,27 @@ function DatePickerHarness({ initialValue = "" }: { initialValue?: string }) {
 }
 
 describe("DatePicker", () => {
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
   it("曜日を月曜始まりで表示する", async () => {
     const user = userEvent.setup();
     render(<DatePickerHarness initialValue="2026-03-15" />);
 
-    await user.click(screen.getByRole("button", { name: "日付を選択" }));
+    await user.click(screen.getByRole("button", { name: /^日付/ }));
 
     const weekdayLabels = ["月", "火", "水", "木", "金", "土", "日"];
     const grid = screen.getByRole("grid", { name: "2026年3月" });
-    const labels = grid.previousElementSibling;
-    expect(labels?.textContent).toBe(weekdayLabels.join(""));
+    expect(
+      within(grid)
+        .getAllByRole("columnheader")
+        .map((header) => header.textContent),
+    ).toEqual(weekdayLabels);
+    expect(within(grid).getAllByRole("row")).toHaveLength(7);
   });
 
   it("前月と翌月へ移動できる", async () => {
     const user = userEvent.setup();
     render(<DatePickerHarness initialValue="2026-03-15" />);
 
-    await user.click(screen.getByRole("button", { name: "日付を選択" }));
+    await user.click(screen.getByRole("button", { name: /^日付/ }));
     await user.click(screen.getByRole("button", { name: "前月" }));
     expect(screen.getByRole("grid", { name: "2026年2月" })).toBeInTheDocument();
 
@@ -44,24 +44,24 @@ describe("DatePicker", () => {
     const user = userEvent.setup();
     render(<DatePickerHarness initialValue="2026-03-15" />);
 
-    await user.click(screen.getByRole("button", { name: "日付を選択" }));
-    await user.click(screen.getByRole("gridcell", { name: "2026-03-20" }));
+    await user.click(screen.getByRole("button", { name: /^日付/ }));
+    await user.click(screen.getByRole("button", { name: "2026-03-20" }));
 
-    expect(
-      screen.getByRole("button", { name: "日付を選択" }),
-    ).toHaveTextContent("2026-03-20");
+    expect(screen.getByRole("button", { name: /^日付/ })).toHaveTextContent(
+      "2026-03-20",
+    );
   });
 
   it("日付を未設定に戻せる", async () => {
     const user = userEvent.setup();
     render(<DatePickerHarness initialValue="2026-03-15" />);
 
-    await user.click(screen.getByRole("button", { name: "日付を選択" }));
+    await user.click(screen.getByRole("button", { name: /^日付/ }));
     await user.click(screen.getByRole("button", { name: "未設定に戻す" }));
 
-    expect(
-      screen.getByRole("button", { name: "日付を選択" }),
-    ).toHaveTextContent("日付を選択");
+    expect(screen.getByRole("button", { name: /^日付/ })).toHaveTextContent(
+      "日付を選択",
+    );
   });
 
   it("選択中の日付と今日を視覚的に区別する", async () => {
@@ -76,16 +76,19 @@ describe("DatePicker", () => {
     const user = userEvent.setup();
     render(<DatePickerHarness initialValue={selectedKey} />);
 
-    await user.click(screen.getByRole("button", { name: "日付を選択" }));
+    await user.click(screen.getByRole("button", { name: /^日付/ }));
 
-    expect(screen.getByRole("gridcell", { name: selectedKey })).toHaveAttribute(
+    const selectedButton = screen.getByRole("button", { name: selectedKey });
+    expect(selectedButton.closest('[role="gridcell"]')).toHaveAttribute(
       "aria-selected",
       "true",
     );
-    expect(screen.getByRole("gridcell", { name: selectedKey })).toHaveClass(
-      "bg-primary",
+    expect(selectedButton).toHaveClass("bg-primary");
+    expect(screen.getByRole("button", { name: todayKey })).toHaveAttribute(
+      "aria-current",
+      "date",
     );
-    expect(screen.getByRole("gridcell", { name: todayKey })).toHaveClass(
+    expect(screen.getByRole("button", { name: todayKey })).toHaveClass(
       "ring-primary",
     );
   });
@@ -94,10 +97,10 @@ describe("DatePicker", () => {
     const user = userEvent.setup();
     render(<DatePickerHarness initialValue="2026-03-15" />);
 
-    const trigger = screen.getByRole("button", { name: "日付を選択" });
+    const trigger = screen.getByRole("button", { name: /^日付/ });
     await user.click(trigger);
 
-    const selectedDay = screen.getByRole("gridcell", { name: "2026-03-15" });
+    const selectedDay = screen.getByRole("button", { name: "2026-03-15" });
     expect(selectedDay).toHaveFocus();
 
     await user.keyboard("{ArrowRight}{Enter}");
@@ -113,12 +116,28 @@ describe("DatePicker", () => {
     const user = userEvent.setup();
     render(<DatePickerHarness initialValue="2026-03-15" />);
 
-    await user.click(screen.getByRole("button", { name: "日付を選択" }));
+    await user.click(screen.getByRole("button", { name: /^日付/ }));
     await user.keyboard("{PageDown}");
 
     const grid = screen.getByRole("grid", { name: "2026年4月" });
     expect(
-      within(grid).getByRole("gridcell", { name: "2026-04-15" }),
+      within(grid).getByRole("button", { name: "2026-04-15" }),
     ).toHaveFocus();
+  });
+
+  it("今日が選択中でも今日と選択中の両方を示す", async () => {
+    const todayKey = formatDateKey(new Date());
+    const user = userEvent.setup();
+    render(<DatePickerHarness initialValue={todayKey} />);
+
+    await user.click(screen.getByRole("button", { name: /^日付/ }));
+
+    const todayButton = screen.getByRole("button", { name: todayKey });
+    expect(todayButton).toHaveAttribute("aria-current", "date");
+    expect(todayButton).toHaveClass("bg-primary", "ring-primary");
+    expect(todayButton.closest('[role="gridcell"]')).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
   });
 });

--- a/apps/web/src/components/DatePicker.test.tsx
+++ b/apps/web/src/components/DatePicker.test.tsx
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { formatDateKey } from "../utils/calendar";
+import { DatePicker } from "./DatePicker";
+
+function DatePickerHarness({ initialValue = "" }: { initialValue?: string }) {
+  const [value, setValue] = useState(initialValue);
+  return <DatePicker id="date" value={value} onChange={setValue} />;
+}
+
+describe("DatePicker", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("曜日を月曜始まりで表示する", async () => {
+    const user = userEvent.setup();
+    render(<DatePickerHarness initialValue="2026-03-15" />);
+
+    await user.click(screen.getByRole("button", { name: "日付を選択" }));
+
+    const weekdayLabels = ["月", "火", "水", "木", "金", "土", "日"];
+    const grid = screen.getByRole("grid", { name: "2026年3月" });
+    const labels = grid.previousElementSibling;
+    expect(labels?.textContent).toBe(weekdayLabels.join(""));
+  });
+
+  it("前月と翌月へ移動できる", async () => {
+    const user = userEvent.setup();
+    render(<DatePickerHarness initialValue="2026-03-15" />);
+
+    await user.click(screen.getByRole("button", { name: "日付を選択" }));
+    await user.click(screen.getByRole("button", { name: "前月" }));
+    expect(screen.getByRole("grid", { name: "2026年2月" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "翌月" }));
+    await user.click(screen.getByRole("button", { name: "翌月" }));
+    expect(screen.getByRole("grid", { name: "2026年4月" })).toBeInTheDocument();
+  });
+
+  it("選択した日付を YYYY-MM-DD 形式で反映する", async () => {
+    const user = userEvent.setup();
+    render(<DatePickerHarness initialValue="2026-03-15" />);
+
+    await user.click(screen.getByRole("button", { name: "日付を選択" }));
+    await user.click(screen.getByRole("gridcell", { name: "2026-03-20" }));
+
+    expect(
+      screen.getByRole("button", { name: "日付を選択" }),
+    ).toHaveTextContent("2026-03-20");
+  });
+
+  it("日付を未設定に戻せる", async () => {
+    const user = userEvent.setup();
+    render(<DatePickerHarness initialValue="2026-03-15" />);
+
+    await user.click(screen.getByRole("button", { name: "日付を選択" }));
+    await user.click(screen.getByRole("button", { name: "未設定に戻す" }));
+
+    expect(
+      screen.getByRole("button", { name: "日付を選択" }),
+    ).toHaveTextContent("日付を選択");
+  });
+
+  it("選択中の日付と今日を視覚的に区別する", async () => {
+    const today = new Date();
+    const selectedDate = new Date(
+      today.getFullYear(),
+      today.getMonth(),
+      today.getDate() === 1 ? 2 : 1,
+    );
+    const todayKey = formatDateKey(today);
+    const selectedKey = formatDateKey(selectedDate);
+    const user = userEvent.setup();
+    render(<DatePickerHarness initialValue={selectedKey} />);
+
+    await user.click(screen.getByRole("button", { name: "日付を選択" }));
+
+    expect(screen.getByRole("gridcell", { name: selectedKey })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByRole("gridcell", { name: selectedKey })).toHaveClass(
+      "bg-primary",
+    );
+    expect(screen.getByRole("gridcell", { name: todayKey })).toHaveClass(
+      "ring-primary",
+    );
+  });
+
+  it("キーボードで日付を移動・選択し、閉じるとトリガーへフォーカスを戻す", async () => {
+    const user = userEvent.setup();
+    render(<DatePickerHarness initialValue="2026-03-15" />);
+
+    const trigger = screen.getByRole("button", { name: "日付を選択" });
+    await user.click(trigger);
+
+    const selectedDay = screen.getByRole("gridcell", { name: "2026-03-15" });
+    expect(selectedDay).toHaveFocus();
+
+    await user.keyboard("{ArrowRight}{Enter}");
+
+    expect(trigger).toHaveTextContent("2026-03-16");
+    expect(trigger).toHaveFocus();
+    await waitFor(() => {
+      expect(screen.queryByRole("grid")).not.toBeInTheDocument();
+    });
+  });
+
+  it("PageDown で翌月の同じ日へ移動できる", async () => {
+    const user = userEvent.setup();
+    render(<DatePickerHarness initialValue="2026-03-15" />);
+
+    await user.click(screen.getByRole("button", { name: "日付を選択" }));
+    await user.keyboard("{PageDown}");
+
+    const grid = screen.getByRole("grid", { name: "2026年4月" });
+    expect(
+      within(grid).getByRole("gridcell", { name: "2026-04-15" }),
+    ).toHaveFocus();
+  });
+});

--- a/apps/web/src/components/DatePicker.tsx
+++ b/apps/web/src/components/DatePicker.tsx
@@ -1,0 +1,314 @@
+import { Popover, PopoverButton, PopoverPanel } from "@headlessui/react";
+import { useEffect, useRef, useState } from "react";
+import { formatDateKey, getCalendarDays, isToday } from "../utils/calendar";
+
+const WEEKDAY_LABELS = ["月", "火", "水", "木", "金", "土", "日"];
+
+type DatePickerProps = {
+  id: string;
+  value: string;
+  onChange: (value: string) => void;
+};
+
+function parseDateKey(value: string): Date | null {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) return null;
+
+  const date = new Date(
+    Number(match[1]),
+    Number(match[2]) - 1,
+    Number(match[3]),
+  );
+  return formatDateKey(date) === value ? date : null;
+}
+
+function getDateInAdjacentMonth(date: Date, offset: number): Date {
+  const year = date.getFullYear();
+  const month = date.getMonth() + offset;
+  const lastDay = new Date(year, month + 1, 0).getDate();
+  return new Date(year, month, Math.min(date.getDate(), lastDay));
+}
+
+export function DatePicker({ id, value, onChange }: DatePickerProps) {
+  const selectedDate = parseDateKey(value);
+  const initialDate = selectedDate ?? new Date();
+  const [visibleMonth, setVisibleMonth] = useState(
+    () => new Date(initialDate.getFullYear(), initialDate.getMonth(), 1),
+  );
+  const [focusedDateKey, setFocusedDateKey] = useState(() =>
+    formatDateKey(initialDate),
+  );
+  const dayButtonRefs = useRef(new Map<string, HTMLButtonElement>());
+  const shouldFocusDay = useRef(false);
+
+  useEffect(() => {
+    const nextSelectedDate = parseDateKey(value);
+    if (!nextSelectedDate) return;
+
+    setVisibleMonth(
+      new Date(nextSelectedDate.getFullYear(), nextSelectedDate.getMonth(), 1),
+    );
+    setFocusedDateKey(value);
+  }, [value]);
+
+  const focusDayAfterRender = () => {
+    shouldFocusDay.current = true;
+  };
+
+  const moveMonth = (offset: number) => {
+    const nextMonth = new Date(
+      visibleMonth.getFullYear(),
+      visibleMonth.getMonth() + offset,
+      1,
+    );
+    const focusedDate = parseDateKey(focusedDateKey) ?? nextMonth;
+    const nextFocusedDate = new Date(
+      nextMonth.getFullYear(),
+      nextMonth.getMonth(),
+      Math.min(
+        focusedDate.getDate(),
+        new Date(
+          nextMonth.getFullYear(),
+          nextMonth.getMonth() + 1,
+          0,
+        ).getDate(),
+      ),
+    );
+
+    setVisibleMonth(nextMonth);
+    setFocusedDateKey(formatDateKey(nextFocusedDate));
+  };
+
+  const handleDayKeyDown = (
+    event: React.KeyboardEvent<HTMLButtonElement>,
+    date: Date,
+  ) => {
+    let nextDate: Date | null = null;
+
+    switch (event.key) {
+      case "ArrowLeft":
+        nextDate = new Date(
+          date.getFullYear(),
+          date.getMonth(),
+          date.getDate() - 1,
+        );
+        break;
+      case "ArrowRight":
+        nextDate = new Date(
+          date.getFullYear(),
+          date.getMonth(),
+          date.getDate() + 1,
+        );
+        break;
+      case "ArrowUp":
+        nextDate = new Date(
+          date.getFullYear(),
+          date.getMonth(),
+          date.getDate() - 7,
+        );
+        break;
+      case "ArrowDown":
+        nextDate = new Date(
+          date.getFullYear(),
+          date.getMonth(),
+          date.getDate() + 7,
+        );
+        break;
+      case "Home": {
+        const mondayBasedDay = (date.getDay() + 6) % 7;
+        nextDate = new Date(
+          date.getFullYear(),
+          date.getMonth(),
+          date.getDate() - mondayBasedDay,
+        );
+        break;
+      }
+      case "End": {
+        const mondayBasedDay = (date.getDay() + 6) % 7;
+        nextDate = new Date(
+          date.getFullYear(),
+          date.getMonth(),
+          date.getDate() + (6 - mondayBasedDay),
+        );
+        break;
+      }
+      case "PageUp":
+        nextDate = getDateInAdjacentMonth(date, -1);
+        break;
+      case "PageDown":
+        nextDate = getDateInAdjacentMonth(date, 1);
+        break;
+      default:
+        return;
+    }
+
+    event.preventDefault();
+    const nextKey = formatDateKey(nextDate);
+    focusDayAfterRender();
+    setFocusedDateKey(nextKey);
+    if (
+      nextDate.getFullYear() !== visibleMonth.getFullYear() ||
+      nextDate.getMonth() !== visibleMonth.getMonth()
+    ) {
+      setVisibleMonth(new Date(nextDate.getFullYear(), nextDate.getMonth(), 1));
+    }
+  };
+
+  const days = getCalendarDays(
+    visibleMonth.getFullYear(),
+    visibleMonth.getMonth() + 1,
+  );
+
+  return (
+    <Popover className="relative">
+      {({ open, close }) => (
+        <>
+          <PopoverButton
+            id={id}
+            onClick={() => {
+              if (!open) {
+                const dateToFocus = selectedDate ?? new Date();
+                setVisibleMonth(
+                  new Date(
+                    dateToFocus.getFullYear(),
+                    dateToFocus.getMonth(),
+                    1,
+                  ),
+                );
+                setFocusedDateKey(formatDateKey(dateToFocus));
+                focusDayAfterRender();
+              }
+            }}
+            className="flex w-full items-center justify-between rounded-md border border-border px-3 py-2 text-left text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+            aria-label="日付を選択"
+          >
+            <span
+              className={value ? "text-on-surface" : "text-on-surface-muted"}
+            >
+              {value || "日付を選択"}
+            </span>
+            <svg
+              aria-hidden="true"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              className="h-4 w-4 text-on-surface-muted"
+            >
+              <path
+                fillRule="evenodd"
+                d="M6 1.75a.75.75 0 0 1 .75.75V3h6.5v-.5a.75.75 0 0 1 1.5 0V3h.75A2.5 2.5 0 0 1 18 5.5v10a2.5 2.5 0 0 1-2.5 2.5h-11A2.5 2.5 0 0 1 2 15.5v-10A2.5 2.5 0 0 1 4.5 3h.75v-.5A.75.75 0 0 1 6 1.75ZM3.5 7v8.5a1 1 0 0 0 1 1h11a1 1 0 0 0 1-1V7h-13Z"
+                clipRule="evenodd"
+              />
+            </svg>
+          </PopoverButton>
+
+          <PopoverPanel
+            transition
+            className="absolute z-10 mt-2 w-72 rounded-lg border border-border bg-white p-3 shadow-xl transition duration-100 ease-out data-[closed]:scale-95 data-[closed]:opacity-0"
+          >
+            <div className="mb-3 flex items-center justify-between">
+              <button
+                type="button"
+                onClick={() => moveMonth(-1)}
+                className="rounded-md p-1.5 text-on-surface-secondary hover:bg-surface-hover focus:outline-none focus:ring-2 focus:ring-primary"
+                aria-label="前月"
+              >
+                ←
+              </button>
+              <div
+                className="text-sm font-bold text-on-surface"
+                aria-live="polite"
+              >
+                {visibleMonth.getFullYear()}年{visibleMonth.getMonth() + 1}月
+              </div>
+              <button
+                type="button"
+                onClick={() => moveMonth(1)}
+                className="rounded-md p-1.5 text-on-surface-secondary hover:bg-surface-hover focus:outline-none focus:ring-2 focus:ring-primary"
+                aria-label="翌月"
+              >
+                →
+              </button>
+            </div>
+
+            <div className="grid grid-cols-7" aria-label="曜日">
+              {WEEKDAY_LABELS.map((label) => (
+                <div
+                  key={label}
+                  className="pb-1 text-center text-xs font-medium text-on-surface-muted"
+                >
+                  {label}
+                </div>
+              ))}
+            </div>
+
+            <div
+              role="grid"
+              aria-label={`${visibleMonth.getFullYear()}年${visibleMonth.getMonth() + 1}月`}
+              className="grid grid-cols-7"
+            >
+              {days.map(({ date, isCurrentMonth }) => {
+                const dateKey = formatDateKey(date);
+                const selected = dateKey === value;
+                const today = isToday(date);
+
+                return (
+                  <button
+                    key={dateKey}
+                    ref={(element) => {
+                      if (element) {
+                        dayButtonRefs.current.set(dateKey, element);
+                        if (
+                          shouldFocusDay.current &&
+                          dateKey === focusedDateKey
+                        ) {
+                          element.focus();
+                          shouldFocusDay.current = false;
+                        }
+                      } else {
+                        dayButtonRefs.current.delete(dateKey);
+                      }
+                    }}
+                    type="button"
+                    role="gridcell"
+                    aria-label={dateKey}
+                    aria-selected={selected}
+                    tabIndex={dateKey === focusedDateKey ? 0 : -1}
+                    onFocus={() => setFocusedDateKey(dateKey)}
+                    onKeyDown={(event) => handleDayKeyDown(event, date)}
+                    onClick={() => {
+                      onChange(dateKey);
+                      close();
+                    }}
+                    className={`m-0.5 flex h-8 w-8 items-center justify-center rounded-full text-sm focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-1 ${
+                      selected
+                        ? "bg-primary font-bold text-white hover:bg-primary-dark"
+                        : today
+                          ? "font-bold text-primary ring-1 ring-primary"
+                          : isCurrentMonth
+                            ? "text-on-surface hover:bg-surface-hover"
+                            : "text-on-surface-muted hover:bg-surface-hover"
+                    }`}
+                  >
+                    {date.getDate()}
+                  </button>
+                );
+              })}
+            </div>
+
+            <button
+              type="button"
+              onClick={() => {
+                onChange("");
+                close();
+              }}
+              disabled={!value}
+              className="mt-2 w-full rounded-md border border-border px-3 py-1.5 text-sm text-on-surface-secondary hover:bg-surface-hover focus:outline-none focus:ring-2 focus:ring-primary disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              未設定に戻す
+            </button>
+          </PopoverPanel>
+        </>
+      )}
+    </Popover>
+  );
+}

--- a/apps/web/src/components/DatePicker.tsx
+++ b/apps/web/src/components/DatePicker.tsx
@@ -180,7 +180,7 @@ export function DatePicker({ id, value, onChange }: DatePickerProps) {
               }
             }}
             className="flex w-full items-center justify-between rounded-md border border-border px-3 py-2 text-left text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
-            aria-label="日付を選択"
+            aria-label={value ? `日付: ${value}` : "日付を選択"}
           >
             <span
               className={value ? "text-on-surface" : "text-on-surface-muted"}
@@ -230,69 +230,83 @@ export function DatePicker({ id, value, onChange }: DatePickerProps) {
               </button>
             </div>
 
-            <div className="grid grid-cols-7" aria-label="曜日">
-              {WEEKDAY_LABELS.map((label) => (
-                <div
-                  key={label}
-                  className="pb-1 text-center text-xs font-medium text-on-surface-muted"
-                >
-                  {label}
-                </div>
-              ))}
-            </div>
-
             <div
               role="grid"
               aria-label={`${visibleMonth.getFullYear()}年${visibleMonth.getMonth() + 1}月`}
               className="grid grid-cols-7"
             >
-              {days.map(({ date, isCurrentMonth }) => {
-                const dateKey = formatDateKey(date);
-                const selected = dateKey === value;
-                const today = isToday(date);
-
-                return (
-                  <button
-                    key={dateKey}
-                    ref={(element) => {
-                      if (element) {
-                        dayButtonRefs.current.set(dateKey, element);
-                        if (
-                          shouldFocusDay.current &&
-                          dateKey === focusedDateKey
-                        ) {
-                          element.focus();
-                          shouldFocusDay.current = false;
-                        }
-                      } else {
-                        dayButtonRefs.current.delete(dateKey);
-                      }
-                    }}
-                    type="button"
-                    role="gridcell"
-                    aria-label={dateKey}
-                    aria-selected={selected}
-                    tabIndex={dateKey === focusedDateKey ? 0 : -1}
-                    onFocus={() => setFocusedDateKey(dateKey)}
-                    onKeyDown={(event) => handleDayKeyDown(event, date)}
-                    onClick={() => {
-                      onChange(dateKey);
-                      close();
-                    }}
-                    className={`m-0.5 flex h-8 w-8 items-center justify-center rounded-full text-sm focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-1 ${
-                      selected
-                        ? "bg-primary font-bold text-white hover:bg-primary-dark"
-                        : today
-                          ? "font-bold text-primary ring-1 ring-primary"
-                          : isCurrentMonth
-                            ? "text-on-surface hover:bg-surface-hover"
-                            : "text-on-surface-muted hover:bg-surface-hover"
-                    }`}
+              <div role="row" className="contents">
+                {WEEKDAY_LABELS.map((label) => (
+                  <div
+                    key={label}
+                    role="columnheader"
+                    className="pb-1 text-center text-xs font-medium text-on-surface-muted"
                   >
-                    {date.getDate()}
-                  </button>
-                );
-              })}
+                    {label}
+                  </div>
+                ))}
+              </div>
+
+              {Array.from({ length: 6 }, (_, weekIndex) => (
+                <div key={weekIndex} role="row" className="contents">
+                  {days
+                    .slice(weekIndex * 7, weekIndex * 7 + 7)
+                    .map(({ date, isCurrentMonth }) => {
+                      const dateKey = formatDateKey(date);
+                      const selected = dateKey === value;
+                      const today = isToday(date);
+
+                      return (
+                        <div
+                          key={dateKey}
+                          role="gridcell"
+                          aria-selected={selected}
+                          className="flex items-center justify-center"
+                        >
+                          <button
+                            ref={(element) => {
+                              if (element) {
+                                dayButtonRefs.current.set(dateKey, element);
+                                if (
+                                  shouldFocusDay.current &&
+                                  dateKey === focusedDateKey
+                                ) {
+                                  element.focus();
+                                  shouldFocusDay.current = false;
+                                }
+                              } else {
+                                dayButtonRefs.current.delete(dateKey);
+                              }
+                            }}
+                            type="button"
+                            aria-label={dateKey}
+                            aria-current={today ? "date" : undefined}
+                            tabIndex={dateKey === focusedDateKey ? 0 : -1}
+                            onFocus={() => setFocusedDateKey(dateKey)}
+                            onKeyDown={(event) => handleDayKeyDown(event, date)}
+                            onClick={() => {
+                              onChange(dateKey);
+                              close();
+                            }}
+                            className={`m-0.5 flex h-8 w-8 items-center justify-center rounded-full text-sm focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-1 ${
+                              selected
+                                ? "bg-primary font-bold text-white hover:bg-primary-dark"
+                                : isCurrentMonth
+                                  ? "text-on-surface hover:bg-surface-hover"
+                                  : "text-on-surface-muted hover:bg-surface-hover"
+                            } ${
+                              today
+                                ? "font-bold ring-1 ring-primary ring-offset-1"
+                                : ""
+                            }`}
+                          >
+                            {date.getDate()}
+                          </button>
+                        </div>
+                      );
+                    })}
+                </div>
+              ))}
             </div>
 
             <button

--- a/apps/web/src/components/TaskDetailModal.test.tsx
+++ b/apps/web/src/components/TaskDetailModal.test.tsx
@@ -58,7 +58,9 @@ describe("TaskDetailModal", () => {
     expect(screen.getByText("タスクの詳細")).toBeInTheDocument();
     expect(screen.getByDisplayValue("既存タスク")).toBeInTheDocument();
     expect(screen.getByDisplayValue("既存の説明")).toBeInTheDocument();
-    expect(screen.getByDisplayValue("2026-03-15")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "日付を選択" }),
+    ).toHaveTextContent("2026-03-15");
   });
 
   it("タイトルを変更して保存できる", async () => {
@@ -148,5 +150,39 @@ describe("TaskDetailModal", () => {
     );
 
     expect(screen.getByLabelText(/説明/)).toHaveValue("");
+  });
+
+  it("DatePicker で選択した日付を保存できる", async () => {
+    mockUpdateTask.mockResolvedValue({ ...mockTask, date: "2026-03-20" });
+    const user = userEvent.setup();
+    renderWithQueryClient(<TaskDetailModal {...defaultProps} />);
+
+    await user.click(screen.getByRole("button", { name: "日付を選択" }));
+    await user.click(screen.getByRole("gridcell", { name: "2026-03-20" }));
+    await user.click(screen.getByText("保存"));
+
+    await waitFor(() => {
+      expect(mockUpdateTask).toHaveBeenCalledWith(
+        "task-1",
+        expect.objectContaining({ date: "2026-03-20" }),
+      );
+    });
+  });
+
+  it("DatePicker で日付を未設定にして保存できる", async () => {
+    mockUpdateTask.mockResolvedValue({ ...mockTask, date: null });
+    const user = userEvent.setup();
+    renderWithQueryClient(<TaskDetailModal {...defaultProps} />);
+
+    await user.click(screen.getByRole("button", { name: "日付を選択" }));
+    await user.click(screen.getByRole("button", { name: "未設定に戻す" }));
+    await user.click(screen.getByText("保存"));
+
+    await waitFor(() => {
+      expect(mockUpdateTask).toHaveBeenCalledWith(
+        "task-1",
+        expect.objectContaining({ date: null }),
+      );
+    });
   });
 });

--- a/apps/web/src/components/TaskDetailModal.test.tsx
+++ b/apps/web/src/components/TaskDetailModal.test.tsx
@@ -58,9 +58,9 @@ describe("TaskDetailModal", () => {
     expect(screen.getByText("タスクの詳細")).toBeInTheDocument();
     expect(screen.getByDisplayValue("既存タスク")).toBeInTheDocument();
     expect(screen.getByDisplayValue("既存の説明")).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "日付を選択" }),
-    ).toHaveTextContent("2026-03-15");
+    expect(screen.getByRole("button", { name: /^日付/ })).toHaveTextContent(
+      "2026-03-15",
+    );
   });
 
   it("タイトルを変更して保存できる", async () => {
@@ -157,8 +157,8 @@ describe("TaskDetailModal", () => {
     const user = userEvent.setup();
     renderWithQueryClient(<TaskDetailModal {...defaultProps} />);
 
-    await user.click(screen.getByRole("button", { name: "日付を選択" }));
-    await user.click(screen.getByRole("gridcell", { name: "2026-03-20" }));
+    await user.click(screen.getByRole("button", { name: /^日付/ }));
+    await user.click(screen.getByRole("button", { name: "2026-03-20" }));
     await user.click(screen.getByText("保存"));
 
     await waitFor(() => {
@@ -174,7 +174,7 @@ describe("TaskDetailModal", () => {
     const user = userEvent.setup();
     renderWithQueryClient(<TaskDetailModal {...defaultProps} />);
 
-    await user.click(screen.getByRole("button", { name: "日付を選択" }));
+    await user.click(screen.getByRole("button", { name: /^日付/ }));
     await user.click(screen.getByRole("button", { name: "未設定に戻す" }));
     await user.click(screen.getByText("保存"));
 

--- a/apps/web/src/components/TaskDetailModal.tsx
+++ b/apps/web/src/components/TaskDetailModal.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import type { Task } from "../types/task";
 import { useCategories } from "../hooks/useCategories";
 import { useUpdateTask, useDeleteTask } from "../hooks/useTasks";
+import { DatePicker } from "./DatePicker";
 import { ModalWrapper } from "./ModalWrapper";
 
 type TaskDetailModalProps = {
@@ -118,13 +119,7 @@ export function TaskDetailModal({
           >
             日付
           </label>
-          <input
-            id="detail-date"
-            type="date"
-            value={date}
-            onChange={(e) => setDate(e.target.value)}
-            className="w-full rounded-md border border-border px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
-          />
+          <DatePicker id="detail-date" value={date} onChange={setDate} />
         </div>
         {categories.length > 0 && (
           <div>


### PR DESCRIPTION
close #246

## 概要

タスク詳細画面のブラウザ標準の日付入力を、メインカレンダーと同じ月曜始まりの DatePicker に置き換えました。

## 変更内容

- `apps/web/src/components/DatePicker.tsx` に再利用可能な DatePicker を追加
- 月曜始まりの曜日表示、前月・翌月移動、日付選択、未設定への変更に対応
- 選択日と今日を視覚表示および ARIA 属性で区別
- 矢印キー、Home / End、PageUp / PageDown、Enter / Space、Escape と開閉時のフォーカス制御に対応
- `TaskDetailModal` の `input[type=date]` を DatePicker に置き換え
- DatePicker 単体テストとタスク更新連携テストを追加

## 影響範囲

- `apps/web/src/components/DatePicker.tsx`
- `apps/web/src/components/DatePicker.test.tsx`
- `apps/web/src/components/TaskDetailModal.tsx`
- `apps/web/src/components/TaskDetailModal.test.tsx`

## ローカル検証

- `corepack pnpm -r run build`
- `corepack pnpm -r run lint`
- `corepack pnpm -r run format:check`
- `corepack pnpm -r run typecheck`
- `corepack pnpm -r run test`
- `corepack pnpm -r run knip`
- `corepack pnpm --filter @tascal/web run build`
- `corepack pnpm --filter @tascal/web run test`（89 tests passed）