### PR TITLE
モバイル版のタスク取得をTanStack Queryへ移行する

### DIFF
--- a/apps/mobile/__tests__/task-form.test.tsx
+++ b/apps/mobile/__tests__/task-form.test.tsx
@@ -1,0 +1,86 @@
+import TaskFormScreen from "@/app/task-form";
+import { renderRouter, screen, waitFor } from "@/test-utils/router";
+import type { Task } from "@/types/task";
+
+const mockUseTasks = jest.fn();
+const mockUseUnscheduledTasks = jest.fn();
+const mockMutateAsync = jest.fn();
+
+jest.mock("@/hooks/use-color-scheme", () => ({
+  useColorScheme: () => "light",
+}));
+
+jest.mock("@/hooks/use-tasks", () => ({
+  useCreateTask: () => ({ isPending: false, mutateAsync: mockMutateAsync }),
+  useDeleteTask: () => ({ isPending: false, mutateAsync: mockMutateAsync }),
+  useTasks: (...args: unknown[]) => mockUseTasks(...args),
+  useUnscheduledTasks: (...args: unknown[]) => mockUseUnscheduledTasks(...args),
+  useUpdateTask: () => ({ isPending: false, mutateAsync: mockMutateAsync }),
+}));
+
+const task: Task = {
+  id: "task-1",
+  userId: "user-1",
+  title: "テストタスク",
+  description: null,
+  date: "2026-08-06",
+  status: "todo",
+  categoryId: null,
+  createdAt: "2026-08-06T00:00:00.000Z",
+  updatedAt: "2026-08-06T00:00:00.000Z",
+};
+
+const refetch = jest.fn();
+
+function queryResult({
+  data,
+  isError = false,
+  isPending = false,
+}: {
+  data?: Task[];
+  isError?: boolean;
+  isPending?: boolean;
+}) {
+  return { data, isError, isPending, refetch };
+}
+
+function renderTaskForm() {
+  return renderRouter(
+    { "task-form": TaskFormScreen },
+    {
+      initialUrl: "/task-form?taskId=task-1&year=2026&month=8",
+    },
+  );
+}
+
+describe("TaskFormScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("取得完了後に対象taskが存在しなければ戻る導線を表示する", () => {
+    mockUseTasks.mockReturnValue(queryResult({ data: [] }));
+    mockUseUnscheduledTasks.mockReturnValue(queryResult({ data: [] }));
+
+    renderTaskForm();
+
+    expect(screen.getByText("タスクが見つかりません")).toBeOnTheScreen();
+    expect(screen.getByRole("button", { name: "戻る" })).toBeOnTheScreen();
+    expect(screen.queryByText("保存")).not.toBeOnTheScreen();
+  });
+
+  it("task取得済みならもう片方のqueryが失敗しても編集フォームを維持する", async () => {
+    mockUseTasks.mockReturnValue(queryResult({ data: [task] }));
+    mockUseUnscheduledTasks.mockReturnValue(queryResult({ isError: true }));
+
+    renderTaskForm();
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue(task.title)).toBeOnTheScreen();
+    });
+    expect(
+      screen.queryByText("タスクの取得に失敗しました"),
+    ).not.toBeOnTheScreen();
+    expect(screen.getByText("保存")).toBeOnTheScreen();
+  });
+});

--- a/apps/mobile/__tests__/use-app-state-focus.test.ts
+++ b/apps/mobile/__tests__/use-app-state-focus.test.ts
@@ -1,0 +1,39 @@
+import { act, renderHook } from "@testing-library/react-native";
+import { focusManager } from "@tanstack/react-query";
+import { AppState, Platform, type AppStateStatus } from "react-native";
+
+import { useAppStateFocus } from "@/hooks/use-app-state-focus";
+
+describe("useAppStateFocus", () => {
+  it("初期状態とAppState変更をfocusManagerへ同期し、unmount時に購読を解除する", () => {
+    const remove = jest.fn();
+    let onChange: ((status: AppStateStatus) => void) | undefined;
+    const addEventListener = jest
+      .spyOn(AppState, "addEventListener")
+      .mockImplementation((_event, listener) => {
+        onChange = listener;
+        return { remove };
+      });
+    const setFocused = jest.spyOn(focusManager, "setFocused");
+
+    expect(Platform.OS).not.toBe("web");
+    const { unmount } = renderHook(() => useAppStateFocus());
+
+    expect(setFocused).toHaveBeenLastCalledWith(
+      AppState.currentState === "active",
+    );
+    expect(addEventListener).toHaveBeenCalledWith(
+      "change",
+      expect.any(Function),
+    );
+
+    act(() => onChange?.("background"));
+    expect(setFocused).toHaveBeenLastCalledWith(false);
+
+    act(() => onChange?.("active"));
+    expect(setFocused).toHaveBeenLastCalledWith(true);
+
+    unmount();
+    expect(remove).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/mobile/__tests__/use-refresh-on-focus.test.tsx
+++ b/apps/mobile/__tests__/use-refresh-on-focus.test.tsx
@@ -1,0 +1,44 @@
+import { act, renderHook } from "@testing-library/react-native";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { taskQueryKeys } from "@/hooks/use-tasks";
+import { useRefreshOnFocus } from "@/hooks/use-refresh-on-focus";
+
+let mockFocusCallback: (() => void) | undefined;
+
+jest.mock("@react-navigation/native", () => ({
+  useFocusEffect: (callback: () => void) => {
+    mockFocusCallback = callback;
+  },
+}));
+
+describe("useRefreshOnFocus", () => {
+  it("初回focusを飛ばし、復帰時にactiveかつstaleなtask queryだけ再取得する", () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { gcTime: Infinity } },
+    });
+    const refetchQueries = jest
+      .spyOn(queryClient, "refetchQueries")
+      .mockResolvedValue();
+
+    const { unmount } = renderHook(() => useRefreshOnFocus(), {
+      wrapper: ({ children }: { children: React.ReactNode }) => (
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      ),
+    });
+
+    act(() => mockFocusCallback?.());
+    expect(refetchQueries).not.toHaveBeenCalled();
+
+    act(() => mockFocusCallback?.());
+    expect(refetchQueries).toHaveBeenCalledWith({
+      queryKey: taskQueryKeys.all,
+      stale: true,
+      type: "active",
+    });
+    unmount();
+    queryClient.clear();
+  });
+});

