### PR TITLE
Vercel custom container の試験設定と評価結果を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 *.log
 .DS_Store
 *.tsbuildinfo
+.vercel

--- a/Dockerfile.vercel
+++ b/Dockerfile.vercel
@@ -1,0 +1,44 @@
+FROM node:24-slim AS base
+RUN corepack enable pnpm
+
+# --- Web build ---
+FROM base AS web-build
+WORKDIR /app
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+COPY apps/web/package.json apps/web/package.json
+COPY apps/api/package.json apps/api/package.json
+COPY apps/cli/package.json apps/cli/package.json
+RUN pnpm install --frozen-lockfile
+COPY tsconfig.json ./
+COPY apps/api/tsconfig.json apps/api/tsconfig.json
+COPY apps/api/src/ apps/api/src/
+COPY apps/web/ apps/web/
+RUN pnpm --filter @tascal/web run build
+
+# --- API build ---
+FROM base AS api-build
+WORKDIR /app
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+COPY apps/api/package.json apps/api/package.json
+COPY apps/web/package.json apps/web/package.json
+COPY apps/cli/package.json apps/cli/package.json
+RUN pnpm install --frozen-lockfile
+COPY tsconfig.json ./
+COPY apps/api/ apps/api/
+RUN pnpm --filter @tascal/api run build
+RUN pnpm deploy --filter @tascal/api --legacy --prod /app/api-deploy
+
+# --- Production ---
+FROM base AS production
+WORKDIR /app
+
+COPY --from=api-build /app/api-deploy ./
+COPY --from=api-build /app/apps/api/dist ./dist
+COPY --from=web-build /app/apps/web/dist ./public
+COPY --from=api-build /app/apps/api/drizzle ./drizzle
+
+# Vercel injects PORT (80 by default) at runtime.
+EXPOSE 80
+ENV NODE_ENV=production
+
+CMD ["node", "dist/src/index.js"]

--- a/README.md
+++ b/README.md
@@ -47,3 +47,6 @@ tascal category edit <id>  # カテゴリ編集
 tascal category delete <id>  # カテゴリ削除
 ```
 
+## デプロイ評価
+
+- [Vercel custom container 評価](docs/vercel-container-evaluation.md)

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -57,6 +57,15 @@ tascal-cli logout
 | `delete`   | タスクを削除する                         |
 | `category` | カテゴリを管理する (一覧/追加/編集/削除) |
 
+## 環境変数
+
+| 変数                 | 説明                                                           |
+| -------------------- | -------------------------------------------------------------- |
+| `TASCAL_API_URL`     | 接続する API のベース URL（既定: `https://tascal.dev`）        |
+| `TASCAL_CONFIG_PATH` | token と API URL を保存する設定ファイル（既定: `~/.tascalrc`） |
+
+preview 環境を試す場合は両方を指定すると、production の設定を上書きせずに利用できる。
+
 ## ライセンス
 
 MIT

