### PR TITLE
カレンダーの前後月セルにもタスクを表示する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,23 +22,22 @@ tascal (task + calendar) — カレンダービューがメインのタスク管
 
 ルートの `package.json` scripts から実行：
 
-| コマンド                      | 内容                                   |
-| ----------------------------- | -------------------------------------- |
-| `pnpm install`                | 全 app の依存インストール              |
-| `pnpm dev`                    | DB 起動 + API + Web の開発サーバー起動 |
-| `pnpm build`                  | 全 app ビルド                          |
-| `pnpm lint`                   | ESLint (全 app)                        |
-| `pnpm format`                 | Prettier 自動修正                      |
-| `pnpm format:check`           | Prettier チェックのみ                  |
-| `pnpm typecheck`              | TypeScript 型チェック                  |
-| `pnpm test`                   | テスト実行 (API + Web + CLI)           |
-| `pnpm knip`                   | 未使用コード・依存の検出               |
-| `pnpm db:up` / `pnpm db:down` | PostgreSQL の起動/停止                 |
-| `pnpm db:migrate`             | Drizzle マイグレーション適用           |
-| `pnpm db:seed`                | テストデータ投入                       |
+| コマンド | 内容 |
+|---|---|
+| `pnpm install` | 全 app の依存インストール |
+| `pnpm dev` | DB 起動 + API + Web の開発サーバー起動 |
+| `pnpm build` | 全 app ビルド |
+| `pnpm lint` | ESLint (全 app) |
+| `pnpm format` | Prettier 自動修正 |
+| `pnpm format:check` | Prettier チェックのみ |
+| `pnpm typecheck` | TypeScript 型チェック |
+| `pnpm test` | テスト実行 (API + Web + CLI) |
+| `pnpm knip` | 未使用コード・依存の検出 |
+| `pnpm db:up` / `pnpm db:down` | PostgreSQL の起動/停止 |
+| `pnpm db:migrate` | Drizzle マイグレーション適用 |
+| `pnpm db:seed` | テストデータ投入 |
 
 個別 app でのテスト実行：
-
 ```bash
 pnpm --filter @tascal/api exec vitest run src/routes/tasks.test.ts  # 単一テスト
 pnpm --filter @tascal/web exec vitest run src/components/Calendar.test.tsx
@@ -109,7 +108,6 @@ Vite dev server が `/api` を `http://localhost:3000` にプロキシ。
 ## 環境変数
 
 `apps/api/.env` に設定（`.env.example` 参照）：
-
 - `DATABASE_URL` — PostgreSQL 接続文字列
 - `CORS_ORIGIN` — 許可オリジン
 - `BETTER_AUTH_SECRET` — 認証シークレット

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,22 +22,23 @@ tascal (task + calendar) — カレンダービューがメインのタスク管
 
 ルートの `package.json` scripts から実行：
 
-| コマンド | 内容 |
-|---|---|
-| `pnpm install` | 全 app の依存インストール |
-| `pnpm dev` | DB 起動 + API + Web の開発サーバー起動 |
-| `pnpm build` | 全 app ビルド |
-| `pnpm lint` | ESLint (全 app) |
-| `pnpm format` | Prettier 自動修正 |
-| `pnpm format:check` | Prettier チェックのみ |
-| `pnpm typecheck` | TypeScript 型チェック |
-| `pnpm test` | テスト実行 (API + Web + CLI) |
-| `pnpm knip` | 未使用コード・依存の検出 |
-| `pnpm db:up` / `pnpm db:down` | PostgreSQL の起動/停止 |
-| `pnpm db:migrate` | Drizzle マイグレーション適用 |
-| `pnpm db:seed` | テストデータ投入 |
+| コマンド                      | 内容                                   |
+| ----------------------------- | -------------------------------------- |
+| `pnpm install`                | 全 app の依存インストール              |
+| `pnpm dev`                    | DB 起動 + API + Web の開発サーバー起動 |
+| `pnpm build`                  | 全 app ビルド                          |
+| `pnpm lint`                   | ESLint (全 app)                        |
+| `pnpm format`                 | Prettier 自動修正                      |
+| `pnpm format:check`           | Prettier チェックのみ                  |
+| `pnpm typecheck`              | TypeScript 型チェック                  |
+| `pnpm test`                   | テスト実行 (API + Web + CLI)           |
+| `pnpm knip`                   | 未使用コード・依存の検出               |
+| `pnpm db:up` / `pnpm db:down` | PostgreSQL の起動/停止                 |
+| `pnpm db:migrate`             | Drizzle マイグレーション適用           |
+| `pnpm db:seed`                | テストデータ投入                       |
 
 個別 app でのテスト実行：
