### PR TITLE
Mobileの見た目確認を標準化するagent skillを追加する

### DIFF
--- a/.agents/skills/mobile-visual-check/SKILL.md
+++ b/.agents/skills/mobile-visual-check/SKILL.md
@@ -68,16 +68,17 @@ git diff --name-status "origin/${DEFAULT_BRANCH}...HEAD"
 
 選定結果を先に表へまとめる。
 
-| Story                  | diff との関係                | 確認する状態      | Theme       | Device class      |
-| ---------------------- | ---------------------------- | ----------------- | ----------- | ----------------- |
-| `Components/... / ...` | 変更 component を直接 render | long / empty など | light, dark | compact, standard |
+| Story                  | diff との関係                | 確認する状態      | Theme      | Device class      |
+| ---------------------- | ---------------------------- | ----------------- | ---------- | ----------------- |
+| `Components/... / ...` | 変更 component を直接 render | long / empty など | 関連 theme | 関連 device class |
 
 ## 3. 確認 matrix を作る
 
-対象 story はすべて standard 端末の light / dark で確認する。さらに、折り返し、横幅、
-bottom sheet、safe area、重なりに影響する story は compact 端末でも light / dark を
-確認する。色以外の変更でも dark 固有のコントラストや native material があるため、
-片方を省略しない。
+matrix 全体で compact / standard の両端末と light / dark の両 theme を含める。
+折り返し、横幅、safe area に関係する state は両端末で、色、contrast、native material
+に関係する state は両 theme で確認する。state と theme が相互作用する変更だけはその
+組み合わせも確認する。全 state × 全 theme の直積を機械的に要求せず、diff の visual
+concern を各条件で代表できる最小 matrix にする。
 
 端末名を固定せず、`xcrun simctl list devices available` から利用可能な iPhone を選ぶ。
 
@@ -91,6 +92,11 @@ bottom sheet、safe area、重なりに影響する story は compact 端末で�
 `MultipleTasks`、`LongTitle`、通常状態を確認する。必要な state / theme の組み合わせを
 fixture や Controls で再現できず、対応 story もなければ coverage blocker とする。
 この視覚確認の途中で UI を勝手に修正したり、scope 外の story を追加したりしない。
+
+`.rnstorybook/preview.tsx` の safe-area `initialMetrics` は 390×844 に固定されている。
+compact / standard の実画面幅による折り返しや配置は比較できるが、端末固有の safe-area
+insets は比較できない。safe area が変更対象ならこの制約を Remaining issues に記録し、
+Storybook だけで検証済みにしない。
 
 ## 4. Simulator と Storybook を起動する
 
@@ -117,9 +123,10 @@ pnpm --filter @tascal/mobile storybook:ios
 Metro cache が原因で story が見つからない場合は、既存 process を止めてから
 `pnpm --filter @tascal/mobile storybook --clear` を試す。
 
-複数 Simulator が boot 済みなら、Storybook が matrix の UDID / model に表示された
-ことを Simulator window と `xcrun simctl list devices` の両方で確認する。別端末に
-表示されたまま検査を続けない。
+`storybook:ios` の実体である `expo start --ios` には UDID 指定がない。Simulator UI で
+対象 device を active にしてから起動し、Storybook が matrix の UDID / model に表示された
+ことを Simulator window と `xcrun simctl list devices` の両方で確認する。複数 Simulator
+が boot 済みで対象を確定できない場合は、別端末の証拠で続けず blocker とする。
 
 ## 5. Story を表示して証拠を取る
 
@@ -162,6 +169,12 @@ xcrun simctl io <DEVICE_UDID> screenshot \
 
 主観的な違和感は断定せず、story / screenshot / 観察事実を添える。
 
+Liquid Glass が対象なら、対応する iOS runtime で「設定 > アクセシビリティ > 画面表示と
+テキストサイズ > 透明度を下げる」を off にして native glass を、on にして不透明な
+fallback surface を確認する。切り替え後は story を再選択し、`SheetSurface` の実装が
+参照する accessibility state を更新させる。利用可能なら非対応 runtime の fallback も
+追加する。対応 runtime がなく native 表現を再現できない場合は未確認条件として報告する。
+
 ## 7. Tool fallback と blocker
 
 次の順で fallback する。
@@ -177,6 +190,11 @@ xcrun simctl io <DEVICE_UDID> screenshot \
 
 fallback でも story、device、theme を証拠から識別できることが必要。証拠なしに pass を
 宣言しない。
+
+- `pass`: 全 matrix に証拠があり、未解決 finding / blocker がない
+- `partial`: 対象 UI の証拠は一部取得できたが、matrix の一部または再現条件が未確認
+- `blocked`: 対象 UI を示す信頼できる screenshot がない、Storybook を起動できない、
+  または変更の中心を表す story / state がない
 
 ## 8. 報告形式
 
