### PR TITLE
WebとMobileの共通デザイントークンを単一ソース化する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,27 @@ on:
     branches: [main]
 
 jobs:
+  design-tokens:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Lint
+        run: pnpm --filter @tascal/design-tokens run lint
+      - name: Format check
+        run: pnpm --filter @tascal/design-tokens run format:check
+      - name: Type check
+        run: pnpm --filter @tascal/design-tokens run typecheck
+      - name: Test
+        run: pnpm --filter @tascal/design-tokens run test
+      - name: Build
+        run: pnpm --filter @tascal/design-tokens run build
+
   shared:
     runs-on: ubuntu-latest
     steps:
@@ -63,6 +84,8 @@ jobs:
         run: pnpm --filter @tascal/web run format:check
       - name: Type check
         run: pnpm --filter @tascal/web run typecheck
+      - name: Build
+        run: pnpm --filter @tascal/web run build
       - name: Test
         run: pnpm --filter @tascal/web run test
       - name: Knip

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,13 @@ COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 COPY apps/web/package.json apps/web/package.json
 COPY apps/api/package.json apps/api/package.json
 COPY apps/cli/package.json apps/cli/package.json
+COPY packages/design-tokens/package.json packages/design-tokens/package.json
 COPY packages/shared/package.json packages/shared/package.json
 RUN pnpm install --frozen-lockfile
 COPY tsconfig.json ./
 COPY apps/api/tsconfig.json apps/api/tsconfig.json
 COPY apps/api/src/ apps/api/src/
+COPY packages/design-tokens/ packages/design-tokens/
 COPY packages/shared/ packages/shared/
 COPY apps/web/ apps/web/
 RUN pnpm --filter @tascal/web run build
@@ -24,6 +26,7 @@ COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 COPY apps/api/package.json apps/api/package.json
 COPY apps/web/package.json apps/web/package.json
 COPY apps/cli/package.json apps/cli/package.json
+COPY packages/design-tokens/package.json packages/design-tokens/package.json
 COPY packages/shared/package.json packages/shared/package.json
 RUN pnpm install --frozen-lockfile
 COPY tsconfig.json ./