+
 ```bash
 pnpm --filter @tascal/api exec vitest run src/routes/tasks.test.ts  # 単一テスト
 pnpm --filter @tascal/web exec vitest run src/components/Calendar.test.tsx
@@ -51,7 +52,7 @@ pnpm --filter @tascal/web exec vitest run src/components/Calendar.test.tsx
 
 - `src/index.ts` — エントリポイント。サーバー起動のみ
 - `src/app.ts` — Hono アプリ定義。CORS 設定、セッション取得ミドルウェア、ルートマウント、SPA 静的ファイル配信
-- `src/routes/tasks.ts` — タスク CRUD (`GET /api/tasks?year&month`, `POST`, `PATCH /:id`, `DELETE /:id`)。認証ミドルウェアで保護
+- `src/routes/tasks.ts` — タスク CRUD (`GET /api/tasks?year&month`, 終了日を含む最大42日間の `GET /api/tasks/range?startDate&endDate`, `POST`, `PATCH /:id`, `DELETE /:id`)。認証ミドルウェアで保護
 - `src/auth.ts` — better-auth 設定 (Drizzle アダプタ、Bearer トークンプラグイン)
 - `src/db/schema.ts` — Drizzle スキーマ定義 (users, tasks, sessions, accounts, verifications)
 - `src/db/index.ts` — DB コネクション (シングルトン)
@@ -108,6 +109,7 @@ Vite dev server が `/api` を `http://localhost:3000` にプロキシ。
 ## 環境変数
 
 `apps/api/.env` に設定（`.env.example` 参照）：
+
 - `DATABASE_URL` — PostgreSQL 接続文字列
 - `CORS_ORIGIN` — 許可オリジン
 - `BETTER_AUTH_SECRET` — 認証シークレット

--- a/apps/api/src/routes/tasks.test.ts
+++ b/apps/api/src/routes/tasks.test.ts
@@ -227,6 +227,19 @@ describe("GET /api/tasks/range", () => {
     expect(mockSelect).not.toHaveBeenCalled();
   });
 
