### PR TITLE
list-sessions レスポンスからセッショントークンを除外する

### DIFF
--- a/apps/api/src/auth.test.ts
+++ b/apps/api/src/auth.test.ts
@@ -109,6 +109,14 @@ describe("GET /api/auth/get-session", () => {
 });
 
 describe("GET /api/auth/list-sessions", () => {
+  it("未認証では 401 を返す", async () => {
+    const response = await instance.customFetchImpl(
+      "http://localhost:3000/api/auth/list-sessions",
+    );
+
+    expect(response.status).toBe(401);
+  });
+
   it("Cookie 認証では非機密フィールドだけを返す", async () => {
     const { headers } = await instance.signInWithTestUser();
     const response = await instance.customFetchImpl(

--- a/apps/api/src/auth.test.ts
+++ b/apps/api/src/auth.test.ts
@@ -1,11 +1,45 @@
 import { beforeAll, describe, expect, it } from "vitest";
 import { getTestInstance } from "better-auth/test";
-import { createPublicSessionPlugin } from "./auth.js";
+import {
+  createPublicSessionListPlugin,
+  createPublicSessionPlugin,
+} from "./auth.js";
 
 function createTestAuth() {
   return getTestInstance({
-    plugins: [createPublicSessionPlugin()],
+    plugins: [createPublicSessionPlugin(), createPublicSessionListPlugin()],
   });
+}
+
+async function expectSafeSessionList(response: Response) {
+  expect(response.ok).toBe(true);
+  expect(response.headers.get("cache-control")).toBe("private, no-store");
+
+  const body = (await response.json()) as Record<string, unknown>[];
+
+  expect(body.length).toBeGreaterThan(0);
+  for (const session of body) {
+    expect(Object.keys(session).sort()).toEqual(
+      [
+        "id",
+        "userId",
+        "expiresAt",
+        "createdAt",
+        "updatedAt",
+        "ipAddress",
+        "userAgent",
+      ].sort(),
+    );
+    expect(session.id).toEqual(expect.any(String));
+    expect(session.userId).toEqual(expect.any(String));
+    expect(session.expiresAt).toEqual(expect.any(String));
+    expect(session.createdAt).toEqual(expect.any(String));
+    expect(session.updatedAt).toEqual(expect.any(String));
+    expect(session).toHaveProperty("ipAddress");
+    expect(session).toHaveProperty("userAgent");
+    expect(session).not.toHaveProperty("token");
+  }
+  expect(JSON.stringify(body)).not.toContain(bearerToken);
 }
 
 type TestInstance = Awaited<ReturnType<typeof createTestAuth>>;
@@ -71,5 +105,26 @@ describe("GET /api/auth/get-session", () => {
     );
 
     await expectSafeSession(response);
+  });
+});
+
+describe("GET /api/auth/list-sessions", () => {
+  it("Cookie 認証では非機密フィールドだけを返す", async () => {
+    const { headers } = await instance.signInWithTestUser();
+    const response = await instance.customFetchImpl(
+      "http://localhost:3000/api/auth/list-sessions",
+      { headers },
+    );
+
+    await expectSafeSessionList(response);
+  });
+
+  it("Bearer 認証を維持しつつ非機密フィールドだけを返す", async () => {
+    const response = await instance.customFetchImpl(
+      "http://localhost:3000/api/auth/list-sessions",
+      { headers: { Authorization: `Bearer ${bearerToken}` } },
+    );
+
+    await expectSafeSessionList(response);
   });
 });

--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -1,5 +1,5 @@
 import { createAuthMiddleware } from "better-auth/api";
-import { betterAuth } from "better-auth";
+import { betterAuth, type BetterAuthPlugin } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { bearer, customSession } from "better-auth/plugins";
 import { getDb } from "./db/index.js";
@@ -32,6 +32,56 @@ export function createPublicSessionPlugin() {
   });
 }
 