@@ -202,6 +220,9 @@ fallback でも story、device、theme を証拠から識別できることが�
 ```
 
 `Status: pass` は matrix の全行に証拠があり、重大な finding と blocker がない場合だけ使う。
+共有可能な review / PR が成果物なら、利用可能な添付機能で screenshot を共有し、Evidence
+から参照できるようにする。依頼がなければ screenshot を repository に commit せず、添付
+できない環境では一時 path と共有 blocker を報告する。
 
 ## 参考資料
 
@@ -209,4 +230,5 @@ fallback でも story、device、theme を証拠から識別できることが�
 - [React Native Storybook: Getting started](https://storybookjs.github.io/react-native/docs/intro/getting-started/)
 - [React Native Storybook: Writing stories](https://storybookjs.github.io/react-native/docs/intro/writing-stories/)
 - [React Native Storybook: Storybook UI configuration](https://storybookjs.github.io/react-native/docs/intro/configuration/storybook-ui-configuration/)
+- [Expo: GlassEffect](https://docs.expo.dev/versions/latest/sdk/glass-effect/)
 - [`apps/mobile/README.md`](../../../apps/mobile/README.md)

--- a/.agents/skills/mobile-visual-check/SKILL.md
+++ b/.agents/skills/mobile-visual-check/SKILL.md
@@ -68,8 +68,8 @@ git diff --name-status "origin/${DEFAULT_BRANCH}...HEAD"
 
 選定結果を先に表へまとめる。
 
-| Story | diff との関係 | 確認する状態 | Theme | Device class |
-| --- | --- | --- | --- | --- |
+| Story                  | diff との関係                | 確認する状態      | Theme       | Device class      |
+| ---------------------- | ---------------------------- | ----------------- | ----------- | ----------------- |
 | `Components/... / ...` | 変更 component を直接 render | long / empty など | light, dark | compact, standard |
 
 ## 3. 確認 matrix を作る
@@ -188,9 +188,9 @@ fallback でも story、device、theme を証拠から識別できることが�
 - Storybook: <起動 command と結果>
 - Artifacts: <screenshot directory / 添付>
 
-| Story / state | Device (runtime) | Theme | Result | Evidence |
-| --- | --- | --- | --- | --- |
-| Components/... / LongTitle | compact model (iOS ...) | dark | pass / issue / blocked | path or attachment |
+| Story / state              | Device (runtime)        | Theme | Result                 | Evidence           |
+| -------------------------- | ----------------------- | ----- | ---------------------- | ------------------ |
+| Components/... / LongTitle | compact model (iOS ...) | dark  | pass / issue / blocked | path or attachment |
 
 ### Findings
 

--- a/.agents/skills/mobile-visual-check/SKILL.md
+++ b/.agents/skills/mobile-visual-check/SKILL.md
@@ -1,0 +1,212 @@
+---
+name: mobile-visual-check
+description: "tascal の Mobile UI を実装・変更・レビューしたときに、React Native Storybook と iOS Simulator で対象 story を選定し、light/dark・端末サイズ・関連状態を目視確認してスクリーンショット付きで報告する。apps/mobile のコンポーネント、画面、theme、design token、Liquid Glass など見た目に影響する変更では明示指定がなくても使用する。API、DB、CLI、テスト、型、ロジック、依存関係だけの非視覚的な変更では使用しない。Storybook の導入・upgrade 自体には使用しない。"
+---
+
+# Mobile visual check
+
+tascal の Mobile UI 変更を、既存の React Native Storybook と iOS Simulator で
+再現可能に目視確認する。setup、VRT、E2E、UI の自動修正は扱わない。
+
+## 完了条件
+
+次をすべて満たしたときだけ視覚確認を pass とする。
+
+- diff から見た目に影響する変更と対応 story を説明できる
+- 対象 story を iOS Simulator 上で実際に表示した
+- light / dark、compact / standard の 2 サイズ、変更に関係する状態を確認した
+- 各確認条件を識別できるスクリーンショットを保存した
+- チェックリストを適用し、結果と残課題を所定の形式で報告した
+
+一部しか実行できない場合は partial または blocked とする。コードを読んだだけで
+目視確認を pass にしない。
+
+## 1. Scope gate
+
+まず依頼と diff を読み、この skill の対象か判定する。
+
+対象になる例:
+
+- `apps/mobile` の画面、visual component、style、asset、animation、safe area
+- `apps/mobile/constants/theme.ts` や `packages/design-tokens` の見た目に関わる変更
+- Liquid Glass など native 表現や fallback 表示の変更
+- Mobile UI の PR review、見た目確認、スクリーンショット取得
+
+対象外になる例:
+
+- API、DB、Web、CLI だけの変更
+- Mobile でも data fetching、認証、型、test、build 設定だけで見た目が変わらない変更
+- Storybook の導入、設定移行、version upgrade（公式 setup skill / docs の領域）
+
+対象外なら「非視覚的な変更のため mobile visual check は不要」と短く報告して終了する。
+見た目への影響が不明なら、消極的に除外せず diff の consumer まで追跡する。
+
+## 2. Diff から story を選ぶ
+
+ユーザーが base / compare range を指定していればそれを優先する。指定がなければ
+GitHub から default branch を解決し、working tree、staged diff、default branch
+との branch diff を確認する。
+
+```bash
+git status --short
+git diff --name-status
+git diff --cached --name-status
+DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')
+git diff --name-status "origin/${DEFAULT_BRANCH}...HEAD"
+```
+
+各 visual change を次の順で story に対応付ける。
+
+1. 変更 component と同じ directory の `*.stories.tsx` を探す。
+2. import と render tree を `rg` で追い、変更 component を含む親 component の
+   story を加える。
+3. theme、design token、Storybook decorator、共有 surface の変更では、その値を
+   import する story と representative な component story を加える。
+4. rename / delete では旧参照が残っていないか確認し、置換先 story を選ぶ。
+5. route 固有 UI など対応 story がなければ、関連 component story で確認できる範囲と
+   coverage gap を分ける。未確認部分を pass にせず blocker として報告する。
+
+選定結果を先に表へまとめる。
+
+| Story | diff との関係 | 確認する状態 | Theme | Device class |
+| --- | --- | --- | --- | --- |
+| `Components/... / ...` | 変更 component を直接 render | long / empty など | light, dark | compact, standard |
+
+## 3. 確認 matrix を作る
+
+対象 story はすべて standard 端末の light / dark で確認する。さらに、折り返し、横幅、
+bottom sheet、safe area、重なりに影響する story は compact 端末でも light / dark を
+確認する。色以外の変更でも dark 固有のコントラストや native material があるため、
+片方を省略しない。
+
+端末名を固定せず、`xcrun simctl list devices available` から利用可能な iPhone を選ぶ。
+
+- compact: 利用可能な中で画面幅または高さが小さい iPhone
+- standard: 日常開発で使う現行相当の標準的な iPhone
+
+実際の model、iOS runtime、向き、必要なら viewport を報告する。iPad や landscape
+への影響が diff から予想される場合だけ追加する。
+
+状態は変更に関係するものを選ぶ。最低限、該当する既存 story の `Empty`、
+`MultipleTasks`、`LongTitle`、通常状態を確認する。必要な state / theme の組み合わせを
+fixture や Controls で再現できず、対応 story もなければ coverage blocker とする。
+この視覚確認の途中で UI を勝手に修正したり、scope 外の story を追加したりしない。
+
+## 4. Simulator と Storybook を起動する
+
+repository root で前提を確認する。
+
+```bash
+command -v xcrun
+xcrun simctl list devices available
+test -f apps/mobile/.rnstorybook/index.ts
+```
+
+compact と standard の device identifier を記録する。対象 Simulator を boot し、
+boot 完了を待ってから tascal の script で Storybook を起動する。
+
+```bash
+open -a Simulator
+xcrun simctl boot <DEVICE_UDID> 2>/dev/null || true
+xcrun simctl bootstatus <DEVICE_UDID> -b
+pnpm --filter @tascal/mobile storybook:ios
+```
+
+`storybook:ios` は `STORYBOOK_ENABLED=true` を設定し、Metro の entry-point swapping
+で `.rnstorybook/index.ts` を表示する。通常アプリの `ios` script で代用しない。
+Metro cache が原因で story が見つからない場合は、既存 process を止めてから
+`pnpm --filter @tascal/mobile storybook --clear` を試す。
+
+複数 Simulator が boot 済みなら、Storybook が matrix の UDID / model に表示された
+ことを Simulator window と `xcrun simctl list devices` の両方で確認する。別端末に
+表示されたまま検査を続けない。
+
+## 5. Story を表示して証拠を取る
+
+Storybook の on-device navigator を開き、Step 2 の `title` と named export に対応する
+story を選ぶ。UI 操作 tool が使えるなら story explorer の検索、選択、fullscreen
+切り替えを操作する。自動操作が使えない場合は、ユーザーへ選択だけを依頼し、表示中の
+story 名を画面で再確認してから続ける。
+
+tascal では light が既定で、dark story は
+`parameters: { colorScheme: "dark" }` により共通 decorator が theme、background、
+safe-area metrics を揃える。名前だけで theme を推測せず story 定義を確認する。
+
+各 matrix 行で Storybook controls を閉じ、story canvas が読める状態にしてから保存する。
+スクリーンショットは repo 外の一時 directory に置き、ファイル名に story、state、theme、
+device class を含める。
+
+```bash
+ARTIFACT_DIR="/tmp/tascal-mobile-visual-check-$(date +%Y%m%d-%H%M%S)"
+mkdir -p "$ARTIFACT_DIR"
+xcrun simctl io <DEVICE_UDID> screenshot \
+  "$ARTIFACT_DIR/<story>-<state>-<theme>-<device-class>.png"
+```
+
+取得直後に画像を開いて、誤った story、loading / error overlay、Storybook navigator の
+被り、空の screenshot でないことを確認する。
+
+## 6. 視覚チェックリスト
+
+各 screenshot と実機表示に次を適用する。
+
+- layout: alignment、spacing、safe area、画面端、bottom sheet 高さが意図どおりか
+- clipping: 長文、badge、button、scroll content が切れたり不自然に省略されないか
+- overlap: text、icon、sheet、keyboard / system UI が重なっていないか
+- contrast: light / dark の text、icon、surface、disabled state が判別できるか
+- state: empty、複数件、長文など変更に関係する差が正しく表現されるか
+- native: Liquid Glass、blur、shadow、corner、system symbol が対応 runtime で native
+  らしく見えるか。fallback が変更対象なら fallback runtime / 条件も別に確認する
+- consistency: `apps/mobile/constants/theme.ts` と `@tascal/design-tokens` に沿い、
+  Web の見た目をそのまま模倣していないか
+
+主観的な違和感は断定せず、story / screenshot / 観察事実を添える。
+
+## 7. Tool fallback と blocker
+
+次の順で fallback する。
+
+1. Simulator の UI 操作 tool がない: ユーザーに story 選択と theme 切り替えを依頼し、
+   `xcrun simctl io` で agent が screenshot を取得する。
+2. `xcrun simctl io ... screenshot` が使えない: UI 操作 tool の screenshot、または
+   ユーザー提供画像を使い、取得方法を報告する。
+3. Simulator / Xcode runtime / Storybook 起動 / UI 操作 / screenshot のいずれも代替
+   できない: static review で判明した対象と matrix だけを報告し、status を blocked にする。
+4. 対応 story や必要状態がない: coverage gap を blocker にする。無関係な story の画像で
+   代用しない。
+
+fallback でも story、device、theme を証拠から識別できることが必要。証拠なしに pass を
+宣言しない。
+
+## 8. 報告形式
+
+```markdown
+## Mobile visual check
+
+- Status: pass | partial | blocked
+- Diff: <比較範囲または対象変更>
+- Storybook: <起動 command と結果>
+- Artifacts: <screenshot directory / 添付>
+
+| Story / state | Device (runtime) | Theme | Result | Evidence |
+| --- | --- | --- | --- | --- |
+| Components/... / LongTitle | compact model (iOS ...) | dark | pass / issue / blocked | path or attachment |
+
+### Findings
+
+- [severity] <layout / clipping / overlap / contrast / state / native の観察事実>
+
+### Remaining issues
+
+- <coverage gap、未確認 matrix、tool blocker。なければ「なし」>
+```
+
+`Status: pass` は matrix の全行に証拠があり、重大な finding と blocker がない場合だけ使う。
+
+## 参考資料
+
+- [OpenAI: Build skills](https://developers.openai.com/codex/skills)
+- [React Native Storybook: Getting started](https://storybookjs.github.io/react-native/docs/intro/getting-started/)
+- [React Native Storybook: Writing stories](https://storybookjs.github.io/react-native/docs/intro/writing-stories/)
+- [React Native Storybook: Storybook UI configuration](https://storybookjs.github.io/react-native/docs/intro/configuration/storybook-ui-configuration/)
+- [`apps/mobile/README.md`](../../../apps/mobile/README.md)

--- a/.agents/skills/mobile-visual-check/SKILL.md
+++ b/.agents/skills/mobile-visual-check/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mobile-visual-check
-description: "tascal の Mobile UI を実装・変更・レビューしたときに、React Native Storybook と iOS Simulator で対象 story を選定し、light/dark・端末サイズ・関連状態を目視確認してスクリーンショット付きで報告する。apps/mobile のコンポーネント、画面、theme、design token、Liquid Glass など見た目に影響する変更では明示指定がなくても使用する。API、DB、CLI、テスト、型、ロジック、依存関係だけの非視覚的な変更では使用しない。Storybook の導入・upgrade 自体には使用しない。"
+description: "tascal の Mobile UI を実装・変更・レビューしたときに、React Native Storybook と iOS Simulator で対象 story を選定し、light/dark・端末サイズ・関連状態を目視確認してスクリーンショット付きで報告する。apps/mobile のコンポーネント、画面、theme、design token、Liquid Glass、Storybook 設定変更後の描画など見た目に影響する変更では明示指定がなくても使用する。API、DB、CLI、テスト、型、ロジック、依存関係だけの非視覚的な変更では使用しない。Storybook の導入・upgrade 作業そのものや build 確認だけには使用しない。"
 ---
 
 # Mobile visual check
@@ -30,13 +30,16 @@ tascal の Mobile UI 変更を、既存の React Native Storybook と iOS Simula
 - `apps/mobile` の画面、visual component、style、asset、animation、safe area
 - `apps/mobile/constants/theme.ts` や `packages/design-tokens` の見た目に関わる変更
 - Liquid Glass など native 表現や fallback 表示の変更
+- Storybook の設定移行・upgrade 後に、既存 story の描画、theme、decorator への
+  視覚的影響を確認する作業
 - Mobile UI の PR review、見た目確認、スクリーンショット取得
 
 対象外になる例:
 
 - API、DB、Web、CLI だけの変更
 - Mobile でも data fetching、認証、型、test、build 設定だけで見た目が変わらない変更
-- Storybook の導入、設定移行、version upgrade（公式 setup skill / docs の領域）
+- Storybook の導入、設定移行、version upgrade の実施や build 確認だけの作業
+  （公式 setup skill / docs の領域）。完了後の視覚的影響確認は対象に含む
 
 対象外なら「非視覚的な変更のため mobile visual check は不要」と短く報告して終了する。
 見た目への影響が不明なら、消極的に除外せず diff の consumer まで追跡する。
@@ -225,7 +228,7 @@ fallback でも story、device、theme を証拠から識別できることが�
 - <coverage gap、未確認 matrix、tool blocker。なければ「なし」>
 ```
 