--- a/apps/mobile/constants/theme.ts
+++ b/apps/mobile/constants/theme.ts
@@ -3,33 +3,30 @@
  * There are many other ways to style your app. For example, [Nativewind](https://www.nativewind.dev/), [Tamagui](https://tamagui.dev/), [unistyles](https://reactnativeunistyles.vercel.app), etc.
  */
 
+import { semanticColors } from "@tascal/design-tokens";
 import { Platform } from "react-native";
-
-// Keep these semantic colors aligned with apps/web/src/index.css.
-const primary = "#4a4181";
-const primaryMuted = "#7a73a8";
 
 export const Colors = {
   light: {
-    text: "#2d2a26",
+    text: semanticColors.text.base,
     background: "#fff",
-    tint: primary,
-    tintBackground: primary,
+    tint: semanticColors.primary.base,
+    tintBackground: semanticColors.primary.base,
     onTint: "#fff",
-    icon: "#6b6560",
-    muted: "#a09a94",
-    surface: "#f5f4f0",
+    icon: semanticColors.text.secondary,
+    muted: semanticColors.text.muted,
+    surface: semanticColors.surface.base,
     glassTint: "rgba(245, 244, 240, 0.72)",
-    surfaceHover: "#eeedea",
-    border: "#cbc8c0",
-    borderLight: "#dddbd5",
+    surfaceHover: semanticColors.surface.hover,
+    border: semanticColors.border.base,
+    borderLight: semanticColors.border.light,
     controlBorder: "#8b857f",
-    danger: "#881337",
-    tabIconDefault: "#6b6560",
-    tabIconSelected: primary,
+    danger: semanticColors.danger.base,
+    tabIconDefault: semanticColors.text.secondary,
+    tabIconSelected: semanticColors.primary.base,
   },
   dark: {
-    text: "#f5f4f0",
+    text: semanticColors.surface.base,
     background: "#17151a",
     tint: "#b8b2dc",
     tintBackground: "#8881b4",
@@ -44,7 +41,7 @@ export const Colors = {
     controlBorder: "#706b75",
     danger: "#e89aae",
     tabIconDefault: "#c0bbb6",
-    tabIconSelected: primaryMuted,
+    tabIconSelected: semanticColors.primary.muted,
   },
 };
 

--- a/apps/mobile/constants/theme.ts
+++ b/apps/mobile/constants/theme.ts
@@ -26,7 +26,7 @@ export const Colors = {
     tabIconSelected: semanticColors.primary.base,
   },
   dark: {
-    text: semanticColors.surface.base,
+    text: "#f5f4f0",
     background: "#17151a",
     tint: "#b8b2dc",
     tintBackground: "#8881b4",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -19,6 +19,7 @@
     "@react-navigation/bottom-tabs": "^7.4.0",
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",
+    "@tascal/design-tokens": "workspace:*",
     "@tascal/shared": "workspace:*",
     "@tanstack/react-query": "^5.99.0",
     "expo": "~54.0.33",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
     "@headlessui/react": "^2.2.10",
+    "@tascal/design-tokens": "workspace:*",
     "@tascal/shared": "workspace:*",
     "@tanstack/react-query": "^5.97.0",
     "@tanstack/react-router": "^1.167.3",

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1,28 +1,2 @@
 @import "tailwindcss";
-
-@theme {
-  /* Primary — Dusty Indigo */
-  --color-primary: #4a4181;
-  --color-primary-dark: #3d366d;
-  --color-primary-light: #edecf3;
-  --color-primary-lighter: #f3f2f8;
-  --color-primary-muted: #7a73a8;
-
-  /* Danger / Error */
-  --color-danger: #881337;
-  --color-danger-dark: #6e0f2d;
-  --color-danger-light: #f5e6eb;
-
-  /* Surface */
-  --color-surface: #f5f4f0;
-  --color-surface-hover: #eeedea;
-
-  /* Text */
-  --color-on-surface: #2d2a26;
-  --color-on-surface-secondary: #6b6560;
-  --color-on-surface-muted: #a09a94;
-
-  /* Border */
-  --color-border: #cbc8c0;
-  --color-border-light: #dddbd5;
-}
+@import "@tascal/design-tokens/theme.css";

--- a/packages/design-tokens/README.md
+++ b/packages/design-tokens/README.md
@@ -1,0 +1,9 @@
+# `@tascal/design-tokens`
+
+Web と Mobile で意味と値を共有する semantic color token を管理する、プラットフォーム非依存の package です。
+
+- `src/index.ts`: 唯一の手編集対象となる token 定義
+- `theme.css`: Tailwind CSS v4 用の生成物（直接編集しない）
+- `pnpm generate`: token 定義から `theme.css` を再生成
+
+Web / Mobile 固有の theme mapping と固有色は、それぞれのアプリ側に残します。`pnpm build` と `pnpm test` は生成物が token 定義と一致しない場合に失敗します。

--- a/packages/design-tokens/eslint.config.js
+++ b/packages/design-tokens/eslint.config.js
@@ -1,0 +1,19 @@
+import js from "@eslint/js";
+import tseslint from "typescript-eslint";
+
+export default tseslint.config(
+  js.configs.recommended,
+  ...tseslint.configs.recommendedTypeChecked,
+  {
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+  {
+    files: ["**/*.js"],
+    ...tseslint.configs.disableTypeChecked,
+  },
+);

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@tascal/design-tokens",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./theme.css": "./theme.css"
+  },
+  "scripts": {
+    "build": "tsx scripts/generate-theme-css.ts --check",
+    "generate": "tsx scripts/generate-theme-css.ts",
+    "lint": "eslint .",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@eslint/js": "9.39.4",
+    "@types/node": "22.19.17",
+    "eslint": "9.39.4",
+    "prettier": "3.8.2",
+    "tsx": "4.21.0",
+    "typescript": "6.0.2",
+    "typescript-eslint": "8.58.2",
+    "vitest": "4.1.4"
+  }
+}

--- a/packages/design-tokens/scripts/generate-theme-css.ts
+++ b/packages/design-tokens/scripts/generate-theme-css.ts
@@ -1,0 +1,19 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { createTailwindThemeCss } from "../src/theme-css";
+
+const outputPath = fileURLToPath(new URL("../theme.css", import.meta.url));
+const expected = createTailwindThemeCss();
+
+if (process.argv.includes("--check")) {
+  const actual = await readFile(outputPath, "utf8").catch(() => "");
+
+  if (actual !== expected) {
+    console.error(
+      "packages/design-tokens/theme.css is stale. Run `pnpm --filter @tascal/design-tokens generate`.",
+    );
+    process.exitCode = 1;
+  }
+} else {
+  await writeFile(outputPath, expected);
+}

--- a/packages/design-tokens/src/index.ts
+++ b/packages/design-tokens/src/index.ts
@@ -1,0 +1,35 @@
+/**
+ * Platform-independent semantic colors shared by Web and Mobile.
+ *
+ * Keep platform theme mappings in each app. This object is the single source
+ * for values that have the same meaning and appearance on both platforms.
+ */
+export const semanticColors = {
+  primary: {
+    base: "#4a4181",
+    dark: "#3d366d",
+    light: "#edecf3",
+    lighter: "#f3f2f8",
+    muted: "#7a73a8",
+  },
+  danger: {
+    base: "#881337",
+    dark: "#6e0f2d",
+    light: "#f5e6eb",
+  },
+  surface: {
+    base: "#f5f4f0",
+    hover: "#eeedea",
+  },
+  text: {
+    base: "#2d2a26",
+    secondary: "#6b6560",
+    muted: "#a09a94",
+  },
+  border: {
+    base: "#cbc8c0",
+    light: "#dddbd5",
+  },
+} as const;
+
+export type SemanticColors = typeof semanticColors;

--- a/packages/design-tokens/src/theme-css.test.ts
+++ b/packages/design-tokens/src/theme-css.test.ts
@@ -1,0 +1,38 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+import { semanticColors } from "./index";
+import { createTailwindThemeCss } from "./theme-css";
+
+describe("design tokens", () => {
+  it("preserves the shared semantic palette", () => {
+    expect(semanticColors).toEqual({
+      primary: {
+        base: "#4a4181",
+        dark: "#3d366d",
+        light: "#edecf3",
+        lighter: "#f3f2f8",
+        muted: "#7a73a8",
+      },
+      danger: {
+        base: "#881337",
+        dark: "#6e0f2d",
+        light: "#f5e6eb",
+      },
+      surface: { base: "#f5f4f0", hover: "#eeedea" },
+      text: {
+        base: "#2d2a26",
+        secondary: "#6b6560",
+        muted: "#a09a94",
+      },
+      border: { base: "#cbc8c0", light: "#dddbd5" },
+    });
+  });
+
+  it("keeps the generated Tailwind theme in sync", async () => {
+    const generatedPath = new URL("../theme.css", import.meta.url);
+
+    await expect(readFile(generatedPath, "utf8")).resolves.toBe(
+      createTailwindThemeCss(),
+    );
+  });
+});

--- a/packages/design-tokens/src/theme-css.test.ts
+++ b/packages/design-tokens/src/theme-css.test.ts
@@ -4,27 +4,27 @@ import { semanticColors } from "./index";
 import { createTailwindThemeCss } from "./theme-css";
 
 describe("design tokens", () => {
-  it("preserves the shared semantic palette", () => {
-    expect(semanticColors).toEqual({
-      primary: {
-        base: "#4a4181",
-        dark: "#3d366d",
-        light: "#edecf3",
-        lighter: "#f3f2f8",
-        muted: "#7a73a8",
-      },
-      danger: {
-        base: "#881337",
-        dark: "#6e0f2d",
-        light: "#f5e6eb",
-      },
-      surface: { base: "#f5f4f0", hover: "#eeedea" },
-      text: {
-        base: "#2d2a26",
-        secondary: "#6b6560",
-        muted: "#a09a94",
-      },
-      border: { base: "#cbc8c0", light: "#dddbd5" },
+  it("exposes the shared semantic token structure", () => {
+    expect(Object.keys(semanticColors)).toEqual([
+      "primary",
+      "danger",
+      "surface",
+      "text",
+      "border",
+    ]);
+    expect(
+      Object.fromEntries(
+        Object.entries(semanticColors).map(([group, tokens]) => [
+          group,
+          Object.keys(tokens),
+        ]),
+      ),
+    ).toEqual({
+      primary: ["base", "dark", "light", "lighter", "muted"],
+      danger: ["base", "dark", "light"],
+      surface: ["base", "hover"],
+      text: ["base", "secondary", "muted"],
+      border: ["base", "light"],
     });
   });
 

--- a/packages/design-tokens/src/theme-css.ts
+++ b/packages/design-tokens/src/theme-css.ts
@@ -1,0 +1,27 @@
+import { semanticColors } from "./index";
+
+const tailwindThemeColors = [
+  ["primary", semanticColors.primary.base],
+  ["primary-dark", semanticColors.primary.dark],
+  ["primary-light", semanticColors.primary.light],
+  ["primary-lighter", semanticColors.primary.lighter],
+  ["primary-muted", semanticColors.primary.muted],
+  ["danger", semanticColors.danger.base],
+  ["danger-dark", semanticColors.danger.dark],
+  ["danger-light", semanticColors.danger.light],
+  ["surface", semanticColors.surface.base],
+  ["surface-hover", semanticColors.surface.hover],
+  ["on-surface", semanticColors.text.base],
+  ["on-surface-secondary", semanticColors.text.secondary],
+  ["on-surface-muted", semanticColors.text.muted],
+  ["border", semanticColors.border.base],
+  ["border-light", semanticColors.border.light],
+] as const;
+
+export function createTailwindThemeCss(): string {
+  const variables = tailwindThemeColors
+    .map(([name, value]) => `  --color-${name}: ${value};`)
+    .join("\n");
+
+  return `/* Generated from src/index.ts by pnpm generate. Do not edit. */\n@theme {\n${variables}\n}\n`;
+}

--- a/packages/design-tokens/theme.css
+++ b/packages/design-tokens/theme.css
@@ -1,0 +1,18 @@
+/* Generated from src/index.ts by pnpm generate. Do not edit. */
+@theme {
+  --color-primary: #4a4181;
+  --color-primary-dark: #3d366d;
+  --color-primary-light: #edecf3;
+  --color-primary-lighter: #f3f2f8;
+  --color-primary-muted: #7a73a8;
+  --color-danger: #881337;
+  --color-danger-dark: #6e0f2d;
+  --color-danger-light: #f5e6eb;
+  --color-surface: #f5f4f0;
+  --color-surface-hover: #eeedea;
+  --color-on-surface: #2d2a26;
+  --color-on-surface-secondary: #6b6560;
+  --color-on-surface-muted: #a09a94;
+  --color-border: #cbc8c0;
+  --color-border-light: #dddbd5;
+}

--- a/packages/design-tokens/tsconfig.json
+++ b/packages/design-tokens/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["scripts", "src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,6 +124,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.99.0
         version: 5.99.0(react@19.1.0)
+      '@tascal/design-tokens':
+        specifier: workspace:*
+        version: link:../../packages/design-tokens
       '@tascal/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -236,6 +239,9 @@ importers:
       '@tanstack/react-router':
         specifier: ^1.167.3
         version: 1.168.18(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@tascal/design-tokens':
+        specifier: workspace:*
+        version: link:../../packages/design-tokens
       '@tascal/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -300,6 +306,33 @@ importers:
       vite:
         specifier: ^6.4.3
         version: 6.4.3(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
+  packages/design-tokens:
+    devDependencies:
+      '@eslint/js':
+        specifier: 9.39.4
+        version: 9.39.4
+      '@types/node':
+        specifier: 22.19.17
+        version: 22.19.17
+      eslint:
+        specifier: 9.39.4
+        version: 9.39.4(jiti@2.6.1)
+      prettier:
+        specifier: 3.8.2
+        version: 3.8.2
+      tsx:
+        specifier: 4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: 6.0.2
+        version: 6.0.2
+      typescript-eslint:
+        specifier: 8.58.2
+        version: 8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2)
+      vitest:
+        specifier: 4.1.4
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@6.4.3(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/shared:
     dependencies:


### PR DESCRIPTION
close #267

## 目的

Web と Mobile で重複していた semantic color token を、プラットフォーム非依存の `@tascal/design-tokens` workspace packageへ集約します。配色と Mobile の light/dark・OS追従挙動は維持します。

## 変更内容

- `packages/design-tokens` に共通 token の正本と Tailwind CSS v4用の生成処理を追加
- `apps/web/src/index.css` から生成済み `theme.css` を import
- `apps/mobile/constants/theme.ts` の共通色を token 参照へ置換し、Mobile固有のdark色・mappingはアプリ側に維持
- 生成CSSの未更新を検出する test/build と専用CI jobを追加
- DockerのWeb/API build stageで新規workspaceを解決できるようCOPY対象を更新
- Web CIでproduction buildを検証

## 影響パス

- `packages/design-tokens/`
- `apps/web/src/index.css`
- `apps/web/package.json`
- `apps/mobile/constants/theme.ts`
- `apps/mobile/package.json`
- `.github/workflows/ci.yml`
- `Dockerfile`
- `pnpm-lock.yaml`

## 検証

- `pnpm lint`
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `docker build --progress=plain -t tascal:issue-267-review .`
- acceptance-check: 9/9 ✓
- independent cross-review: critical 0 / warning 0 / info 0

## 参考資料

- [Tailwind CSS: Theme variables](https://tailwindcss.com/docs/theme)
- [React Native: useColorScheme](https://reactnative.dev/docs/usecolorscheme)
- [Expo: Color themes](https://docs.expo.dev/develop/user-interface/color-themes/)