--- a/apps/mobile/__tests__/use-tasks.test.tsx
+++ b/apps/mobile/__tests__/use-tasks.test.tsx
@@ -1,0 +1,167 @@
+import { act, renderHook, waitFor } from "@testing-library/react-native";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import {
+  createTask,
+  deleteTask,
+  fetchTasksRange,
+  fetchUnscheduledTasks,
+  updateTask,
+} from "@/api/tasks";
+import {
+  getTaskDateRange,
+  taskQueryKeys,
+  useCreateTask,
+  useDeleteTask,
+  useTasks,
+  useUnscheduledTasks,
+  useUpdateTask,
+} from "@/hooks/use-tasks";
+import type { Task } from "@/types/task";
+
+jest.mock("@/api/tasks", () => ({
+  createTask: jest.fn(),
+  deleteTask: jest.fn(),
+  fetchTasksRange: jest.fn(),
+  fetchUnscheduledTasks: jest.fn(),
+  updateTask: jest.fn(),
+}));
+
+const task: Task = {
+  id: "task-1",
+  userId: "user-1",
+  title: "テストタスク",
+  description: null,
+  date: "2026-08-06",
+  status: "todo",
+  categoryId: null,
+  createdAt: "2026-08-06T00:00:00.000Z",
+  updatedAt: "2026-08-06T00:00:00.000Z",
+};
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+function createTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      mutations: { gcTime: Infinity },
+      queries: { gcTime: Infinity, retry: false },
+    },
+  });
+}
+
+describe("mobile task queries", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("月の6週表示範囲から安定したquery keyを作る", async () => {
+    const queryClient = createTestQueryClient();
+    jest.mocked(fetchTasksRange).mockResolvedValue([task]);
+
+    const { result, unmount } = renderHook(() => useTasks(2026, 8), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const range = getTaskDateRange(2026, 8);
+    expect(range).toEqual({
+      startDate: "2026-07-27",
+      endDate: "2026-09-06",
+    });
+    expect(fetchTasksRange).toHaveBeenCalledWith(
+      range.startDate,
+      range.endDate,
+      expect.anything(),
+    );
+    expect(
+      queryClient.getQueryData(
+        taskQueryKeys.range(range.startDate, range.endDate),
+      ),
+    ).toEqual([task]);
+    unmount();
+    queryClient.clear();
+  });
+
+  it("未スケジュールタスクを専用query keyで取得する", async () => {
+    const queryClient = createTestQueryClient();
+    jest.mocked(fetchUnscheduledTasks).mockResolvedValue([task]);
+
+    const { result, unmount } = renderHook(() => useUnscheduledTasks(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(queryClient.getQueryData(taskQueryKeys.unscheduled)).toEqual([task]);
+    unmount();
+    queryClient.clear();
+  });
+
+  it("新規作成画面向けにtask queryを無効化できる", () => {
+    const queryClient = createTestQueryClient();
+    const { unmount } = renderHook(
+      () => {
+        useTasks(2026, 8, false);
+        useUnscheduledTasks(false);
+      },
+      { wrapper: createWrapper(queryClient) },
+    );
+
+    expect(fetchTasksRange).not.toHaveBeenCalled();
+    expect(fetchUnscheduledTasks).not.toHaveBeenCalled();
+    unmount();
+    queryClient.clear();
+  });
+
+  it("作成・更新・削除の成功後にtask queryをinvalidationする", async () => {
+    const queryClient = createTestQueryClient();
+    const invalidateQueries = jest.spyOn(queryClient, "invalidateQueries");
+    jest.mocked(createTask).mockResolvedValue(task);
+    jest.mocked(updateTask).mockResolvedValue({ ...task, status: "done" });
+    jest.mocked(deleteTask).mockResolvedValue(undefined);
+
+    const create = renderHook(() => useCreateTask(), {
+      wrapper: createWrapper(queryClient),
+    });
+    const update = renderHook(() => useUpdateTask(), {
+      wrapper: createWrapper(queryClient),
+    });
+    const remove = renderHook(() => useDeleteTask(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await create.result.current.mutateAsync({ title: task.title });
+      await update.result.current.mutateAsync({
+        id: task.id,
+        data: { status: "done" },
+      });
+      await remove.result.current.mutateAsync(task.id);
+    });
+
+    await waitFor(() => {
+      expect(create.result.current.isSuccess).toBe(true);
+      expect(update.result.current.isSuccess).toBe(true);
+      expect(remove.result.current.isSuccess).toBe(true);
+    });
+
+    expect(createTask).toHaveBeenCalledWith({ title: task.title });
+    expect(updateTask).toHaveBeenCalledWith(task.id, { status: "done" });
+    expect(deleteTask).toHaveBeenCalledWith(task.id);
+    expect(invalidateQueries).toHaveBeenCalledTimes(3);
+    expect(invalidateQueries).toHaveBeenNthCalledWith(1, {
+      queryKey: taskQueryKeys.all,
+    });
+    create.unmount();
+    update.unmount();
+    remove.unmount();
+    queryClient.clear();
+  });
+});

--- a/apps/mobile/__tests__/use-tasks.test.tsx
+++ b/apps/mobile/__tests__/use-tasks.test.tsx
@@ -159,6 +159,12 @@ describe("mobile task queries", () => {
     expect(invalidateQueries).toHaveBeenNthCalledWith(1, {
       queryKey: taskQueryKeys.all,
     });
+    expect(invalidateQueries).toHaveBeenNthCalledWith(2, {
+      queryKey: taskQueryKeys.all,
+    });
+    expect(invalidateQueries).toHaveBeenNthCalledWith(3, {
+      queryKey: taskQueryKeys.all,
+    });
     create.unmount();
     update.unmount();
     remove.unmount();

--- a/apps/mobile/api/tasks.ts
+++ b/apps/mobile/api/tasks.ts
@@ -15,26 +15,16 @@ async function authHeaders(): Promise<Record<string, string>> {
   };
 }
 
-export async function fetchTasks(year: number, month: number): Promise<Task[]> {
-  const headers = await authHeaders();
-  const res = await fetch(
-    `${API_BASE_URL}/api/tasks?year=${year}&month=${month}`,
-    { headers },
-  );
-  if (!res.ok) {
-    throw new Error("タスクの取得に失敗しました");
-  }
-  return res.json();
-}
-
 export async function fetchTasksRange(
   startDate: string,
   endDate: string,
+  signal?: AbortSignal,
 ): Promise<Task[]> {
   const headers = await authHeaders();
   const params = new URLSearchParams({ startDate, endDate });
   const res = await fetch(`${API_BASE_URL}/api/tasks/range?${params}`, {
     headers,
+    signal,
   });
   if (!res.ok) {
     throw new Error("タスクの取得に失敗しました");
@@ -42,10 +32,13 @@ export async function fetchTasksRange(
   return res.json();
 }
 
-export async function fetchUnscheduledTasks(): Promise<Task[]> {
+export async function fetchUnscheduledTasks(
+  signal?: AbortSignal,
+): Promise<Task[]> {
   const headers = await authHeaders();
   const res = await fetch(`${API_BASE_URL}/api/tasks/unscheduled`, {
     headers,
+    signal,
   });
   if (!res.ok) {
     throw new Error("未スケジュールタスクの取得に失敗しました");

--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -13,16 +13,10 @@ import {
   View,
 } from "react-native";
 import { router } from "expo-router";
-import { useFocusEffect } from "@react-navigation/native";
+import { useQueryClient } from "@tanstack/react-query";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useReducedMotion } from "react-native-reanimated";
 
-import {
-  createTask,
-  fetchTasksRange,
-  fetchUnscheduledTasks,
-  updateTask,
-} from "@/api/tasks";
 import { DayTaskBottomSheet } from "@/components/day-task-bottom-sheet";
 import { ThemedText } from "@/components/themed-text";
 import { ThemedView } from "@/components/themed-view";
@@ -30,6 +24,13 @@ import { UnscheduledTasksButton } from "@/components/unscheduled-tasks-button";
 import { Colors } from "@/constants/theme";
 import { useAuth } from "@/contexts/auth-context";
 import { useColorScheme } from "@/hooks/use-color-scheme";
+import { useRefreshOnFocus } from "@/hooks/use-refresh-on-focus";
+import {
+  useCreateTask,
+  useTasks,
+  useUnscheduledTasks,
+  useUpdateTask,
+} from "@/hooks/use-tasks";
 import type { Task } from "@/types/task";
 import {
   resolveMonthSwipe,
@@ -39,6 +40,7 @@ import {
 } from "@/utils/month-swipe";
 
 const WEEKDAY_LABELS = ["月", "火", "水", "木", "金", "土", "日"];
+const EMPTY_TASKS: Task[] = [];
 
 type CalendarDay = {
   date: Date;
@@ -93,6 +95,7 @@ function getCalendarDays(year: number, month: number): CalendarDay[] {
 
 export default function HomeScreen() {
   const { signOut } = useAuth();
+  const queryClient = useQueryClient();
   const colorScheme = useColorScheme() ?? "light";
   const colors = Colors[colorScheme];
   const reduceMotion = useReducedMotion();
@@ -104,14 +107,8 @@ export default function HomeScreen() {
     year: initialDate.getFullYear(),
     month: initialDate.getMonth() + 1,
   });
-  const [scheduledTasks, setScheduledTasks] = useState<Task[]>([]);
-  const [unscheduledTasks, setUnscheduledTasks] = useState<Task[]>([]);
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
   const [showUnscheduled, setShowUnscheduled] = useState(false);
-  const [isLoading, setIsLoading] = useState(true);
-  const [isRefreshing, setIsRefreshing] = useState(false);
-  const isFirstLoad = useRef(true);
-  const requestGeneration = useRef(0);
   const calendarTranslateX = useRef(new Animated.Value(0)).current;
   const calendarWidth = useRef(0);
   const isMonthTransitioning = useRef(false);
@@ -120,44 +117,20 @@ export default function HomeScreen() {
     () => getCalendarDays(year, month),
     [year, month],
   );
+  const scheduledTasksQuery = useTasks(year, month);
+  const unscheduledTasksQuery = useUnscheduledTasks();
+  const createTaskMutation = useCreateTask();
+  const updateTaskMutation = useUpdateTask();
+  useRefreshOnFocus();
 
-  const loadTasks = useCallback(async () => {
-    const generation = ++requestGeneration.current;
-    try {
-      const visibleDays = getCalendarDays(year, month);
-      const [scheduled, unscheduled] = await Promise.all([
-        fetchTasksRange(
-          visibleDays[0].dateKey,
-          visibleDays[visibleDays.length - 1].dateKey,
-        ),
-        fetchUnscheduledTasks(),
-      ]);
-      if (generation !== requestGeneration.current) return;
-      setScheduledTasks(scheduled);
-      setUnscheduledTasks(unscheduled);
-    } catch {
-      if (generation !== requestGeneration.current) return;
-      Alert.alert("エラー", "タスクの取得に失敗しました");
-    } finally {
-      if (generation === requestGeneration.current) {
-        setIsLoading(false);
-        setIsRefreshing(false);
-      }
-    }
-  }, [year, month]);
-
-  useFocusEffect(
-    useCallback(() => {
-      if (isFirstLoad.current) {
-        isFirstLoad.current = false;
-        setIsLoading(true);
-      }
-      void loadTasks();
-      return () => {
-        requestGeneration.current += 1;
-      };
-    }, [loadTasks]),
-  );
+  const scheduledTasks = scheduledTasksQuery.data ?? EMPTY_TASKS;
+  const unscheduledTasks = unscheduledTasksQuery.data ?? EMPTY_TASKS;
+  const isLoading =
+    scheduledTasksQuery.isPending || unscheduledTasksQuery.isPending;
+  const isRefreshing =
+    scheduledTasksQuery.isRefetching || unscheduledTasksQuery.isRefetching;
+  const hasTaskError =
+    scheduledTasksQuery.isError || unscheduledTasksQuery.isError;
 
   const tasksByDate = useMemo(() => {
     const map = new Map<string, Task[]>();
@@ -175,17 +148,16 @@ export default function HomeScreen() {
     : [];
 
   const handleRefresh = async () => {
-    setIsRefreshing(true);
-    await loadTasks();
+    await Promise.all([
+      scheduledTasksQuery.refetch(),
+      unscheduledTasksQuery.refetch(),
+    ]);
   };
 
   const moveMonth = useCallback((offset: -1 | 1) => {
     const next = shiftCalendarMonth(displayedMonth.current, offset);
     displayedMonth.current = next;
-    requestGeneration.current += 1;
     setSelectedDate(null);
-    setScheduledTasks([]);
-    setIsLoading(true);
     setYear(next.year);
     setMonth(next.month);
     AccessibilityInfo.announceForAccessibility(
@@ -262,9 +234,6 @@ export default function HomeScreen() {
     calendarTranslateX.setValue(0);
     isMonthTransitioning.current = false;
     const today = new Date();
-    const isAlreadyCurrentMonth =
-      displayedMonth.current.year === today.getFullYear() &&
-      displayedMonth.current.month === today.getMonth() + 1;
     displayedMonth.current = {
       year: today.getFullYear(),
       month: today.getMonth() + 1,
@@ -272,11 +241,6 @@ export default function HomeScreen() {
     setYear(today.getFullYear());
     setMonth(today.getMonth() + 1);
     setSelectedDate(formatDateKey(today));
-    if (!isAlreadyCurrentMonth) {
-      requestGeneration.current += 1;
-      setScheduledTasks([]);
-      setIsLoading(true);
-    }
     AccessibilityInfo.announceForAccessibility(
       formatMonth(today.getFullYear(), today.getMonth() + 1),
     );
@@ -284,12 +248,11 @@ export default function HomeScreen() {
 
   const handleToggleStatus = async (task: Task) => {
     const newStatus = task.status === "todo" ? "done" : "todo";
-    const updateList = task.date ? setScheduledTasks : setUnscheduledTasks;
     try {
-      const updated = await updateTask(task.id, { status: newStatus });
-      updateList((tasks) =>
-        tasks.map((value) => (value.id === updated.id ? updated : value)),
-      );
+      await updateTaskMutation.mutateAsync({
+        id: task.id,
+        data: { status: newStatus },
+      });
     } catch {
       Alert.alert("エラー", "ステータスの更新に失敗しました");
     }
@@ -323,10 +286,8 @@ export default function HomeScreen() {
           onPress: (title?: string) => {
             const trimmedTitle = title?.trim();
             if (!trimmedTitle) return;
-            void createTask({ title: trimmedTitle, date: selectedDate })
-              .then((task) => {
-                setScheduledTasks((tasks) => [...tasks, task]);
-              })
+            void createTaskMutation
+              .mutateAsync({ title: trimmedTitle, date: selectedDate })
               .catch(() => {
                 Alert.alert("エラー", "タスクの作成に失敗しました");
               });
@@ -343,7 +304,9 @@ export default function HomeScreen() {
       {
         text: "ログアウト",
         style: "destructive",
-        onPress: () => void signOut(),
+        onPress: () => {
+          void signOut().finally(() => queryClient.clear());
+        },
       },
     ]);
   };
@@ -418,6 +381,17 @@ export default function HomeScreen() {
               />
             }
           >
+            {hasTaskError ? (
+              <View style={styles.errorBanner}>
+                <ThemedText>タスクの取得に失敗しました</ThemedText>
+                <Pressable
+                  accessibilityRole="button"
+                  onPress={() => void handleRefresh()}
+                >
+                  <ThemedText style={{ color: colors.tint }}>再試行</ThemedText>
+                </Pressable>
+              </View>
+            ) : null}
             <Animated.View
               accessibilityHint="左右にスワイプして月を移動できます"
               onLayout={(event) => {
@@ -608,6 +582,13 @@ const styles = StyleSheet.create({
     flexGrow: 1,
     paddingBottom: 16,
     paddingHorizontal: 8,
+  },
+  errorBanner: {
+    alignItems: "center",
+    flexDirection: "row",
+    gap: 12,
+    justifyContent: "center",
+    paddingBottom: 10,
   },
   calendar: {
     borderRadius: 10,

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -6,11 +6,21 @@ import {
 import { Redirect, Slot, useSegments } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { ActivityIndicator, View } from "react-native";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import "react-native-reanimated";
 
 import { useColorScheme } from "@/hooks/use-color-scheme";
 import { AuthProvider, useAuth } from "@/contexts/auth-context";
 import { Colors } from "@/constants/theme";
+import { useAppStateFocus } from "@/hooks/use-app-state-focus";
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 30_000,
+    },
+  },
+});
 
 const lightNavigationTheme = {
   ...DefaultTheme,
@@ -66,17 +76,20 @@ function AuthGate() {
 
 export default function RootLayout() {
   const colorScheme = useColorScheme();
+  useAppStateFocus();
 
   return (
-    <AuthProvider>
-      <ThemeProvider
-        value={
-          colorScheme === "dark" ? darkNavigationTheme : lightNavigationTheme
-        }
-      >
-        <AuthGate />
-        <StatusBar style="auto" />
-      </ThemeProvider>
-    </AuthProvider>
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider>
+        <ThemeProvider
+          value={
+            colorScheme === "dark" ? darkNavigationTheme : lightNavigationTheme
+          }
+        >
+          <AuthGate />
+          <StatusBar style="auto" />
+        </ThemeProvider>
+      </AuthProvider>
+    </QueryClientProvider>
   );
 }

--- a/apps/mobile/app/task-form.tsx
+++ b/apps/mobile/app/task-form.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   ActivityIndicator,
   Alert,
@@ -17,12 +17,12 @@ import { ThemedView } from "@/components/themed-view";
 import { Colors } from "@/constants/theme";
 import { useColorScheme } from "@/hooks/use-color-scheme";
 import {
-  createTask,
-  deleteTask,
-  fetchTasks,
-  fetchUnscheduledTasks,
-  updateTask,
-} from "@/api/tasks";
+  useCreateTask,
+  useDeleteTask,
+  useTasks,
+  useUnscheduledTasks,
+  useUpdateTask,
+} from "@/hooks/use-tasks";
 import type { Task } from "@/types/task";
 
 export default function TaskFormScreen() {
@@ -33,12 +33,14 @@ export default function TaskFormScreen() {
   }>();
   const colorScheme = useColorScheme() ?? "light";
   const isEditing = !!taskId;
+  const numericYear = Number(year);
+  const numericMonth = Number(month);
 
   // デフォルト日付: 表示中の月が当月なら今日、それ以外なら月初
   const defaultDate = (() => {
     const now = new Date();
-    const y = Number(year);
-    const m = Number(month);
+    const y = numericYear;
+    const m = numericMonth;
     if (y === now.getFullYear() && m === now.getMonth() + 1) {
       return `${y}-${String(m).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
     }
@@ -48,35 +50,34 @@ export default function TaskFormScreen() {
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [date, setDate] = useState(isEditing ? "" : defaultDate);
-  const [isLoadingTask, setIsLoadingTask] = useState(isEditing);
-  const [isSaving, setIsSaving] = useState(false);
   const [originalTask, setOriginalTask] = useState<Task | null>(null);
+  const initializedTaskId = useRef<string | null>(null);
+  const scheduledTasksQuery = useTasks(numericYear, numericMonth, isEditing);
+  const unscheduledTasksQuery = useUnscheduledTasks(isEditing);
+  const createTaskMutation = useCreateTask();
+  const updateTaskMutation = useUpdateTask();
+  const deleteTaskMutation = useDeleteTask();
+
+  const task = [
+    ...(scheduledTasksQuery.data ?? []),
+    ...(unscheduledTasksQuery.data ?? []),
+  ].find((value) => value.id === taskId);
+  const isLoadingTask =
+    isEditing &&
+    (scheduledTasksQuery.isPending || unscheduledTasksQuery.isPending);
+  const hasTaskError =
+    isEditing && (scheduledTasksQuery.isError || unscheduledTasksQuery.isError);
+  const isSaving = createTaskMutation.isPending || updateTaskMutation.isPending;
 
   useEffect(() => {
-    if (!isEditing) return;
+    if (!taskId || !task || initializedTaskId.current === taskId) return;
 
-    void (async () => {
-      try {
-        const [scheduledTasks, unscheduledTasks] = await Promise.all([
-          fetchTasks(Number(year), Number(month)),
-          fetchUnscheduledTasks(),
-        ]);
-        const task = [...scheduledTasks, ...unscheduledTasks].find(
-          (value) => value.id === taskId,
-        );
-        if (task) {
-          setOriginalTask(task);
-          setTitle(task.title);
-          setDescription(task.description ?? "");
-          setDate(task.date ?? "");
-        }
-      } catch {
-        Alert.alert("エラー", "タスクの取得に失敗しました");
-      } finally {
-        setIsLoadingTask(false);
-      }
-    })();
-  }, [isEditing, taskId, year, month]);
+    initializedTaskId.current = taskId;
+    setOriginalTask(task);
+    setTitle(task.title);
+    setDescription(task.description ?? "");
+    setDate(task.date ?? "");
+  }, [task, taskId]);
 
   const handleSave = async () => {
     const trimmedTitle = title.trim();
@@ -91,16 +92,18 @@ export default function TaskFormScreen() {
       return;
     }
 
-    setIsSaving(true);
     try {
       if (isEditing && taskId) {
-        await updateTask(taskId, {
-          title: trimmedTitle,
-          description: description.trim() || null,
-          date: trimmedDate || null,
+        await updateTaskMutation.mutateAsync({
+          id: taskId,
+          data: {
+            title: trimmedTitle,
+            description: description.trim() || null,
+            date: trimmedDate || null,
+          },
         });
       } else {
-        await createTask({
+        await createTaskMutation.mutateAsync({
           title: trimmedTitle,
           description: description.trim() || null,
           date: trimmedDate || null,
@@ -112,8 +115,6 @@ export default function TaskFormScreen() {
         "エラー",
         isEditing ? "タスクの更新に失敗しました" : "タスクの作成に失敗しました",
       );
-    } finally {
-      setIsSaving(false);
     }
   };
 
@@ -126,7 +127,7 @@ export default function TaskFormScreen() {
         style: "destructive",
         onPress: async () => {
           try {
-            await deleteTask(taskId);
+            await deleteTaskMutation.mutateAsync(taskId);
             router.back();
           } catch {
             Alert.alert("エラー", "タスクの削除に失敗しました");
@@ -140,7 +141,10 @@ export default function TaskFormScreen() {
     if (!taskId || !originalTask) return;
     const newStatus = originalTask.status === "todo" ? "done" : "todo";
     try {
-      const updated = await updateTask(taskId, { status: newStatus });
+      const updated = await updateTaskMutation.mutateAsync({
+        id: taskId,
+        data: { status: newStatus },
+      });
       setOriginalTask(updated);
     } catch {
       Alert.alert("エラー", "ステータスの更新に失敗しました");
@@ -151,6 +155,26 @@ export default function TaskFormScreen() {
     return (
       <ThemedView style={[styles.container, styles.centered]}>
         <ActivityIndicator size="large" />
+      </ThemedView>
+    );
+  }
+
+  if (hasTaskError) {
+    return (
+      <ThemedView style={[styles.container, styles.centered]}>
+        <ThemedText>タスクの取得に失敗しました</ThemedText>
+        <Pressable
+          onPress={() => {
+            void Promise.all([
+              scheduledTasksQuery.refetch(),
+              unscheduledTasksQuery.refetch(),
+            ]);
+          }}
+        >
+          <ThemedText style={{ color: Colors[colorScheme].tint }}>
+            再試行
+          </ThemedText>
+        </Pressable>
       </ThemedView>
     );
   }

--- a/apps/mobile/app/task-form.tsx
+++ b/apps/mobile/app/task-form.tsx
@@ -62,11 +62,18 @@ export default function TaskFormScreen() {
     ...(scheduledTasksQuery.data ?? []),
     ...(unscheduledTasksQuery.data ?? []),
   ].find((value) => value.id === taskId);
+  const loadedTask = task ?? originalTask;
   const isLoadingTask =
     isEditing &&
+    !loadedTask &&
     (scheduledTasksQuery.isPending || unscheduledTasksQuery.isPending);
-  const hasTaskError =
-    isEditing && (scheduledTasksQuery.isError || unscheduledTasksQuery.isError);
+  const hasInitialTaskError =
+    isEditing &&
+    !loadedTask &&
+    !isLoadingTask &&
+    (scheduledTasksQuery.isError || unscheduledTasksQuery.isError);
+  const isTaskMissing =
+    isEditing && !loadedTask && !isLoadingTask && !hasInitialTaskError;
   const isSaving = createTaskMutation.isPending || updateTaskMutation.isPending;
 
   useEffect(() => {
@@ -80,6 +87,11 @@ export default function TaskFormScreen() {
   }, [task, taskId]);
 
   const handleSave = async () => {
+    if (isEditing && (!taskId || !loadedTask)) {
+      Alert.alert("エラー", "タスクが見つかりません");
+      return;
+    }
+
     const trimmedTitle = title.trim();
     if (!trimmedTitle) {
       Alert.alert("エラー", "タイトルを入力してください");
@@ -159,7 +171,7 @@ export default function TaskFormScreen() {
     );
   }
 
-  if (hasTaskError) {
+  if (hasInitialTaskError) {
     return (
       <ThemedView style={[styles.container, styles.centered]}>
         <ThemedText>タスクの取得に失敗しました</ThemedText>
@@ -173,6 +185,19 @@ export default function TaskFormScreen() {
         >
           <ThemedText style={{ color: Colors[colorScheme].tint }}>
             再試行
+          </ThemedText>
+        </Pressable>
+      </ThemedView>
+    );
+  }
+
+  if (isTaskMissing) {
+    return (
+      <ThemedView style={[styles.container, styles.centered]}>
+        <ThemedText>タスクが見つかりません</ThemedText>
+        <Pressable accessibilityRole="button" onPress={() => router.back()}>
+          <ThemedText style={{ color: Colors[colorScheme].tint }}>
+            戻る
           </ThemedText>
         </Pressable>
       </ThemedView>

--- a/apps/mobile/hooks/use-app-state-focus.ts
+++ b/apps/mobile/hooks/use-app-state-focus.ts
@@ -10,6 +10,7 @@ function onAppStateChange(status: AppStateStatus) {
 
 export function useAppStateFocus() {
   useEffect(() => {
+    onAppStateChange(AppState.currentState);
     const subscription = AppState.addEventListener("change", onAppStateChange);
     return () => subscription.remove();
   }, []);

--- a/apps/mobile/hooks/use-app-state-focus.ts
+++ b/apps/mobile/hooks/use-app-state-focus.ts
@@ -1,0 +1,16 @@
+import { useEffect } from "react";
+import { AppState, Platform, type AppStateStatus } from "react-native";
+import { focusManager } from "@tanstack/react-query";
+
+function onAppStateChange(status: AppStateStatus) {
+  if (Platform.OS !== "web") {
+    focusManager.setFocused(status === "active");
+  }
+}
+
+export function useAppStateFocus() {
+  useEffect(() => {
+    const subscription = AppState.addEventListener("change", onAppStateChange);
+    return () => subscription.remove();
+  }, []);
+}

--- a/apps/mobile/hooks/use-refresh-on-focus.ts
+++ b/apps/mobile/hooks/use-refresh-on-focus.ts
@@ -1,0 +1,25 @@
+import { useCallback, useRef } from "react";
+import { useFocusEffect } from "@react-navigation/native";
+import { useQueryClient } from "@tanstack/react-query";
+
+import { taskQueryKeys } from "@/hooks/use-tasks";
+
+export function useRefreshOnFocus() {
+  const queryClient = useQueryClient();
+  const isFirstFocus = useRef(true);
+
+  useFocusEffect(
+    useCallback(() => {
+      if (isFirstFocus.current) {
+        isFirstFocus.current = false;
+        return;
+      }
+
+      void queryClient.refetchQueries({
+        queryKey: taskQueryKeys.all,
+        stale: true,
+        type: "active",
+      });
+    }, [queryClient]),
+  );
+}

--- a/apps/mobile/hooks/use-tasks.ts
+++ b/apps/mobile/hooks/use-tasks.ts
@@ -1,0 +1,93 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import {
+  createTask,
+  deleteTask,
+  fetchTasksRange,
+  fetchUnscheduledTasks,
+  updateTask,
+} from "@/api/tasks";
+
+export const taskQueryKeys = {
+  all: ["tasks"] as const,
+  range: (startDate: string, endDate: string) =>
+    ["tasks", "range", startDate, endDate] as const,
+  unscheduled: ["tasks", "unscheduled"] as const,
+};
+
+function formatDateKey(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+export function getTaskDateRange(year: number, month: number) {
+  const firstDay = new Date(year, month - 1, 1);
+  const mondayOffset = (firstDay.getDay() + 6) % 7;
+  const start = new Date(year, month - 1, 1 - mondayOffset);
+  const end = new Date(
+    start.getFullYear(),
+    start.getMonth(),
+    start.getDate() + 41,
+  );
+  return { startDate: formatDateKey(start), endDate: formatDateKey(end) };
+}
+
+export function useTasks(year: number, month: number, enabled = true) {
+  const { startDate, endDate } = getTaskDateRange(year, month);
+  return useQuery({
+    enabled,
+    queryKey: taskQueryKeys.range(startDate, endDate),
+    queryFn: ({ signal }) => fetchTasksRange(startDate, endDate, signal),
+  });
+}
+
+export function useUnscheduledTasks(enabled = true) {
+  return useQuery({
+    enabled,
+    queryKey: taskQueryKeys.unscheduled,
+    queryFn: ({ signal }) => fetchUnscheduledTasks(signal),
+  });
+}
+
+type TaskInput = {
+  title: string;
+  description?: string | null;
+  date?: string | null;
+  status?: "todo" | "done";
+};
+
+type TaskUpdate = Omit<Partial<TaskInput>, "title"> & {
+  title?: string;
+};
+
+function useInvalidateTasks() {
+  const queryClient = useQueryClient();
+  return () => queryClient.invalidateQueries({ queryKey: taskQueryKeys.all });
+}
+
+export function useCreateTask() {
+  const invalidateTasks = useInvalidateTasks();
+  return useMutation({
+    mutationFn: (data: TaskInput) => createTask(data),
+    onSuccess: invalidateTasks,
+  });
+}
+
+export function useUpdateTask() {
+  const invalidateTasks = useInvalidateTasks();
+  return useMutation({
+    mutationFn: ({ id, data }: { id: string; data: TaskUpdate }) =>
+      updateTask(id, data),
+    onSuccess: invalidateTasks,
+  });
+}
+
+export function useDeleteTask() {
+  const invalidateTasks = useInvalidateTasks();
+  return useMutation({
+    mutationFn: (id: string) => deleteTask(id),
+    onSuccess: invalidateTasks,
+  });
+}

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -19,6 +19,7 @@
     "@react-navigation/bottom-tabs": "^7.4.0",
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",
+    "@tanstack/react-query": "^5.99.0",
     "expo": "~54.0.33",
     "expo-constants": "~18.0.13",
     "expo-font": "~14.0.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,6 +121,9 @@ importers:
       '@react-navigation/native':
         specifier: ^7.1.8
         version: 7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      '@tanstack/react-query':
+        specifier: ^5.99.0
+        version: 5.99.0(react@19.1.0)
       expo:
         specifier: ~54.0.33
         version: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
@@ -10414,6 +10417,11 @@ snapshots:
   '@tanstack/history@1.161.6': {}
 
   '@tanstack/query-core@5.99.0': {}
+
+  '@tanstack/react-query@5.99.0(react@19.1.0)':
+    dependencies:
+      '@tanstack/query-core': 5.99.0
+      react: 19.1.0
 
   '@tanstack/react-query@5.99.0(react@19.2.5)':
     dependencies:


### PR DESCRIPTION
Closes #257

## 目的

モバイル版で画面ごとに手動管理していたタスクのサーバー状態を TanStack Query の query / mutation へ移行し、取得状態・キャッシュ・再取得・更新後の整合性を統一します。

## 変更内容

- `apps/mobile` に `@tanstack/react-query` と `QueryClientProvider` を追加
- 表示中の42日範囲と未スケジュールタスクを、安定した query key を持つ `useQuery` フックへ移行
- 作成・更新・ステータス変更・削除を `useMutation` へ移行し、成功後に task query を invalidation
- AppState と画面フォーカスを TanStack Query の focus/refetch 管理へ接続
- 月変更、Pull to Refresh、画面復帰時の再取得を Query 状態へ統合
- task form の対象不在、初回取得エラー、部分エラーを区別
- query key、mutation invalidation、AppState、task form の回帰テストを追加

## 影響範囲

- `apps/mobile/app/_layout.tsx`
- `apps/mobile/app/(tabs)/index.tsx`
- `apps/mobile/app/task-form.tsx`
- `apps/mobile/hooks/`
- `apps/mobile/api/tasks.ts`
- `apps/mobile/package.json`
- `pnpm-lock.yaml`
- `apps/mobile/__tests__/`

## ローカル検証

- `pnpm --filter @tascal/mobile run test` — 24 tests passed
- `pnpm --filter @tascal/mobile run lint`
- `pnpm --filter @tascal/mobile run format:check`
- `pnpm --filter @tascal/mobile run typecheck`
- Expo production bundle: iOS / Android とも成功

## 受け入れ条件・レビュー

- acceptance-check: ✓ 7 / ✗ 0 / ? 1
  - 実機操作を伴う iOS / Android CRUD 維持のみ自動判定外
  - 両 platform bundle、既存・追加テスト、CRUD 経路の照合により実装側で通過判定
- cross-review: critical 0
  - warning 4件は追加 commit `1b1e88c` で対応済み

## 公式資料

- [TanStack Query: React Native](https://tanstack.com/query/latest/docs/framework/react/react-native)
- [TanStack Query: Query Invalidation](https://tanstack.com/query/latest/docs/framework/react/guides/query-invalidation)
- [TanStack Query: Installation](https://tanstack.com/query/latest/docs/framework/react/installation)