-`Status: pass` は matrix の全行に証拠があり、重大な finding と blocker がない場合だけ使う。
+`Status: pass` は matrix の全行に証拠があり、未解決 finding と blocker がない場合だけ使う。
 共有可能な review / PR が成果物なら、利用可能な添付機能で screenshot を共有し、Evidence
 から参照できるようにする。依頼がなければ screenshot を repository に commit せず、添付
 できない環境では一時 path と共有 blocker を報告する。

--- a/.agents/skills/mobile-visual-check/SKILL.md
+++ b/.agents/skills/mobile-visual-check/SKILL.md
@@ -108,25 +108,30 @@ xcrun simctl list devices available
 test -f apps/mobile/.rnstorybook/index.ts
 ```
 
-compact と standard の device identifier を記録する。対象 Simulator を boot し、
-boot 完了を待ってから tascal の script で Storybook を起動する。
+tascal の script で Storybook の Metro server と Terminal UI を起動する。
 
 ```bash
-open -a Simulator
-xcrun simctl boot <DEVICE_UDID> 2>/dev/null || true
-xcrun simctl bootstatus <DEVICE_UDID> -b
-pnpm --filter @tascal/mobile storybook:ios
+pnpm --filter @tascal/mobile storybook
 ```
 
-`storybook:ios` は `STORYBOOK_ENABLED=true` を設定し、Metro の entry-point swapping
-で `.rnstorybook/index.ts` を表示する。通常アプリの `ios` script で代用しない。
+Terminal UI で `shift+i`（Select an iOS Simulator to open）を押し、まず compact、次に
+standard の model を picker から明示選択する。各選択後に boot 完了と UDID を確認し、
+その端末で対象 matrix の確認と screenshot 取得を終えてから `shift+i` で次へ切り替える。
+
+```bash
+xcrun simctl list devices available
+xcrun simctl bootstatus <SELECTED_DEVICE_UDID> -b
+```
+
+`storybook` は `STORYBOOK_ENABLED=true` を設定し、Metro の entry-point swapping で
+`.rnstorybook/index.ts` を表示する。通常アプリの `ios` script で代用しない。
+`storybook:ios` (`expo start --ios`) は既定 Simulator をすぐ開く単一端末 smoke には使えるが、
+UDID を指定できないため 2 端末 matrix では使わない。active window や先頭の booted device
+から対象を推測しない。picker の選択、Simulator window、`simctl` の model / UDID が一致
+しなければ blocker とする。
+
 Metro cache が原因で story が見つからない場合は、既存 process を止めてから
 `pnpm --filter @tascal/mobile storybook --clear` を試す。
-
-`storybook:ios` の実体である `expo start --ios` には UDID 指定がない。Simulator UI で
-対象 device を active にしてから起動し、Storybook が matrix の UDID / model に表示された
-ことを Simulator window と `xcrun simctl list devices` の両方で確認する。複数 Simulator
-が boot 済みで対象を確定できない場合は、別端末の証拠で続けず blocker とする。
 
 ## 5. Story を表示して証拠を取る
 
@@ -179,8 +184,9 @@ fallback surface を確認する。切り替え後は story を再選択し、`S
 
 次の順で fallback する。
 
