### PR TITLE
get-session レスポンスからセッショントークンを除外する

### DIFF
--- a/apps/api/src/auth.test.ts
+++ b/apps/api/src/auth.test.ts
@@ -1,0 +1,75 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { getTestInstance } from "better-auth/test";
+import { createPublicSessionPlugin } from "./auth.js";
+
+function createTestAuth() {
+  return getTestInstance({
+    plugins: [createPublicSessionPlugin()],
+  });
+}
+
+type TestInstance = Awaited<ReturnType<typeof createTestAuth>>;
+
+let instance: TestInstance;
+let bearerToken: string;
+
+beforeAll(async () => {
+  instance = await createTestAuth();
+
+  const signInResponse = await instance.customFetchImpl(
+    "http://localhost:3000/api/auth/sign-in/email",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email: instance.testUser.email,
+        password: instance.testUser.password,
+      }),
+    },
+  );
+
+  const signInBody = (await signInResponse.json()) as { token?: string };
+  bearerToken = signInResponse.headers.get("set-auth-token") ?? "";
+
+  expect(signInResponse.ok).toBe(true);
+  expect(signInBody.token).toBeTruthy();
+  expect(bearerToken).toBeTruthy();
+});
+
+async function expectSafeSession(response: Response) {
+  expect(response.ok).toBe(true);
+  expect(response.headers.get("cache-control")).toBe("private, no-store");
+
+  const body = (await response.json()) as {
+    user: { email: string };
+    session: Record<string, unknown>;
+  };
+
+  expect(body.user.email).toBe(instance.testUser.email);
+  expect(body.session.id).toEqual(expect.any(String));
+  expect(body.session.userId).toEqual(expect.any(String));
+  expect(body.session.expiresAt).toEqual(expect.any(String));
+  expect(body.session).not.toHaveProperty("token");
+  expect(JSON.stringify(body)).not.toContain(bearerToken);
+}
+
+describe("GET /api/auth/get-session", () => {
+  it("Cookie 認証では再利用可能なトークンをレスポンス本文に含めない", async () => {
+    const { headers } = await instance.signInWithTestUser();
+    const response = await instance.customFetchImpl(
+      "http://localhost:3000/api/auth/get-session",
+      { headers },
+    );
+
+    await expectSafeSession(response);
+  });
+
+  it("Bearer 認証を維持しつつレスポンス本文からトークンを除外する", async () => {
+    const response = await instance.customFetchImpl(
+      "http://localhost:3000/api/auth/get-session",
+      { headers: { Authorization: `Bearer ${bearerToken}` } },
+    );
+
+    await expectSafeSession(response);
+  });
+});

--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -1,7 +1,7 @@
 import { createAuthMiddleware } from "better-auth/api";
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
-import { bearer } from "better-auth/plugins";
+import { bearer, customSession } from "better-auth/plugins";
 import { getDb } from "./db/index.js";
 import * as schema from "./db/schema.js";
 import logger from "./logger.js";