--- a/apps/cli/src/config.test.ts
+++ b/apps/cli/src/config.test.ts
@@ -19,6 +19,7 @@ const mockedUnlink = vi.mocked(unlink);
 
 beforeEach(() => {
   vi.resetAllMocks();
+  delete process.env.TASCAL_CONFIG_PATH;
 });
 
 describe("readConfig", () => {
@@ -46,6 +47,18 @@ describe("readConfig", () => {
     expect(config).toEqual({});
   });
 
+  it("TASCAL_CONFIG_PATH が設定されている場合、そのファイルを読む", async () => {
+    process.env.TASCAL_CONFIG_PATH = "/tmp/tascal-preview-config";
+    mockedReadFile.mockResolvedValue(JSON.stringify({ token: "preview" }));
+
+    await readConfig();
+
+    expect(mockedReadFile).toHaveBeenCalledWith(
+      "/tmp/tascal-preview-config",
+      "utf-8",
+    );
+  });
+
   it("パースエラー時に例外をスローする", async () => {
     mockedReadFile.mockResolvedValue("invalid json");
 
@@ -62,6 +75,19 @@ describe("writeConfig", () => {
     expect(mockedWriteFile).toHaveBeenCalledWith(
       "/mock-home/.tascalrc",
       JSON.stringify({ token: "abc" }, null, 2) + "\n",
+      { encoding: "utf-8", mode: 0o600 },
+    );
+  });
+
+  it("TASCAL_CONFIG_PATH が設定されている場合、そのファイルに書く", async () => {
+    process.env.TASCAL_CONFIG_PATH = "/tmp/tascal-preview-config";
+    mockedWriteFile.mockResolvedValue();
+
+    await writeConfig({ token: "preview" });
+
+    expect(mockedWriteFile).toHaveBeenCalledWith(
+      "/tmp/tascal-preview-config",
+      JSON.stringify({ token: "preview" }, null, 2) + "\n",
       { encoding: "utf-8", mode: 0o600 },
     );
   });

--- a/apps/cli/src/config.test.ts
+++ b/apps/cli/src/config.test.ts
@@ -102,6 +102,15 @@ describe("deleteConfig", () => {
     expect(mockedUnlink).toHaveBeenCalledWith("/mock-home/.tascalrc");
   });
 
+  it("TASCAL_CONFIG_PATH が設定されている場合、そのファイルを削除する", async () => {
+    process.env.TASCAL_CONFIG_PATH = "/tmp/tascal-preview-config";
+    mockedUnlink.mockResolvedValue();
+
+    await deleteConfig();
+
+    expect(mockedUnlink).toHaveBeenCalledWith("/tmp/tascal-preview-config");
+  });
+
   it("ファイルが存在しない場合（ENOENT）、エラーなくスキップする", async () => {
     const err = new Error("ENOENT") as NodeJS.ErrnoException;
     err.code = "ENOENT";

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -2,8 +2,6 @@ import { readFile, writeFile, unlink } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-const CONFIG_PATH = join(homedir(), ".tascalrc");
-
 const DEFAULT_API_URL = "https://tascal.dev";
 
 interface Config {
@@ -11,9 +9,13 @@ interface Config {
   apiUrl?: string;
 }
 
+function getConfigPath(): string {
+  return process.env.TASCAL_CONFIG_PATH ?? join(homedir(), ".tascalrc");
+}
+
 export async function readConfig(): Promise<Config> {
   try {
-    const content = await readFile(CONFIG_PATH, "utf-8");
+    const content = await readFile(getConfigPath(), "utf-8");
     return JSON.parse(content) as Config;
   } catch (err) {
     if (err instanceof Error && "code" in err && err.code === "ENOENT") {
@@ -24,7 +26,7 @@ export async function readConfig(): Promise<Config> {
 }
 
 export async function writeConfig(config: Config): Promise<void> {
-  await writeFile(CONFIG_PATH, JSON.stringify(config, null, 2) + "\n", {
+  await writeFile(getConfigPath(), JSON.stringify(config, null, 2) + "\n", {
     encoding: "utf-8",
     mode: 0o600,
   });
@@ -32,7 +34,7 @@ export async function writeConfig(config: Config): Promise<void> {
 
 export async function deleteConfig(): Promise<void> {
   try {
-    await unlink(CONFIG_PATH);
+    await unlink(getConfigPath());
   } catch (err) {
     if (err instanceof Error && "code" in err && err.code === "ENOENT") {
       return;

--- a/docs/vercel-container-evaluation.md
+++ b/docs/vercel-container-evaluation.md
@@ -10,7 +10,7 @@ tascal の単一 container は `Dockerfile.vercel` への小さな差分だけ�
 Container Images に載せられる。一方、API と SPA が同じ origin で動く既存構成では
 Vercel Services に分割する利点は小さく、Cloud Run から移すことで新たに得られる機能より、
 Function の実行時間・メモリ・ネットワーク制約、preview URL ごとの auth 設定、
-CLI/mobile の API URL 管理が増える影響の方が大きい。
+既存の Cloud Run 向けログ・運用基盤を変更する影響の方が大きい。
 
 Vercel の immutable preview URL と Git 連携が必要になった場合は、まず
 **Web preview のみ Vercel、production API / static serving は Cloud Run**
@@ -102,7 +102,9 @@ pooled connection string を、値を表示せず Vercel の sensitive environme
 CLI は `TASCAL_API_URL=<preview URL>` で接続先を、`TASCAL_CONFIG_PATH=<一時ファイル>`
 で token の保存先を切り替える。これにより `~/.tascalrc` の production URL と token を
 変更せずに試験できる。mobile は今回のスコープ外だが、全面移行時には同様に API base URL の
-切り替えが必要。
+切り替えが必要。この環境別 API URL 管理は Vercel 固有ではなく、現在の Cloud Run preview
+を CLI/mobile から利用する場合にも同様に必要となる。現状はいずれの preview も
+CLI/mobile から利用していない。
 
 ## 動作確認
 
@@ -153,7 +155,7 @@ tascal-cli add
 | logs          | stdout/stderr と Observability。保持は plan 依存                         | Cloud Logging、metrics、alerting                            | 既存運用を維持できる Cloud Run が有利               |
 | pricing       | Active CPU、provisioned memory、invocation、origin transfer、VCR storage | vCPU、memory、request、network。request-based free tierあり | 実トラフィックでの比較が必要                        |
 | auth/origin   | deploy URL 変化に合わせ trusted origin の運用が必要                      | `tascal.dev` の固定 origin                                  | Cloud Run が単純                                    |
-| CLI/mobile    | preview の API URL を別管理                                              | production URL を継続利用                                   | Cloud Run が単純                                    |
+| CLI/mobile    | preview で使う場合は API URL を別管理                                    | preview で使う場合は API URL を別管理                       | 差なし                                              |
 
 ## 実測値
 

--- a/docs/vercel-container-evaluation.md
+++ b/docs/vercel-container-evaluation.md
@@ -1,0 +1,151 @@
+# Vercel custom container 評価
+
+評価日: 2026-07-25
+
+## 結論
+
+現時点では **Cloud Run 継続**を推奨する。
+
+tascal の単一 container は `Dockerfile.vercel` への小さな差分だけで Vercel
+Container Images に載せられる。一方、API と SPA が同じ origin で動く既存構成では
+Vercel Services に分割する利点は小さく、Cloud Run から移すことで新たに得られる機能より、
+Function の実行時間・メモリ・ネットワーク制約、preview URL ごとの auth 設定、
+CLI/mobile の API URL 管理が増える影響の方が大きい。
+
+Vercel の immutable preview URL と Git 連携が必要になった場合は、まず
+**Web preview のみ Vercel、production API / static serving は Cloud Run**
+というハイブリッド構成を別 issue で検証する。production の全面移行は、
+container image 機能の運用実績が蓄積し、Cloud Run と比較した実測コストが有利になってから
+再評価する。
+
+## 試験設定
+
+リポジトリ直下の [`Dockerfile.vercel`](../Dockerfile.vercel) を使う。
+Vercel はこのファイルを自動検出し、全リクエストを container function にルーティングするため、
+単一 container 構成では `vercel.json` や Services 設定は不要。
+
+既存 `Dockerfile` との差分は runtime の port のみ。
+
+- Cloud Run: image 内の既定値として `PORT=8080`
+- Vercel: platform が注入する `PORT` を使用（未指定時は `80`）
+
+ローカル確認:
+
+```bash
+docker build -f Dockerfile.vercel -t tascal-vercel-eval .
+docker run --rm -p 8080:80 \
+  --env-file apps/api/.env \
+  -e PORT=80 \
+  tascal-vercel-eval
+curl http://localhost:8080/healthz
+```
+
+Vercel CLI での試験 deploy:
+
+```bash
+npx vercel@latest link
+npx vercel@latest env add DATABASE_URL preview
+npx vercel@latest env add BETTER_AUTH_SECRET preview
+npx vercel@latest env add BETTER_AUTH_URL preview
+npx vercel@latest env add TRUSTED_ORIGINS preview
+npx vercel@latest env add CORS_ORIGIN preview
+npx vercel@latest deploy
+```
+
+`BETTER_AUTH_URL`、`TRUSTED_ORIGINS`、`CORS_ORIGIN` には同じ preview URL を設定する。
+Vercel が deploy ごとに生成する URL は変わるため、継続的な preview 運用では
+固定 alias または preview 用 custom domain を用意し、その origin を環境変数へ設定する。
+
+## 環境変数と接続
+
+| 変数                 | Preview での設定                                        | 理由                                                     |
+| -------------------- | ------------------------------------------------------- | -------------------------------------------------------- |
+| `DATABASE_URL`       | Neon の preview 専用 branch の pooled connection string | 短時間に instance が増えても接続数を抑える               |
+| `BETTER_AUTH_SECRET` | Vercel の encrypted environment variable                | Cloud Run と同じ secret を使う場合も平文で commit しない |
+| `BETTER_AUTH_URL`    | 固定した HTTPS preview origin                           | auth endpoint と cookie の基準 URL                       |
+| `TRUSTED_ORIGINS`    | Web の preview origin。複数ならカンマ区切り             | better-auth の origin 検証                               |
+| `CORS_ORIGIN`        | Web と API が同一 origin なら同じ preview origin        | cookie を伴う API request を許可                         |
+| `LOG_LEVEL`          | `info`                                                  | runtime logs の量を抑える                                |
+
+現在の Web/API は同一 container・同一 origin なので cookie domain の明示設定は不要。
+ホスト専用 cookie のまま preview URL ごとに分離される。production の `tascal.dev`
+cookie は preview URL へ送信されない。
+
+migration は container 起動時に実行しない。deploy 前に `DATABASE_URL` を指定して
+`pnpm db:migrate` を一度実行し、複数 instance からの重複実行を避ける。
+`GET /healthz` は Neon に `SELECT 1` を実行するため、起動確認と DB 疎通確認を兼ねる。
+
+CLI は `TASCAL_API_URL=<preview URL>` で接続先を、`TASCAL_CONFIG_PATH=<一時ファイル>`
+で token の保存先を切り替える。これにより `~/.tascalrc` の production URL と token を
+変更せずに試験できる。mobile は今回のスコープ外だが、全面移行時には同様に API base URL の
+切り替えが必要。
+
+## 動作確認
+
+試験 URL: デプロイ後に記録する
+
+### Web
+
+- [ ] ログイン
+- [ ] タスク作成
+- [ ] タスク更新
+- [ ] タスク削除
+
+### CLI
+
+production 用 `~/.tascalrc` を上書きしないよう、試験用の一時設定ファイルで実行する。
+
+```bash
+export TASCAL_API_URL=<preview URL>
+export TASCAL_CONFIG_PATH=/tmp/tascal-vercel-preview.json
+tascal-cli login
+tascal-cli list
+tascal-cli add
+```
+
+- [ ] ログイン
+- [ ] タスク一覧
+- [ ] タスク作成
+
+### 運用確認
+
+- [ ] `GET /healthz` が `200 {"status":"ok"}` を返す
+- [ ] Vercel runtime logs で起動・API request log を確認できる
+- [ ] preview が scale-to-zero した後の初回応答時間を計測する
+
+## Cloud Run との比較
+
+| 観点          | Vercel custom container                                                  | Cloud Run                                                   | 評価                                                |
+| ------------- | ------------------------------------------------------------------------ | ----------------------------------------------------------- | --------------------------------------------------- |
+| deploy        | `Dockerfile.vercel` を自動 build・VCR 保存・preview URL 発行             | Artifact Registry build と service deploy                   | Preview UX は Vercel が有利                         |
+| scale-to-zero | Preview は無通信 30 秒、production は 5 分で scale down                  | min instances 0 で scale-to-zero                            | 両方可能。Vercel preview は cold start が起きやすい |
+| 実行時間      | Hobby 300 秒、Pro/Enterprise は既定 300 秒・通常最大 800 秒              | 既定 300 秒、最大 3,600 秒                                  | tascal CRUD には十分だが Cloud Run が柔軟           |
+| memory/CPU    | Hobby 2 GB/1 vCPU、Pro/Enterprise 最大 4 GB/2 vCPU                       | service 設定でより広く選択可能                              | 現状は足りるが Vercel の上限が低い                  |
+| image         | VCR は圧縮後合計 15 GB、単一 layer 500 MB                                | Artifact Registry / Cloud Run の image 制限                 | 現在の image は VCR 内に収まる                      |
+| network       | custom image は Secure Compute / Static IP 未対応                        | VPC、固定 egress 等を構成可能                               | 将来の接続制御は Cloud Run が有利                   |
+| logs          | stdout/stderr と Observability。保持は plan 依存                         | Cloud Logging、metrics、alerting                            | 既存運用を維持できる Cloud Run が有利               |
+| pricing       | Active CPU、provisioned memory、invocation、origin transfer、VCR storage | vCPU、memory、request、network。request-based free tierあり | 実トラフィックでの比較が必要                        |
+| auth/origin   | deploy URL 変化に合わせ trusted origin の運用が必要                      | `tascal.dev` の固定 origin                                  | Cloud Run が単純                                    |
+| CLI/mobile    | preview の API URL を別管理                                              | production URL を継続利用                                   | Cloud Run が単純                                    |
+
+## 実測値
+
+ローカル build（Apple Silicon、Docker）:
+
+- build 成功
+- runtime image: 426,301,468 bytes（uncompressed、arm64）
+
+Vercel の VCR 上限は圧縮 layer 単体 500 MB、圧縮後 image 合計 15 GB。
+実 deploy では Vercel が build する `linux/amd64` / `linux/arm64` image の size を
+Images 画面でも確認する。
+
+## 公式資料
+
+- [Container Images](https://vercel.com/docs/functions/container-images)
+- [Vercel Container Registry limits and pricing](https://vercel.com/docs/container-registry/limits-and-pricing)
+- [Vercel Functions limits](https://vercel.com/docs/functions/limitations)
+- [Fluid compute pricing](https://vercel.com/docs/functions/usage-and-pricing)
+- [Vercel Services](https://vercel.com/docs/services)
+- [Vercel Services pricing and limits](https://vercel.com/docs/services/pricing)
+- [Cloud Run request timeout](https://docs.cloud.google.com/run/docs/configuring/request-timeout)
+- [Cloud Run pricing](https://cloud.google.com/run/pricing)

--- a/docs/vercel-container-evaluation.md
+++ b/docs/vercel-container-evaluation.md
@@ -20,9 +20,15 @@ container image 機能の運用実績が蓄積し、Cloud Run と比較した実
 
 ## 試験設定
 
-リポジトリ直下の [`Dockerfile.vercel`](../Dockerfile.vercel) を使う。
-Vercel はこのファイルを自動検出し、全リクエストを container function にルーティングするため、
-単一 container 構成では `vercel.json` や Services 設定は不要。
+リポジトリ直下の [`Dockerfile.vercel`](../Dockerfile.vercel) と
+[`vercel.json`](../vercel.json) を使う。Vercel は Dockerfile を build し、
+全リクエストを container function にルーティングする。単一 container 構成のため
+Services 設定は不要。
+
+`vercel.json` では container framework を明示し、Function region を Tokyo (`hnd1`)
+に固定する。CLI で新規 project を作った際、Framework Preset が `Other` に固定されると
+`Dockerfile.vercel` の自動検出が無効になり、通常の `pnpm build` が実行されたためである。
+Neon と compute の region は可能な限り近づける。
 
 既存 `Dockerfile` との差分は runtime の port のみ。
 
@@ -43,18 +49,20 @@ curl http://localhost:8080/healthz
 Vercel CLI での試験 deploy:
 
 ```bash
-npx vercel@latest link
-npx vercel@latest env add DATABASE_URL preview
-npx vercel@latest env add BETTER_AUTH_SECRET preview
-npx vercel@latest env add BETTER_AUTH_URL preview
-npx vercel@latest env add TRUSTED_ORIGINS preview
-npx vercel@latest env add CORS_ORIGIN preview
-npx vercel@latest deploy
+npx vercel@latest link --project tascal-vercel-eval-242
+npx vercel@latest env add DATABASE_URL production --sensitive
+npx vercel@latest env add BETTER_AUTH_SECRET production --sensitive
+npx vercel@latest env add BETTER_AUTH_URL production
+npx vercel@latest env add TRUSTED_ORIGINS production
+npx vercel@latest env add CORS_ORIGIN production
+npx vercel@latest deploy --prod
 ```
 
-`BETTER_AUTH_URL`、`TRUSTED_ORIGINS`、`CORS_ORIGIN` には同じ preview URL を設定する。
-Vercel が deploy ごとに生成する URL は変わるため、継続的な preview 運用では
-固定 alias または preview 用 custom domain を用意し、その origin を環境変数へ設定する。
+今回は production の `tascal.dev` とは独立した試験 project を作り、その安定 alias
+`https://tascal-vercel-eval-242.vercel.app` を `BETTER_AUTH_URL`、
+`TRUSTED_ORIGINS`、`CORS_ORIGIN` に設定した。Vercel が deploy ごとに生成する URL は
+変わるため、継続的な preview 運用では固定 alias または preview 用 custom domain を用意し、
+その origin を環境変数へ設定する。
 
 ## 環境変数と接続
 
@@ -74,6 +82,10 @@ cookie は preview URL へ送信されない。
 migration は container 起動時に実行しない。deploy 前に `DATABASE_URL` を指定して
 `pnpm db:migrate` を一度実行し、複数 instance からの重複実行を避ける。
 `GET /healthz` は Neon に `SELECT 1` を実行するため、起動確認と DB 疎通確認を兼ねる。
+今回の試験では既存 Cloud Run preview `tascal-pr-229` と同じ Neon preview branch の
+pooled connection string を、値を表示せず Vercel の sensitive environment variable
+へ登録した。migration 済みの branch であることを確認し、Vercel からの接続を
+`GET /healthz` と CRUD の両方で検証した。
 
 CLI は `TASCAL_API_URL=<preview URL>` で接続先を、`TASCAL_CONFIG_PATH=<一時ファイル>`
 で token の保存先を切り替える。これにより `~/.tascalrc` の production URL と token を
@@ -82,14 +94,14 @@ CLI は `TASCAL_API_URL=<preview URL>` で接続先を、`TASCAL_CONFIG_PATH=<�
 
 ## 動作確認
 
-試験 URL: デプロイ後に記録する
+試験 URL: https://tascal-vercel-eval-242.vercel.app
 
 ### Web
 
-- [ ] ログイン
-- [ ] タスク作成
-- [ ] タスク更新
-- [ ] タスク削除
+- [x] ログイン
+- [x] タスク作成
+- [x] タスク更新
+- [x] タスク削除
 
 ### CLI
 
@@ -103,15 +115,15 @@ tascal-cli list
 tascal-cli add
 ```
 
-- [ ] ログイン
-- [ ] タスク一覧
-- [ ] タスク作成
+- [x] ログイン
+- [x] タスク一覧
+- [x] タスク作成
 
 ### 運用確認
 
-- [ ] `GET /healthz` が `200 {"status":"ok"}` を返す
-- [ ] Vercel runtime logs で起動・API request log を確認できる
-- [ ] preview が scale-to-zero した後の初回応答時間を計測する
+- [x] `GET /healthz` が `200 {"status":"ok"}` を返す
+- [x] Vercel runtime logs で起動・API request log を確認できる
+- [x] scale-to-zero 相当の初回応答時間を計測する
 
 ## Cloud Run との比較
 
@@ -130,10 +142,20 @@ tascal-cli add
 
 ## 実測値
 
-ローカル build（Apple Silicon、Docker）:
+ローカル build（Apple Silicon、Docker）と Vercel production trial:
 
-- build 成功
-- runtime image: 426,301,468 bytes（uncompressed、arm64）
+- local build 成功
+- local runtime image: 426,301,468 bytes（uncompressed、arm64）
+- Vercel build: 118.2 秒（cache なし、`linux/amd64`）
+- Vercel Function bundle: 113.95 MB (`hnd1`)
+- 初回 `GET /healthz`: 6.88 秒（初回 deploy の `iad1` 測定）
+- warm 後の `GET /`: 0.55 秒
+- runtime logs で port 80 の起動、Neon 接続、auth、GET/POST/PATCH/DELETE の
+  success status を確認
+
+設定変更を含む再 deploy でも container layer の build と VCR push に約 2 分を要した。
+小規模な変更でも現状は image build 時間を見込む必要がある。runtime では複数 hostname
+から起動ログが出ており、同時アクセス時に複数 instance が立ち上がることも確認した。
 
 Vercel の VCR 上限は圧縮 layer 単体 500 MB、圧縮後 image 合計 15 GB。
 実 deploy では Vercel が build する `linux/amd64` / `linux/arm64` image の size を

--- a/docs/vercel-container-evaluation.md
+++ b/docs/vercel-container-evaluation.md
@@ -64,6 +64,18 @@ npx vercel@latest deploy --prod
 変わるため、継続的な preview 運用では固定 alias または preview 用 custom domain を用意し、
 その origin を環境変数へ設定する。
 
+上記コマンドは独立 project の production trial 専用である。Git 連携の Preview
+Deployment へ展開する場合、Production と Preview の環境変数スコープは分離されているため、
+preview 専用値も登録する。
+
+```bash
+npx vercel@latest env add DATABASE_URL preview --sensitive
+npx vercel@latest env add BETTER_AUTH_SECRET preview --sensitive
+npx vercel@latest env add BETTER_AUTH_URL preview
+npx vercel@latest env add TRUSTED_ORIGINS preview
+npx vercel@latest env add CORS_ORIGIN preview
+```
+
 ## 環境変数と接続
 
 | 変数                 | Preview での設定                                        | 理由                                                     |
@@ -109,7 +121,10 @@ production 用 `~/.tascalrc` を上書きしないよう、試験用の一時設
 
 ```bash
 export TASCAL_API_URL=<preview URL>
-export TASCAL_CONFIG_PATH=/tmp/tascal-vercel-preview.json
+TASCAL_PREVIEW_DIR="$(mktemp -d)"
+chmod 700 "$TASCAL_PREVIEW_DIR"
+export TASCAL_CONFIG_PATH="$TASCAL_PREVIEW_DIR/config.json"
+trap 'rm -f -- "$TASCAL_CONFIG_PATH"; rmdir -- "$TASCAL_PREVIEW_DIR"' EXIT
 tascal-cli login
 tascal-cli list
 tascal-cli add
@@ -150,12 +165,15 @@ tascal-cli add
 - Vercel Function bundle: 113.95 MB (`hnd1`)
 - 初回 `GET /healthz`: 6.88 秒（初回 deploy の `iad1` 測定）
 - warm 後の `GET /`: 0.55 秒
+- `hnd1` で 5 分以上無通信後の連続 `GET /healthz`: 0.87 秒、6.13 秒
 - runtime logs で port 80 の起動、Neon 接続、auth、GET/POST/PATCH/DELETE の
   success status を確認
 
 設定変更を含む再 deploy でも container layer の build と VCR push に約 2 分を要した。
 小規模な変更でも現状は image build 時間を見込む必要がある。runtime では複数 hostname
 から起動ログが出ており、同時アクセス時に複数 instance が立ち上がることも確認した。
+5 分以上無通信後の 2 リクエストは後発の方が遅く、単純な「初回だけ cold、以降は warm」
+にはならなかった。複数 instance への分散を含めた実トラフィックでの継続計測が必要である。
 
 Vercel の VCR 上限は圧縮 layer 単体 500 MB、圧縮後 image 合計 15 GB。
 実 deploy では Vercel が build する `linux/amd64` / `linux/arm64` image の size を

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "container",
+  "regions": ["hnd1"]
+}


### PR DESCRIPTION
close #242

## 概要

Vercel Container Images で tascal を試験デプロイし、Web・CLI・Neon 接続・ログ・cold start を確認しました。本番移行は行わず、評価結果として現時点では Cloud Run 継続を推奨します。

## 変更内容

- `Dockerfile.vercel` と container framework / 東京リージョンを指定する `vercel.json` を追加
- Vercel/Cloud Run の制限・料金・運用差、必要な環境変数、実測値、推奨判断を評価メモに記録
- CLI に `TASCAL_CONFIG_PATH` を追加し、production の `~/.tascalrc` を上書きせず preview を検証可能に変更
- CLI の設定パス上書きテストと利用手順を追加

## 試験結果

- 試験 URL: https://tascal-vercel-eval-242.vercel.app
- Web: ログイン、タスク作成・更新・削除を確認
- CLI: ログイン、一覧、作成を確認
- Neon PostgreSQL: `/healthz` と CRUD で接続を確認
- Vercel runtime logs: auth と GET/POST/PATCH/DELETE の成功ログを確認
- cold start 相当: 初回 6.88 秒、東京リージョンで 5 分超無通信後の連続応答 0.87 秒 / 6.13 秒

## 検証

- `pnpm build`
- `pnpm lint`
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm test`
- `acceptance-check`: 未達 0 件
- `cross-review`: critical 0、warning 2、info 1（全指摘対応済み）