-1. Simulator の UI 操作 tool がない: ユーザーに story 選択と theme 切り替えを依頼し、
-   `xcrun simctl io` で agent が screenshot を取得する。
+1. Terminal / Simulator の UI 操作 tool がない: ユーザーに `shift+i` での端末選択と
+   story 選択を依頼し、選択した model / UDID を照合してから agent が
+   `xcrun simctl io` で screenshot を取得する。
 2. `xcrun simctl io ... screenshot` が使えない: UI 操作 tool の screenshot、または
    ユーザー提供画像を使い、取得方法を報告する。
 3. Simulator / Xcode runtime / Storybook 起動 / UI 操作 / screenshot のいずれも代替
@@ -230,5 +236,6 @@ fallback でも story、device、theme を証拠から識別できることが�
 - [React Native Storybook: Getting started](https://storybookjs.github.io/react-native/docs/intro/getting-started/)
 - [React Native Storybook: Writing stories](https://storybookjs.github.io/react-native/docs/intro/writing-stories/)
 - [React Native Storybook: Storybook UI configuration](https://storybookjs.github.io/react-native/docs/intro/configuration/storybook-ui-configuration/)
+- [Expo CLI](https://docs.expo.dev/more/expo-cli/)
 - [Expo: GlassEffect](https://docs.expo.dev/versions/latest/sdk/glass-effect/)
 - [`apps/mobile/README.md`](../../../apps/mobile/README.md)

--- a/.agents/skills/mobile-visual-check/evals/evals.json
+++ b/.agents/skills/mobile-visual-check/evals/evals.json
@@ -1,0 +1,42 @@
+{
+  "skill_name": "mobile-visual-check",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "apps/mobile/components/day-task-bottom-sheet.tsx のタスク行の余白と長いタイトルの折り返しを変更しました。PR 前に Mobile の見た目を確認して、確認条件と証拠を報告してください。",
+      "expected_output": "Skill が発火し、diff から DayTaskBottomSheet の LongTitle、MultipleTasks、Empty と dark variant を選び、compact / standard iPhone の light / dark matrix、Storybook 起動、screenshot、構造化報告まで計画または実行する。",
+      "files": [],
+      "expectations": [
+        "Mobile UI の視覚変更として scope 内と判定する",
+        "diff と import 関係から対象 story を選ぶ",
+        "light / dark、compact / standard、long / empty / multiple の関連状態を含む",
+        "Storybook の tascal script と iOS Simulator を使う",
+        "story、device、theme、result、evidence、remaining issues を構造化して報告する"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "packages/design-tokens の surface と text color を変えたので、apps/mobile への見た目の影響をレビューして。Liquid Glass の SheetSurface も含め、必要な story だけ Simulator で確認したい。",
+      "expected_output": "Skill が発火し、token consumer を追って SheetSurface などの representative story を選定し、light / dark、native / fallback、端末サイズと evidence の matrix を作る。",
+      "files": [],
+      "expectations": [
+        "design token の consumer を追跡して story を選ぶ",
+        "light / dark と compact / standard の条件を記録する",
+        "Liquid Glass の native 表現と fallback をチェック対象にする",
+        "未再現状態や tool 不足を pass ではなく blocker として扱う"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Mobile UI のレビューを頼まれましたが、この環境には Xcode Simulator も画面操作 tool もありません。apps/mobile/components/unscheduled-tasks-button.tsx の count badge 変更について、できるところまで確認して結果を出してください。",
+      "expected_output": "Skill が発火し、対象 story と必要 matrix を static に選ぶが、代替 screenshot も得られなければ blocked とし、実行済み範囲と具体的 blocker を報告する。",
+      "files": [],
+      "expectations": [
+        "UnscheduledTasksButton の Empty、MultipleTasks、Dark を候補にする",
+        "UI 操作、simctl screenshot、ユーザー提供画像の fallback 順を示す",
+        "視覚証拠がなければ pass を宣言しない",
+        "blocked status と残課題を構造化して報告する"
+      ]
+    }
+  ]
+}

--- a/.agents/skills/mobile-visual-check/evals/results.md
+++ b/.agents/skills/mobile-visual-check/evals/results.md
@@ -2,45 +2,67 @@
 
 Evaluated: 2026-08-08
 
-## Method
+## Method and limitation
 
-- Trigger evaluation: an independent read-only agent classified all queries from the
-  `SKILL.md` description before comparing its decisions with `should_trigger`.
-- Workflow evaluation: a separate independent read-only agent graded every expectation in
-  `evals.json` against the skill instructions and the current tascal Storybook files.
-- Static validation: JSON shape, positive/negative balance, frontmatter, repository paths,
-  Markdown formatting, and whitespace checks are verified locally.
-- A nested ephemeral `codex exec` attempt could not initialize its app-server inside the
-  managed sandbox. This was an evaluator-harness limitation before prompt execution, so it is
-  not counted as a skill result and no bulky transcript is retained.
+- An independent read-only reviewer classified each query from the final frontmatter description
+  before comparing it with `should_trigger`.
+- A separate independent read-only reviewer graded each workflow expectation against the final
+  `SKILL.md`, current tascal stories, preview, and package scripts.
+- Trigger results are a **description-classification proxy**, not measured Codex runtime skill
+  invocation. A nested ephemeral `codex exec` attempt was rejected by the managed sandbox before
+  prompt execution, so it is not counted and its transcript is not retained.
+- JSON shape, positive/negative balance, frontmatter, repository paths, Markdown formatting, and
+  whitespace are also checked locally.
 
-## Iteration 1
+## Final trigger classification proxy
 
-| Evaluation             |  Result | Notes                                                                                  |
-| ---------------------- | ------: | -------------------------------------------------------------------------------------- |
-| Trigger classification | 10 / 10 | Five visual Mobile prompts triggered; five near-miss non-visual/setup prompts did not. |
-| Workflow expectations  | 13 / 13 | All three representative workflows were explicitly covered.                            |
+The full prompts and expected labels are in `trigger-cases.json`.
 
-The reviewers identified useful execution ambiguities despite the passing expectations:
+|  ID | Expected   | Reviewer decision | Match | Evidence                                                       |
+| --: | ---------- | ----------------- | ----- | -------------------------------------------------------------- |
+|   1 | trigger    | trigger           | yes   | Mobile component spacing and iPhone visual evidence.           |
+|   2 | trigger    | trigger           | yes   | Design-token color change can affect Mobile consumers.         |
+|   3 | trigger    | trigger           | yes   | Liquid Glass and compact-device layout are visual concerns.    |
+|   4 | trigger    | trigger           | yes   | Mobile UI review explicitly requests Storybook screenshots.    |
+|   5 | trigger    | trigger           | yes   | Mobile component overlap and dark mode are visual concerns.    |
+|   6 | no trigger | no trigger        | yes   | Mobile API error mapping and tests are non-visual.             |
+|   7 | no trigger | no trigger        | yes   | Storybook setup/upgrade is explicitly excluded.                |
+|   8 | no trigger | no trigger        | yes   | API, CLI, and Web schema/type changes do not affect Mobile UI. |
+|   9 | no trigger | no trigger        | yes   | Hook logic and Jest coverage are non-visual.                   |
+|  10 | no trigger | no trigger        | yes   | Dependency and build verification alone are non-visual.        |
 
-- compact / standard coverage conflicted between the completion criteria and matrix guidance;
-- `expo start --ios` does not target a specific Simulator UDID;
-- Storybook safe-area metrics are fixed at 390×844;
-- Liquid Glass native/fallback reproduction and partial/blocked status needed sharper rules;
-- local screenshot paths alone are not durable PR evidence.
+Result: **10 / 10 matched; no ambiguous case**.
 
-## Iteration 2 changes
+## Final workflow grading
 
-- Require the matrix to cover both device classes and both themes, while combining states only
-  where the diff's size, color, contrast, or native-material concern makes that combination
-  relevant. This avoids an unsupported Cartesian product of current stories.
-- Require verification of the actual Simulator model/UDID and block when target selection is
-  ambiguous.
-- Record fixed safe-area metrics as a limitation when safe area is in scope.
-- Define native/fallback checks using the iOS Reduce Transparency setting and supported runtime.
-- Define pass, partial, and blocked boundaries and explain how to share screenshot evidence.
-- Clarify the formerly ambiguous positive badge prompt with explicit Mobile component context.
+The full prompts and expectations are in `evals.json`.
 
-The persisted eval inputs remain intentionally small: they cover the issue's representative
-Mobile component, design-token/native, unavailable-tool, and non-UI boundaries without storing
-ephemeral model transcripts or benchmark artifacts.
+| Eval | Expectation                             | Result | Evidence in final skill                                                                                    |
+| ---: | --------------------------------------- | ------ | ---------------------------------------------------------------------------------------------------------- |
+|    1 | Scope Mobile visual change              | pass   | Description and Scope gate include Mobile component/style changes.                                         |
+|    1 | Select stories from diff/imports        | pass   | Step 2 follows colocated stories, render tree, and consumers.                                              |
+|    1 | Cover themes, sizes, related states     | pass   | Step 3 covers both themes/device classes and named related states without an unsupported Cartesian matrix. |
+|    1 | Use tascal Storybook and Simulator      | pass   | Step 4 runs `storybook`, uses Expo `shift+i`, and verifies model/UDID.                                     |
+|    1 | Structured evidence report              | pass   | Step 8 requires story, device, theme, result, evidence, and remaining issues.                              |
+|    2 | Trace design-token consumers            | pass   | Step 2 includes token importers and representative stories.                                                |
+|    2 | Record themes and device classes        | pass   | Steps 2–3 require light/dark and compact/standard in the matrix.                                           |
+|    2 | Check native glass and fallback         | pass   | Step 6 uses Reduce Transparency and supported/unsupported runtimes.                                        |
+|    2 | Treat missing coverage/tools as blocker | pass   | Steps 3 and 7 prohibit a pass without required coverage/evidence.                                          |
+|    3 | Select button state stories             | pass   | Colocated selection plus named states covers Empty, MultipleTasks, and Dark.                               |
+|    3 | Follow tool fallback order              | pass   | Step 7 orders assisted selection, `simctl`, and alternate images.                                          |
+|    3 | Never pass without visual evidence      | pass   | Completion criteria and Step 7 explicitly prohibit it.                                                     |
+|    3 | Report blocked status and gaps          | pass   | Steps 7–8 define statuses and Remaining issues.                                                            |
+
+Result: **13 / 13 passed**.
+
+## Iteration record
+
+| Draft   | Trigger proxy | Workflow | Material reviewer feedback                                                                                   |
+| ------- | ------------: | -------: | ------------------------------------------------------------------------------------------------------------ |
+| Initial |       10 / 10 |  13 / 13 | Clarify matrix, UDID targeting, safe-area limitation, Liquid Glass fallback, statuses, and evidence sharing. |
+| Final   |       10 / 10 |  13 / 13 | Use Expo `shift+i` device picker; expose case-level proxy evidence and its runtime limitation.               |
+
+The final draft uses a risk-based matrix, records the fixed 390×844 Storybook safe-area limitation,
+defines native/fallback and pass/partial/blocked rules, and selects compact and standard Simulators
+explicitly from the Expo Terminal UI. This evidence stays intentionally small and reviewable; no
+ephemeral model transcripts or generated benchmark viewer are committed.

--- a/.agents/skills/mobile-visual-check/evals/results.md
+++ b/.agents/skills/mobile-visual-check/evals/results.md
@@ -18,36 +18,20 @@ Evaluated: 2026-08-08
 
 The full prompts and expected labels are in `trigger-cases.json`.
 
-|  ID | Expected   | Reviewer decision | Match | Evidence                                                          |
-| --: | ---------- | ----------------- | ----- | ----------------------------------------------------------------- |
-|   1 | trigger    | trigger           | yes   | Mobile component spacing and iPhone visual evidence.              |
-|   2 | trigger    | trigger           | yes   | Design-token color change can affect Mobile consumers.            |
-|   3 | trigger    | trigger           | yes   | Liquid Glass and compact-device layout are visual concerns.       |
-|   4 | trigger    | trigger           | yes   | Mobile UI review explicitly requests Storybook screenshots.       |
-|   5 | trigger    | trigger           | yes   | Mobile component overlap and dark mode are visual concerns.       |
-|   6 | no trigger | no trigger        | yes   | Mobile API error mapping and tests are non-visual.                |
-|   7 | no trigger | no trigger        | yes   | Storybook upgrade implementation and build checks are non-visual. |
-|   8 | no trigger | no trigger        | yes   | API, CLI, and Web schema/type changes do not affect Mobile UI.    |
-|   9 | no trigger | no trigger        | yes   | Hook logic and Jest coverage are non-visual.                      |
-|  10 | no trigger | no trigger        | yes   | Dependency and build verification alone are non-visual.           |
+|  ID | Expected   | Reviewer decision | Match | Evidence                                                              |
+| --: | ---------- | ----------------- | ----- | --------------------------------------------------------------------- |
+|   1 | trigger    | trigger           | yes   | Mobile component spacing and iPhone visual evidence.                  |
+|   2 | trigger    | trigger           | yes   | Design-token color change can affect Mobile consumers.                |
+|   3 | trigger    | trigger           | yes   | Liquid Glass and compact-device layout are visual concerns.           |
+|   4 | trigger    | trigger           | yes   | Post-upgrade Mobile story rendering explicitly needs visual evidence. |
+|   5 | trigger    | trigger           | yes   | Mobile component overlap and dark mode are visual concerns.           |
+|   6 | no trigger | no trigger        | yes   | Mobile API error mapping and tests are non-visual.                    |
+|   7 | no trigger | no trigger        | yes   | Storybook upgrade implementation and build checks are non-visual.     |
+|   8 | no trigger | no trigger        | yes   | API, CLI, and Web schema/type changes do not affect Mobile UI.        |
+|   9 | no trigger | no trigger        | yes   | Hook logic and Jest coverage are non-visual.                          |
+|  10 | no trigger | no trigger        | yes   | Dependency and build verification alone are non-visual.               |
 
 Result: **10 / 10 matched; no ambiguous case**.
-
-## Codex runtime spot check
-
-The final description was also loaded by three independent read-only Codex CLI sessions
-(`codex 0.147.0`, `gpt-5.6-sol`, 2026-08-08). This is a focused runtime check, separate from the
-10-case classification proxy above.
-
-| Prompt boundary                                             | Runtime decision      | Expected   | Result |
-| ----------------------------------------------------------- | --------------------- | ---------- | ------ |
-| Mobile component spacing with light/dark screenshots        | `mobile-visual-check` | trigger    | pass   |
-| Storybook upgrade implementation plus build/typecheck only  | no repo skill         | no trigger | pass   |
-| Visual regression check after a completed Storybook upgrade | `mobile-visual-check` | trigger    | pass   |
-
-Result: **3 / 3 runtime spot checks passed**. The sessions planned only and made no file changes;
-the Simulator workflow itself remains covered by the static workflow grading because the managed
-environment could not connect to CoreSimulatorService.
 
 ## Final workflow grading
 
@@ -76,7 +60,7 @@ Result: **13 / 13 passed**.
 | Draft   | Trigger proxy | Workflow | Material reviewer feedback                                                                                   |
 | ------- | ------------: | -------: | ------------------------------------------------------------------------------------------------------------ |
 | Initial |       10 / 10 |  13 / 13 | Clarify matrix, UDID targeting, safe-area limitation, Liquid Glass fallback, statuses, and evidence sharing. |
-| Final   |       10 / 10 |  13 / 13 | Use Expo `shift+i` device picker; expose case-level proxy evidence and its runtime limitation.               |
+| Final   |       10 / 10 |  13 / 13 | Use Expo `shift+i`; expose case-level proxy evidence; pair upgrade-only and post-upgrade visual boundaries.  |
 
 The final draft uses a risk-based matrix, records the fixed 390×844 Storybook safe-area limitation,
 defines native/fallback and pass/partial/blocked rules, and selects compact and standard Simulators

--- a/.agents/skills/mobile-visual-check/evals/results.md
+++ b/.agents/skills/mobile-visual-check/evals/results.md
@@ -18,20 +18,36 @@ Evaluated: 2026-08-08
 
 The full prompts and expected labels are in `trigger-cases.json`.
 
-|  ID | Expected   | Reviewer decision | Match | Evidence                                                       |
-| --: | ---------- | ----------------- | ----- | -------------------------------------------------------------- |
-|   1 | trigger    | trigger           | yes   | Mobile component spacing and iPhone visual evidence.           |
-|   2 | trigger    | trigger           | yes   | Design-token color change can affect Mobile consumers.         |
-|   3 | trigger    | trigger           | yes   | Liquid Glass and compact-device layout are visual concerns.    |
-|   4 | trigger    | trigger           | yes   | Mobile UI review explicitly requests Storybook screenshots.    |
-|   5 | trigger    | trigger           | yes   | Mobile component overlap and dark mode are visual concerns.    |
-|   6 | no trigger | no trigger        | yes   | Mobile API error mapping and tests are non-visual.             |
-|   7 | no trigger | no trigger        | yes   | Storybook setup/upgrade is explicitly excluded.                |
-|   8 | no trigger | no trigger        | yes   | API, CLI, and Web schema/type changes do not affect Mobile UI. |
-|   9 | no trigger | no trigger        | yes   | Hook logic and Jest coverage are non-visual.                   |
-|  10 | no trigger | no trigger        | yes   | Dependency and build verification alone are non-visual.        |
+|  ID | Expected   | Reviewer decision | Match | Evidence                                                          |
+| --: | ---------- | ----------------- | ----- | ----------------------------------------------------------------- |
+|   1 | trigger    | trigger           | yes   | Mobile component spacing and iPhone visual evidence.              |
+|   2 | trigger    | trigger           | yes   | Design-token color change can affect Mobile consumers.            |
+|   3 | trigger    | trigger           | yes   | Liquid Glass and compact-device layout are visual concerns.       |
+|   4 | trigger    | trigger           | yes   | Mobile UI review explicitly requests Storybook screenshots.       |
+|   5 | trigger    | trigger           | yes   | Mobile component overlap and dark mode are visual concerns.       |
+|   6 | no trigger | no trigger        | yes   | Mobile API error mapping and tests are non-visual.                |
+|   7 | no trigger | no trigger        | yes   | Storybook upgrade implementation and build checks are non-visual. |
+|   8 | no trigger | no trigger        | yes   | API, CLI, and Web schema/type changes do not affect Mobile UI.    |
+|   9 | no trigger | no trigger        | yes   | Hook logic and Jest coverage are non-visual.                      |
+|  10 | no trigger | no trigger        | yes   | Dependency and build verification alone are non-visual.           |
 
 Result: **10 / 10 matched; no ambiguous case**.
+
+## Codex runtime spot check
+
+The final description was also loaded by three independent read-only Codex CLI sessions
+(`codex 0.147.0`, `gpt-5.6-sol`, 2026-08-08). This is a focused runtime check, separate from the
+10-case classification proxy above.
+
+| Prompt boundary                                             | Runtime decision      | Expected   | Result |
+| ----------------------------------------------------------- | --------------------- | ---------- | ------ |
+| Mobile component spacing with light/dark screenshots        | `mobile-visual-check` | trigger    | pass   |
+| Storybook upgrade implementation plus build/typecheck only  | no repo skill         | no trigger | pass   |
+| Visual regression check after a completed Storybook upgrade | `mobile-visual-check` | trigger    | pass   |
+
+Result: **3 / 3 runtime spot checks passed**. The sessions planned only and made no file changes;
+the Simulator workflow itself remains covered by the static workflow grading because the managed
+environment could not connect to CoreSimulatorService.
 
 ## Final workflow grading
 

--- a/.agents/skills/mobile-visual-check/evals/results.md
+++ b/.agents/skills/mobile-visual-check/evals/results.md
@@ -1,0 +1,46 @@
+# Mobile visual check eval results
+
+Evaluated: 2026-08-08
+
+## Method
+
+- Trigger evaluation: an independent read-only agent classified all queries from the
+  `SKILL.md` description before comparing its decisions with `should_trigger`.
+- Workflow evaluation: a separate independent read-only agent graded every expectation in
+  `evals.json` against the skill instructions and the current tascal Storybook files.
+- Static validation: JSON shape, positive/negative balance, frontmatter, repository paths,
+  Markdown formatting, and whitespace checks are verified locally.
+- A nested ephemeral `codex exec` attempt could not initialize its app-server inside the
+  managed sandbox. This was an evaluator-harness limitation before prompt execution, so it is
+  not counted as a skill result and no bulky transcript is retained.
+
+## Iteration 1
+
+| Evaluation             |  Result | Notes                                                                                  |
+| ---------------------- | ------: | -------------------------------------------------------------------------------------- |
+| Trigger classification | 10 / 10 | Five visual Mobile prompts triggered; five near-miss non-visual/setup prompts did not. |
+| Workflow expectations  | 13 / 13 | All three representative workflows were explicitly covered.                            |
+
+The reviewers identified useful execution ambiguities despite the passing expectations:
+
+- compact / standard coverage conflicted between the completion criteria and matrix guidance;
+- `expo start --ios` does not target a specific Simulator UDID;
+- Storybook safe-area metrics are fixed at 390×844;
+- Liquid Glass native/fallback reproduction and partial/blocked status needed sharper rules;
+- local screenshot paths alone are not durable PR evidence.
+
+## Iteration 2 changes
+
+- Require the matrix to cover both device classes and both themes, while combining states only
+  where the diff's size, color, contrast, or native-material concern makes that combination
+  relevant. This avoids an unsupported Cartesian product of current stories.
+- Require verification of the actual Simulator model/UDID and block when target selection is
+  ambiguous.
+- Record fixed safe-area metrics as a limitation when safe area is in scope.
+- Define native/fallback checks using the iOS Reduce Transparency setting and supported runtime.
+- Define pass, partial, and blocked boundaries and explain how to share screenshot evidence.
+- Clarify the formerly ambiguous positive badge prompt with explicit Mobile component context.
+
+The persisted eval inputs remain intentionally small: they cover the issue's representative
+Mobile component, design-token/native, unavailable-tool, and non-UI boundaries without storing
+ephemeral model transcripts or benchmark artifacts.

--- a/.agents/skills/mobile-visual-check/evals/trigger-cases.json
+++ b/.agents/skills/mobile-visual-check/evals/trigger-cases.json
@@ -20,7 +20,7 @@
     "reason": "Mobile UI review と明示的な visual evidence"
   },
   {
-    "query": "長いタスク名でボタンと件数 badge が重ならないか、dark mode も含めてチェックして",
+    "query": "Mobile の UnscheduledTasksButton で、長いタスク名の近くにある件数 badge が重ならないか dark mode も含めてチェックして",
     "should_trigger": true,
     "reason": "長文・重なり・dark mode の visual check"
   },

--- a/.agents/skills/mobile-visual-check/evals/trigger-cases.json
+++ b/.agents/skills/mobile-visual-check/evals/trigger-cases.json
@@ -15,9 +15,9 @@
     "reason": "native 表現と端末サイズに関わる Mobile UI 変更"
   },
   {
-    "query": "この Mobile UI の PR、実装レビューに加えて Storybook のスクリーンショット付きで確認して",
+    "query": "React Native Storybook の upgrade は完了したので、既存の Mobile UI story に描画崩れがないか iOS Simulator のスクリーンショット付きで確認して",
     "should_trigger": true,
-    "reason": "Mobile UI review と明示的な visual evidence"
+    "reason": "Storybook upgrade 後の Mobile UI 描画を確認する視覚 review"
   },
   {
     "query": "Mobile の UnscheduledTasksButton で、長いタスク名の近くにある件数 badge が重ならないか dark mode も含めてチェックして",

--- a/.agents/skills/mobile-visual-check/evals/trigger-cases.json
+++ b/.agents/skills/mobile-visual-check/evals/trigger-cases.json
@@ -1,0 +1,52 @@
+[
+  {
+    "query": "apps/mobile/components/day-task-bottom-sheet.tsx の余白を直した。PR 前に iPhone の light/dark で見た目を確認してスクショを残して",
+    "should_trigger": true,
+    "reason": "Mobile component の layout 変更と視覚確認"
+  },
+  {
+    "query": "デザイントークンの surface color を更新したので、Mobile の影響範囲を story から選んでレビューしてほしい",
+    "should_trigger": true,
+    "reason": "Mobile consumer に波及する color 変更"
+  },
+  {
+    "query": "Liquid Glass の fallback を変えた。小さい iPhone でも bottom sheet が崩れないか見て",
+    "should_trigger": true,
+    "reason": "native 表現と端末サイズに関わる Mobile UI 変更"
+  },
+  {
+    "query": "この Mobile UI の PR、実装レビューに加えて Storybook のスクリーンショット付きで確認して",
+    "should_trigger": true,
+    "reason": "Mobile UI review と明示的な visual evidence"
+  },
+  {
+    "query": "長いタスク名でボタンと件数 badge が重ならないか、dark mode も含めてチェックして",
+    "should_trigger": true,
+    "reason": "長文・重なり・dark mode の visual check"
+  },
+  {
+    "query": "apps/mobile/api/tasks.ts の fetch error mapping を直したので unit test と typecheck を実行して",
+    "should_trigger": false,
+    "reason": "Mobile 配下だが非視覚的な API logic 変更"
+  },
+  {
+    "query": "React Native Storybook を最新版へ upgrade して breaking changes を直して",
+    "should_trigger": false,
+    "reason": "Storybook setup / upgrade は別 workflow"
+  },
+  {
+    "query": "apps/api の task range endpoint の Zod schema を変更して CLI と Web の型エラーを直して",
+    "should_trigger": false,
+    "reason": "Mobile UI と無関係な API / CLI / Web 変更"
+  },
+  {
+    "query": "useTasks の refetch 条件を変えた。Jest で AppState 復帰時のケースを追加して",
+    "should_trigger": false,
+    "reason": "hook logic と test のみで視覚的影響がない"
+  },
+  {
+    "query": "Expo SDK の依存だけ更新した。lockfile と build が通るか確認して",
+    "should_trigger": false,
+    "reason": "依存更新と build verification のみ"
+  }
+]

--- a/.agents/skills/mobile-visual-check/evals/trigger-cases.json
+++ b/.agents/skills/mobile-visual-check/evals/trigger-cases.json
@@ -30,9 +30,9 @@
     "reason": "Mobile 配下だが非視覚的な API logic 変更"
   },
   {
-    "query": "React Native Storybook を最新版へ upgrade して breaking changes を直して",
+    "query": "React Native Storybook を最新版へ upgrade して breaking changes を直し、build と typecheck だけ確認して",
     "should_trigger": false,
-    "reason": "Storybook setup / upgrade は別 workflow"
+    "reason": "Storybook setup / upgrade の実施と非視覚的な build 確認だけは別 workflow"
   },
   {
     "query": "apps/api の task range endpoint の Zod schema を変更して CLI と Web の型エラーを直して",

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -37,3 +37,21 @@ iOS または Android で起動し、対象 story を目視確認してくださ
 `pnpm --filter @tascal/mobile storybook:verify` は通常 production bundle と
 Storybook bundle をそれぞれ iOS 向けに export し、story marker が前者にはなく
 後者にだけ含まれることを検証します。
+
+### Agent による見た目確認
+
+Mobile UI の実装・変更・レビュー時は repo-scoped の
+[`mobile-visual-check`](../../.agents/skills/mobile-visual-check/SKILL.md) skill を使います。
+変更 diff から対象 story を選び、iOS Simulator で light / dark、compact / standard
+端末、長文・empty・複数件など変更に関係する状態を確認し、スクリーンショット付きの
+定型レポートを作成します。API、hook、型、test、依存更新だけの非視覚的な変更では
+使用しません。
+
+Codex では Mobile UI の依頼内容に合えば自動選択されます。明示する場合は prompt で
+`$mobile-visual-check` を指定してください。Simulator 操作や screenshot 取得ができない
+環境では、skill の fallback に従い partial / blocked と未確認条件を報告します。
+
+skill の形式と配置は [OpenAI の skills documentation](https://developers.openai.com/codex/skills)、
+Storybook の起動・story 定義は
+[React Native Storybook documentation](https://storybookjs.github.io/react-native/docs/intro/getting-started/)
+に準拠しています。


### PR DESCRIPTION
close #270

## 目的

Mobile UI の実装・変更・レビュー時に、tascal の React Native Storybook と iOS Simulator を使って再現可能な見た目確認を行えるようにします。

## 変更内容

- `.agents/skills/mobile-visual-check/` に repo-scoped skill を追加
  - diff からの story 選定
  - light/dark、compact/standard、関連 state の risk-based matrix
  - Expo Terminal UI の `Shift + I` による Simulator 明示選択
  - screenshot と layout / clipping / overlap / contrast / native 表現の checklist
  - tool fallback、pass / partial / blocked、構造化報告
- 5 positive / 5 near-miss negative の description trigger cases と、3 workflow eval を追加
- 独立 read-only 評価の case-level 根拠と runtime trigger proxy の制約を記録
- `apps/mobile/README.md` に利用方法と公式資料を追記

## 影響範囲

- `.agents/skills/mobile-visual-check/`
- `apps/mobile/README.md`

## ローカル検証

- skill-creator `quick_validate.py`
- trigger description classification proxy: 10 / 10
- workflow expectations: 13 / 13
- `pnpm lint`
- `pnpm format:check`
- `pnpm --filter @tascal/api build && pnpm typecheck`
- `pnpm test`
- `pnpm knip`
- `pnpm --filter @tascal/mobile storybook:verify`
- acceptance-check: 10 / 10
- independent cross-review: critical 0 / warning 0 / info 0（修正後再レビュー）

## 参考資料

- [OpenAI: Build skills](https://developers.openai.com/codex/skills)
- [React Native Storybook: Getting started](https://storybookjs.github.io/react-native/docs/intro/getting-started/)
- [React Native Storybook: Writing stories](https://storybookjs.github.io/react-native/docs/intro/writing-stories/)
- [Expo CLI](https://docs.expo.dev/more/expo-cli/)
- [Expo GlassEffect](https://docs.expo.dev/versions/latest/sdk/glass-effect/)