@@ -11,6 +11,25 @@ function maskEmail(email: string): string {
   if (!local || !domain) return "***";
   const visible = local.slice(0, Math.min(2, local.length));
   return `${visible}***@${domain}`;
+}
+
+export function createPublicSessionPlugin() {
+  return customSession(({ user, session }, ctx) => {
+    ctx.setHeader("Cache-Control", "private, no-store");
+
+    return Promise.resolve({
+      user,
+      session: {
+        id: session.id,
+        userId: session.userId,
+        expiresAt: session.expiresAt,
+        createdAt: session.createdAt,
+        updatedAt: session.updatedAt,
+        ipAddress: session.ipAddress,
+        userAgent: session.userAgent,
+      },
+    });
+  });
 }
 
 function createAuth() {
@@ -23,7 +42,7 @@ function createAuth() {
     emailAndPassword: {
       enabled: true,
     },
-    plugins: [bearer()],
+    plugins: [bearer(), createPublicSessionPlugin()],
     trustedOrigins: process.env.TRUSTED_ORIGINS
       ? process.env.TRUSTED_ORIGINS.split(",")
           .map((s) => s.trim())

--- a/apps/cli/src/api.test.ts
+++ b/apps/cli/src/api.test.ts
@@ -14,6 +14,7 @@ vi.mock("hono/client", () => ({
 }));
 
 import { consola } from "consola";
+import { hc } from "hono/client";
 import { readConfig, getApiUrl } from "./config.js";
 import { requireAuthClient, handleApiError } from "./api.js";
 
@@ -40,6 +41,12 @@ describe("requireAuthClient", () => {
     const client = await requireAuthClient();
 
     expect(client).toBeDefined();
+    expect(hc).toHaveBeenCalledWith(
+      "http://localhost:3000",
+      expect.objectContaining({
+        headers: { Authorization: "Bearer test-token" },
+      }),
+    );
   });
 
   it("トークンがない場合、process.exit(1) が呼ばれる", async () => {

--- a/apps/cli/src/commands/login.test.ts
+++ b/apps/cli/src/commands/login.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@clack/prompts", () => ({
+  text: vi.fn(),
+  password: vi.fn(),
+  isCancel: vi.fn(() => false),
+}));
+
+vi.mock("consola", () => ({
+  consola: { start: vi.fn(), success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("../config.js", () => ({
+  readConfig: vi.fn(),
+  writeConfig: vi.fn(),
+  getApiUrl: vi.fn(),
+}));
+
+import { password, text } from "@clack/prompts";
+import { readConfig, writeConfig, getApiUrl } from "../config.js";
+import command from "./login.js";
+
+const originalIsTTY = process.stdin.isTTY;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  Object.defineProperty(process.stdin, "isTTY", {
+    configurable: true,
+    value: true,
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  Object.defineProperty(process.stdin, "isTTY", {
+    configurable: true,
+    value: originalIsTTY,
+  });
+});
+
+describe("login", () => {
+  it("ログインレスポンスのトークンを設定へ保存する", async () => {
+    vi.mocked(readConfig).mockResolvedValue({});
+    vi.mocked(getApiUrl).mockReturnValue("https://tascal.dev");
+    vi.mocked(text).mockResolvedValue("test@example.com");
+    vi.mocked(password).mockResolvedValue("password123");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ token: "session-token" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+
+    await command.run!({
+      args: { _: [], "api-url": undefined as unknown as string },
+      rawArgs: [],
+      cmd: command,
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://tascal.dev/api/auth/sign-in/email",
+      expect.objectContaining({
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Origin: "https://tascal.dev",
+        },
+      }),
+    );
+    expect(writeConfig).toHaveBeenCalledWith({
+      token: "session-token",
+      apiUrl: "https://tascal.dev",
+    });
+  });
+});


### PR DESCRIPTION
close #256

## 目的

Web の `GET /api/auth/get-session` レスポンスから Bearer 認証に再利用可能なセッショントークンを除外し、HttpOnly cookie を利用していても XSS 経由で永続的な認証情報を持ち出せる露出を減らします。

## 変更内容

- `apps/api/src/auth.ts`
  - Better Auth の `customSession` plugin を追加
  - session レスポンスを非機密フィールドの allowlist に限定
  - `Cache-Control: private, no-store` を付与
  - 既存の Bearer plugin は維持
- `apps/api/src/auth.test.ts`
  - Cookie / Bearer の両方で `get-session` 本文から token が除外されることを統合テスト
  - Mobile 用 `set-auth-token` と CLI 用 login response token が維持されることを確認
- `apps/cli/src/commands/login.test.ts`, `apps/cli/src/api.test.ts`
  - login token の保存と保存 token の Bearer 利用を確認

## 影響パッケージ

- `apps/api`
- `apps/cli`（テストのみ）
- Web / Mobile の認証クライアント実装は変更なし

## ローカル検証

- `pnpm build`
- `pnpm lint`
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm test`
- `pnpm knip`

## レビュー

- acceptance-check: ✓ 5 / ✗ 0 / ? 0
- cross-review: critical 0 / warning 1 / info 0
  - warning は `better-auth/test` の `getTestInstance()` が Bearer plugin を自動追加する仕様を見落とした指摘で、テスト成功と依存実装を確認のうえ対応不要と判断