+  it("取得範囲が42日を超える場合 400 を返す", async () => {
+    const app = await createTestApp();
+    const res = await app.request(
+      jsonRequest(
+        "GET",
+        "/api/tasks/range?startDate=2026-02-23&endDate=2026-04-06",
+      ),
+    );
+
+    expect(res.status).toBe(400);
+    expect(mockSelect).not.toHaveBeenCalled();
+  });
+
   it("日付が不正な場合 400 を返す", async () => {
     const app = await createTestApp();
     const res = await app.request(

--- a/apps/api/src/routes/tasks.test.ts
+++ b/apps/api/src/routes/tasks.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Hono } from "hono";
+import type { SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
 import type { Auth } from "../auth.js";
 
 type AuthVariables = {
@@ -41,6 +43,10 @@ const mockUnscheduledTask = {
 
 // DB モック
 const mockSelect = vi.fn();
+const mockWhere = vi.fn((condition: SQL) => {
+  void condition;
+  return { orderBy: mockSelect };
+});
 const mockInsert = vi.fn();
 const mockUpdate = vi.fn();
 const mockDelete = vi.fn();
@@ -49,9 +55,7 @@ vi.mock("../db/index.js", () => ({
   getDb: () => ({
     select: () => ({
       from: () => ({
-        where: () => ({
-          orderBy: mockSelect,
-        }),
+        where: mockWhere,
       }),
     }),
     insert: () => ({
@@ -144,6 +148,8 @@ describe("GET /api/tasks", () => {
     expect(json[0].title).toBe("テストタスク");
     expect(json[0].id).toBe(mockTask.id);
     expect(mockSelect).toHaveBeenCalled();
+    const query = new PgDialect().sqlToQuery(mockWhere.mock.calls[0][0]);
+    expect(query.params).toEqual([mockUser.id, "2026-03-01", "2026-04-01"]);
   });
 
   it("year が未指定の場合 400 を返す", async () => {
@@ -164,6 +170,74 @@ describe("GET /api/tasks", () => {
       jsonRequest("GET", "/api/tasks?year=2026&month=13"),
     );
     expect(res.status).toBe(400);
+  });
+
+  it("日付範囲パラメータだけでは月単位取得として扱わない", async () => {
+    const app = await createTestApp();
+    const res = await app.request(
+      jsonRequest("GET", "/api/tasks?startDate=2026-02-23&endDate=2026-04-05"),
+    );
+
+    expect(res.status).toBe(400);
+    expect(mockSelect).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/tasks/range", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("開始日から終了日までのタスク一覧を取得できる", async () => {
+    const adjacentMonthTask = {
+      ...mockTask,
+      id: "770e8400-e29b-41d4-a716-446655440002",
+      title: "翌月のタスク",
+      date: "2026-04-05",
+    };
+    mockSelect.mockResolvedValue([mockTask, adjacentMonthTask]);
+    const app = await createTestApp();
+
+    const res = await app.request(
+      jsonRequest(
+        "GET",
+        "/api/tasks/range?startDate=2026-02-23&endDate=2026-04-05",
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as (typeof mockTask)[];
+    expect(json.map((task) => task.date)).toEqual(["2026-03-15", "2026-04-05"]);
+    expect(mockSelect).toHaveBeenCalledOnce();
+    const query = new PgDialect().sqlToQuery(mockWhere.mock.calls[0][0]);
+    expect(query.params).toEqual([mockUser.id, "2026-02-23", "2026-04-05"]);
+    expect(query.sql).toContain('"tasks"."date" <= $3');
+  });
+
+  it("開始日が終了日より後の場合 400 を返す", async () => {
+    const app = await createTestApp();
+    const res = await app.request(
+      jsonRequest(
+        "GET",
+        "/api/tasks/range?startDate=2026-04-05&endDate=2026-02-23",
+      ),
+    );
+
+    expect(res.status).toBe(400);
+    expect(mockSelect).not.toHaveBeenCalled();
+  });
+
+  it("日付が不正な場合 400 を返す", async () => {
+    const app = await createTestApp();
+    const res = await app.request(
+      jsonRequest(
+        "GET",
+        "/api/tasks/range?startDate=invalid&endDate=2026-04-05",
+      ),
+    );
+
+    expect(res.status).toBe(400);
+    expect(mockSelect).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import { z } from "zod";
 import { zValidator } from "@hono/zod-validator";
-import { eq, and, gte, lt, asc, isNull } from "drizzle-orm";
+import { eq, and, gte, lt, lte, asc, isNull } from "drizzle-orm";
 import { getDb } from "../db/index.js";
 import { categories, tasks } from "../db/schema.js";
 import type { Auth } from "../auth.js";
@@ -40,6 +40,15 @@ const listQuerySchema = z.object({
   month: z.coerce.number().int().min(1).max(12),
 });
 
+const rangeQuerySchema = z
+  .object({
+    startDate: z.string().date(),
+    endDate: z.string().date(),
+  })
+  .refine(({ startDate, endDate }) => startDate <= endDate, {
+    message: "開始日は終了日以前の日付を指定してください",
+  });
+
 const paramIdSchema = z.object({
   id: z.string().uuid("不正なタスクIDです"),
 });
@@ -71,6 +80,25 @@ const app = new Hono<{ Variables: AuthVariables }>()
           eq(tasks.userId, user.id),
           gte(tasks.date, startDate),
           lt(tasks.date, endDate),
+        ),
+      )
+      .orderBy(asc(tasks.status), asc(tasks.createdAt));
+
+    return c.json(result);
+  })
+  // GET /api/tasks/range?startDate=YYYY-MM-DD&endDate=YYYY-MM-DD
+  .get("/range", zValidator("query", rangeQuerySchema), async (c) => {
+    const user = c.get("user")!;
+    const { startDate, endDate } = c.req.valid("query");
+
+    const result = await getDb()
+      .select()
+      .from(tasks)
+      .where(
+        and(
+          eq(tasks.userId, user.id),
+          gte(tasks.date, startDate),
+          lte(tasks.date, endDate),
         ),
       )
       .orderBy(asc(tasks.status), asc(tasks.createdAt));

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -40,14 +40,28 @@ const listQuerySchema = z.object({
   month: z.coerce.number().int().min(1).max(12),
 });
 
+const MAX_TASK_RANGE_DAYS = 42;
+
 const rangeQuerySchema = z
   .object({
-    startDate: z.string().date(),
-    endDate: z.string().date(),
+    startDate: z
+      .string()
+      .date("開始日はYYYY-MM-DD形式の実在する日付で指定してください"),
+    endDate: z
+      .string()
+      .date("終了日はYYYY-MM-DD形式の実在する日付で指定してください"),
   })
   .refine(({ startDate, endDate }) => startDate <= endDate, {
     message: "開始日は終了日以前の日付を指定してください",
-  });
+  })
+  .refine(
+    ({ startDate, endDate }) =>
+      Date.parse(endDate) - Date.parse(startDate) <
+      MAX_TASK_RANGE_DAYS * 24 * 60 * 60 * 1000,
+    {
+      message: `取得範囲は${MAX_TASK_RANGE_DAYS}日以内で指定してください`,
+    },
+  );
 
 const paramIdSchema = z.object({
   id: z.string().uuid("不正なタスクIDです"),

--- a/apps/web/src/api/tasks.ts
+++ b/apps/web/src/api/tasks.ts
@@ -1,7 +1,7 @@
 import type { InferResponseType } from "hono/client";
 import { client } from "./client";
 
-type Task = InferResponseType<typeof client.api.tasks.$get, 200>[number];
+type Task = InferResponseType<typeof client.api.tasks.range.$get, 200>[number];
 
 export type { Task };
 

--- a/apps/web/src/api/tasks.ts
+++ b/apps/web/src/api/tasks.ts
@@ -6,12 +6,12 @@ type Task = InferResponseType<typeof client.api.tasks.$get, 200>[number];
 export type { Task };
 
 export async function fetchTasks(
-  year: number,
-  month: number,
+  startDate: string,
+  endDate: string,
   signal?: AbortSignal,
 ): Promise<Task[]> {
-  const res = await client.api.tasks.$get(
-    { query: { year: String(year), month: String(month) } },
+  const res = await client.api.tasks.range.$get(
+    { query: { startDate, endDate } },
     { init: { signal } },
   );
   if (!res.ok) {

--- a/apps/web/src/components/Calendar.test.tsx
+++ b/apps/web/src/components/Calendar.test.tsx
@@ -92,6 +92,24 @@ const mockUnscheduledTask = {
   updatedAt: "2026-01-01T00:00:00.000Z",
 };
 
+function formatDate(date: Date) {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+}
+
+function getDisplayedRange(year: number, month: number) {
+  const firstDay = new Date(year, month - 1, 1);
+  const mondayOffset = (firstDay.getDay() + 6) % 7;
+  const start = new Date(year, month - 1, 1 - mondayOffset);
+  const end = new Date(start);
+  end.setDate(end.getDate() + 41);
+  return { start, end };
+}
+
+function getAdjacentDate(year: number, month: number) {
+  const { start, end } = getDisplayedRange(year, month);
+  return start.getMonth() !== month - 1 ? start : end;
+}
+
 describe("Calendar", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -123,11 +141,100 @@ describe("Calendar", () => {
       expect(screen.getByText("テストタスク")).toBeInTheDocument();
     });
 
+    const now = new Date();
+    const { start, end } = getDisplayedRange(
+      now.getFullYear(),
+      now.getMonth() + 1,
+    );
+
     expect(mockFetchTasks).toHaveBeenCalledWith(
-      expect.any(Number),
-      expect.any(Number),
+      formatDate(start),
+      formatDate(end),
       expect.any(AbortSignal),
     );
+  });
+
+  it("前後月セルのタスクを表示し、クリックして詳細を開ける", async () => {
+    const now = new Date();
+    const adjacentDate = getAdjacentDate(now.getFullYear(), now.getMonth() + 1);
+    const dateKey = formatDate(adjacentDate);
+    const adjacentTask = {
+      ...mockTask,
+      id: "adjacent-task",
+      title: "前後月のタスク",
+      date: dateKey,
+    };
+    mockFetchTasks.mockResolvedValue([adjacentTask]);
+
+    const user = userEvent.setup();
+    renderWithQueryClient(<Calendar />);
+
+    await user.click(await screen.findByText("前後月のタスク"));
+
+    expect(screen.getByText("タスクの詳細")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("前後月のタスク")).toBeInTheDocument();
+  });
+
+  it("前後月セルのタスクを完了へ切り替えられる", async () => {
+    const now = new Date();
+    const adjacentTask = {
+      ...mockTask,
+      id: "adjacent-task",
+      title: "前後月のタスク",
+      date: formatDate(getAdjacentDate(now.getFullYear(), now.getMonth() + 1)),
+    };
+    mockFetchTasks.mockResolvedValue([adjacentTask]);
+    mockUpdateTask.mockResolvedValue({ ...adjacentTask, status: "done" });
+
+    const user = userEvent.setup();
+    renderWithQueryClient(<Calendar />);
+
+    await user.click(await screen.findByRole("checkbox"));
+
+    await waitFor(() => {
+      expect(mockUpdateTask).toHaveBeenCalledWith(adjacentTask.id, {
+        status: "done",
+      });
+    });
+  });
+
+  it("前後月セルのタスクを詳細から編集・削除できる", async () => {
+    const now = new Date();
+    const adjacentTask = {
+      ...mockTask,
+      id: "adjacent-task",
+      title: "前後月のタスク",
+      date: formatDate(getAdjacentDate(now.getFullYear(), now.getMonth() + 1)),
+    };
+    mockFetchTasks.mockResolvedValue([adjacentTask]);
+    mockUpdateTask.mockResolvedValue({
+      ...adjacentTask,
+      title: "更新した前後月タスク",
+    });
+    mockDeleteTask.mockResolvedValue(undefined);
+
+    const user = userEvent.setup();
+    renderWithQueryClient(<Calendar />);
+
+    await user.click(await screen.findByText("前後月のタスク"));
+    const titleInput = screen.getByLabelText(/タイトル/);
+    await user.clear(titleInput);
+    await user.type(titleInput, "更新した前後月タスク");
+    await user.click(screen.getByText("保存"));
+
+    await waitFor(() => {
+      expect(mockUpdateTask).toHaveBeenCalledWith(
+        adjacentTask.id,
+        expect.objectContaining({ title: "更新した前後月タスク" }),
+      );
+    });
+
+    await user.click(await screen.findByText("前後月のタスク"));
+    await user.click(screen.getByText("削除"));
+
+    await waitFor(() => {
+      expect(mockDeleteTask).toHaveBeenCalledWith(adjacentTask.id);
+    });
   });
 
   it("前月・次月ボタンで月を切り替えられる", async () => {
@@ -161,6 +268,37 @@ describe("Calendar", () => {
       expect(
         screen.getByText(`${currentYear}年${currentMonth}月`),
       ).toBeInTheDocument();
+    });
+  });
+
+  it("月移動ごとに表示範囲を含む別の条件でタスクを取得する", async () => {
+    const user = userEvent.setup();
+    renderWithQueryClient(<Calendar />);
+
+    const now = new Date();
+    const currentYear = now.getFullYear();
+    const currentMonth = now.getMonth() + 1;
+    const nextYear = currentMonth === 12 ? currentYear + 1 : currentYear;
+    const nextMonth = currentMonth === 12 ? 1 : currentMonth + 1;
+    const currentRange = getDisplayedRange(currentYear, currentMonth);
+    const nextRange = getDisplayedRange(nextYear, nextMonth);
+
+    await waitFor(() => {
+      expect(mockFetchTasks).toHaveBeenCalledWith(
+        formatDate(currentRange.start),
+        formatDate(currentRange.end),
+        expect.any(AbortSignal),
+      );
+    });
+
+    await user.click(screen.getByText("→"));
+
+    await waitFor(() => {
+      expect(mockFetchTasks).toHaveBeenCalledWith(
+        formatDate(nextRange.start),
+        formatDate(nextRange.end),
+        expect.any(AbortSignal),
+      );
     });
   });
 
@@ -368,6 +506,33 @@ describe("Calendar", () => {
       expect(mockUpdateTask).toHaveBeenCalledWith(mockTask.id, {
         date: "2026-03-20",
       });
+    });
+  });
+
+  it("前後月セルへドラッグするとタスクの日付と表示が更新される", async () => {
+    const now = new Date();
+    const targetDate = formatDate(
+      getAdjacentDate(now.getFullYear(), now.getMonth() + 1),
+    );
+    mockFetchTasks.mockResolvedValue([mockTask]);
+    mockUpdateTask.mockResolvedValue({ ...mockTask, date: targetDate });
+
+    renderWithQueryClient(<Calendar />);
+    await screen.findByText("テストタスク");
+
+    capturedOnDragEnd!({
+      active: { id: mockTask.id, data: { current: { task: mockTask } } },
+      over: { id: targetDate },
+    });
+
+    await waitFor(() => {
+      expect(mockUpdateTask).toHaveBeenCalledWith(mockTask.id, {
+        date: targetDate,
+      });
+      expect(
+        screen.getByRole("button", { name: `${targetDate}にタスクを追加` })
+          .parentElement,
+      ).toHaveTextContent("テストタスク");
     });
   });
 

--- a/apps/web/src/components/Calendar.test.tsx
+++ b/apps/web/src/components/Calendar.test.tsx
@@ -169,7 +169,9 @@ describe("Calendar", () => {
     const user = userEvent.setup();
     renderWithQueryClient(<Calendar />);
 
-    await user.click(await screen.findByText("前後月のタスク"));
+    const task = await screen.findByText("前後月のタスク");
+    expect(task.closest("div")).toHaveClass("opacity-70");
+    await user.click(task);
 
     expect(screen.getByText("タスクの詳細")).toBeInTheDocument();
     expect(screen.getByDisplayValue("前後月のタスク")).toBeInTheDocument();

--- a/apps/web/src/components/Calendar.test.tsx
+++ b/apps/web/src/components/Calendar.test.tsx
@@ -170,11 +170,20 @@ describe("Calendar", () => {
     renderWithQueryClient(<Calendar />);
 
     const task = await screen.findByText("前後月のタスク");
-    expect(task.closest("div")).toHaveClass("opacity-70");
+    expect(task.closest("div")).toHaveClass("brightness-95", "saturate-75");
     await user.click(task);
 
     expect(screen.getByText("タスクの詳細")).toBeInTheDocument();
     expect(screen.getByDisplayValue("前後月のタスク")).toBeInTheDocument();
+  });
+
+  it("当月セルのタスクは減光しない", async () => {
+    mockFetchTasks.mockResolvedValue([mockTask]);
+    renderWithQueryClient(<Calendar />);
+
+    const task = await screen.findByText("テストタスク");
+
+    expect(task.closest("div")).not.toHaveClass("brightness-95", "saturate-75");
   });
 
   it("前後月セルのタスクを完了へ切り替えられる", async () => {

--- a/apps/web/src/components/CalendarDayCell.tsx
+++ b/apps/web/src/components/CalendarDayCell.tsx
@@ -85,6 +85,7 @@ export function CalendarDayCell({
                 ? (categoryMap.get(task.categoryId) ?? null)
                 : null
             }
+            muted={!isCurrentMonth}
             onTaskClick={onTaskClick}
             onToggleStatus={onToggleStatus}
           />

--- a/apps/web/src/components/DraggableTask.tsx
+++ b/apps/web/src/components/DraggableTask.tsx
@@ -6,6 +6,7 @@ import { CATEGORY_COLORS } from "../constants/categoryColors";
 type DraggableTaskProps = {
   task: Task;
   category: Category | null;
+  muted?: boolean;
   onTaskClick: (task: Task) => void;
   onToggleStatus: (task: Task) => void;
 };
@@ -13,6 +14,7 @@ type DraggableTaskProps = {
 export function DraggableTask({
   task,
   category,
+  muted = false,
   onTaskClick,
   onToggleStatus,
 }: DraggableTaskProps) {
@@ -31,7 +33,7 @@ export function DraggableTask({
         e.stopPropagation();
         onTaskClick(task);
       }}
-      className={`flex items-center gap-1 rounded px-1 py-0 text-xs leading-tight h-[2rem] touch-none ${isDragging ? "cursor-grabbing" : "cursor-pointer"} ${
+      className={`flex items-center gap-1 rounded px-1 py-0 text-xs leading-tight h-[2rem] touch-none ${muted ? "opacity-70" : ""} ${isDragging ? "cursor-grabbing" : "cursor-pointer"} ${
         isDragging
           ? "border border-dashed border-border bg-surface text-transparent [&_input]:invisible"
           : task.status === "done"

--- a/apps/web/src/components/DraggableTask.tsx
+++ b/apps/web/src/components/DraggableTask.tsx
@@ -33,7 +33,7 @@ export function DraggableTask({
         e.stopPropagation();
         onTaskClick(task);
       }}
-      className={`flex items-center gap-1 rounded px-1 py-0 text-xs leading-tight h-[2rem] touch-none ${muted ? "opacity-70" : ""} ${isDragging ? "cursor-grabbing" : "cursor-pointer"} ${
+      className={`flex items-center gap-1 rounded px-1 py-0 text-xs leading-tight h-[2rem] touch-none ${muted ? "brightness-95 saturate-75" : ""} ${isDragging ? "cursor-grabbing" : "cursor-pointer"} ${
         isDragging
           ? "border border-dashed border-border bg-surface text-transparent [&_input]:invisible"
           : task.status === "done"

--- a/apps/web/src/hooks/useTasks.ts
+++ b/apps/web/src/hooks/useTasks.ts
@@ -8,17 +8,28 @@ import {
   updateTask,
   deleteTask,
 } from "../api/tasks";
+import { formatDateKey, getCalendarDays } from "../utils/calendar";
 
-function tasksQueryKey(year: number, month: number) {
-  return ["tasks", year, month] as const;
+function getTaskDateRange(year: number, month: number) {
+  const days = getCalendarDays(year, month);
+  return {
+    startDate: formatDateKey(days[0].date),
+    endDate: formatDateKey(days[days.length - 1].date),
+  };
+}
+
+function tasksQueryKey(startDate: string, endDate: string) {
+  return ["tasks", "range", startDate, endDate] as const;
 }
 
 const unscheduledTasksQueryKey = ["tasks", "unscheduled"] as const;
 
 export function useTasks(year: number, month: number) {
+  const { startDate, endDate } = getTaskDateRange(year, month);
+
   return useQuery({
-    queryKey: tasksQueryKey(year, month),
-    queryFn: ({ signal }) => fetchTasks(year, month, signal),
+    queryKey: tasksQueryKey(startDate, endDate),
+    queryFn: ({ signal }) => fetchTasks(startDate, endDate, signal),
   });
 }
 
@@ -31,7 +42,8 @@ export function useUnscheduledTasks() {
 
 export function useCreateTask(year: number, month: number) {
   const queryClient = useQueryClient();
-  const key = tasksQueryKey(year, month);
+  const { startDate, endDate } = getTaskDateRange(year, month);
+  const key = tasksQueryKey(startDate, endDate);
 
   return useMutation({
     mutationFn: (data: {
@@ -70,17 +82,15 @@ export function useCreateTask(year: number, month: number) {
       toast.error("タスクの作成に失敗しました");
     },
     onSettled: () => {
-      void queryClient.invalidateQueries({ queryKey: key });
-      void queryClient.invalidateQueries({
-        queryKey: unscheduledTasksQueryKey,
-      });
+      void queryClient.invalidateQueries({ queryKey: ["tasks"] });
     },
   });
 }
 
 export function useUpdateTask(year: number, month: number) {
   const queryClient = useQueryClient();
-  const key = tasksQueryKey(year, month);
+  const { startDate, endDate } = getTaskDateRange(year, month);
+  const key = tasksQueryKey(startDate, endDate);
 
   return useMutation({
     mutationFn: ({
@@ -115,17 +125,15 @@ export function useUpdateTask(year: number, month: number) {
       toast.error("タスクの更新に失敗しました");
     },
     onSettled: () => {
-      void queryClient.invalidateQueries({ queryKey: key });
-      void queryClient.invalidateQueries({
-        queryKey: unscheduledTasksQueryKey,
-      });
+      void queryClient.invalidateQueries({ queryKey: ["tasks"] });
     },
   });
 }
 
 export function useDeleteTask(year: number, month: number) {
   const queryClient = useQueryClient();
-  const key = tasksQueryKey(year, month);
+  const { startDate, endDate } = getTaskDateRange(year, month);
+  const key = tasksQueryKey(startDate, endDate);
 
   return useMutation({
     mutationFn: (id: string) => deleteTask(id),
@@ -158,7 +166,9 @@ export function useDeleteTask(year: number, month: number) {
                 categoryId: deletedTask.categoryId,
               })
                 .then(() => {
-                  void queryClient.invalidateQueries({ queryKey: key });
+                  void queryClient.invalidateQueries({
+                    queryKey: ["tasks"],
+                  });
                 })
                 .catch(() => {
                   toast.error("タスクの復元に失敗しました");
@@ -176,10 +186,7 @@ export function useDeleteTask(year: number, month: number) {
       toast.error("タスクの削除に失敗しました");
     },
     onSettled: () => {
-      void queryClient.invalidateQueries({ queryKey: key });
-      void queryClient.invalidateQueries({
-        queryKey: unscheduledTasksQueryKey,
-      });
+      void queryClient.invalidateQueries({ queryKey: ["tasks"] });
     },
   });
 }


### PR DESCRIPTION
close #247

## 目的

月間カレンダーに表示される42日間を対象にタスクを取得し、前月・翌月の日付セルでもタスクの表示と操作を可能にします。

## 変更内容

- `apps/api` に開始日・終了日を指定する最大42日間の日付範囲取得 API を追加
- 既存の `year` / `month` による月単位取得仕様を維持
- `apps/web` で42セルの先頭日・末尾日を取得条件と React Query の query key に使用
- 前後月セルのタスクを、文字のコントラストを保ちながら少し減光して表示
- タスク変更後に関連するタスクキャッシュを再検証し、月移動時の古い状態を防止
- API の範囲条件と、前後月セルでの表示・詳細・完了切替・編集・削除・ドラッグ移動のテストを追加

## 影響範囲

- `apps/api/src/routes/tasks.ts`
- `apps/web/src/api/tasks.ts`
- `apps/web/src/hooks/useTasks.ts`
- `apps/web/src/components/CalendarDayCell.tsx`
- `apps/web/src/components/DraggableTask.tsx`
- API / Web の関連テスト

CLI・Mobile の月別取得仕様および未スケジュールタスク API は変更していません。

## ローカル検証

- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm knip`