+const publicSessionFields = [
+  "id",
+  "userId",
+  "expiresAt",
+  "createdAt",
+  "updatedAt",
+  "ipAddress",
+  "userAgent",
+] as const;
+
+async function getSessionList(returned: unknown): Promise<unknown[] | null> {
+  if (returned instanceof Response) {
+    if (!returned.ok) return null;
+
+    const body: unknown = await returned.clone().json();
+    return Array.isArray(body) ? body : null;
+  }
+
+  return Array.isArray(returned) ? returned : null;
+}
+
+export function createPublicSessionListPlugin() {
+  return {
+    id: "public-session-list",
+    hooks: {
+      after: [
+        {
+          matcher: (ctx) => ctx.path === "/list-sessions",
+          handler: createAuthMiddleware(async (ctx) => {
+            const sessions = await getSessionList(ctx.context.returned);
+            if (!sessions) return;
+
+            ctx.setHeader("Cache-Control", "private, no-store");
+
+            return ctx.json(
+              sessions.map((session) => {
+                const source = session as Record<string, unknown>;
+
+                return Object.fromEntries(
+                  publicSessionFields.map((field) => [field, source[field]]),
+                );
+              }),
+            );
+          }),
+        },
+      ],
+    },
+  } satisfies BetterAuthPlugin;
+}
+
 function createAuth() {
   return betterAuth({
     database: drizzleAdapter(getDb(), {
@@ -42,7 +92,11 @@ function createAuth() {
     emailAndPassword: {
       enabled: true,
     },
-    plugins: [bearer(), createPublicSessionPlugin()],
+    plugins: [
+      bearer(),
+      createPublicSessionPlugin(),
+      createPublicSessionListPlugin(),
+    ],
     trustedOrigins: process.env.TRUSTED_ORIGINS
       ? process.env.TRUSTED_ORIGINS.split(",")
           .map((s) => s.trim())


### PR DESCRIPTION
close #262

## 目的

Better Auth の `GET /api/auth/list-sessions` が返す各 session を非機密フィールドの allowlist に変換し、Bearer 認証へ再利用できる session token をブラウザ JavaScript から取得できないようにします。

## 変更内容

- `apps/api/src/auth.ts`
  - Better Auth の after hook で `/list-sessions` の成功レスポンスを allowlist 化
  - `id`、`userId`、日時、IP address、user agent を維持し、`token` を除外
  - 変換後レスポンスへ `Cache-Control: private, no-store` を設定
- `apps/api/src/auth.test.ts`
  - Cookie 認証・Bearer 認証の双方で token が含まれず、非機密フィールドが維持されることを検証
  - 未認証アクセスが引き続き 401 になることを検証

## 制約

この対応は Better Auth 標準 endpoint の after hook で実行時レスポンス本文を変換します。そのため、Better Auth が生成する `listSessions` の推論型および OpenAPI 契約は標準仕様のままで、`token` 必須として表現される実行時レスポンスとの不一致が残ります。

issue の第一方針である plugin hook による標準 endpoint の allowlist 化に沿い、Web は現在この API を利用しておらず、受け入れ条件は実行時の認証情報除外を対象としているため、本 PR では型/OpenAPI 契約の追加変更を見送ります。将来 Web 等から型付きで利用する場合は、専用 endpoint または契約の明示的な上書きを検討する必要があります。

## 影響範囲

- `apps/api`
- Web の Cookie 認証と Mobile / CLI の Bearer 認証方式・トークン発行経路は変更しません

## ローカル検証

- `pnpm --filter @tascal/api exec vitest run src/auth.test.ts`
- `pnpm lint`
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm test`

すべて成功済みです。

## レビュー

親セッションで cross-review 済みです（critical 0 / warning 1 / info 1）。warning は上記の型/OpenAPI 契約との不一致として制約に記載し、info の未認証 401 テストは追加 commit で対応しました。
